### PR TITLE
Update Gemini model name

### DIFF
--- a/backend/dist/app/modules/ai_model/ai_model.utils.js
+++ b/backend/dist/app/modules/ai_model/ai_model.utils.js
@@ -19,7 +19,7 @@ const config_1 = __importDefault(require("../../../config"));
 const uuid_1 = require("uuid");
 const genAI = new generative_ai_1.GoogleGenerativeAI(config_1.default.gemini_api_key);
 const model = genAI.getGenerativeModel({
-    model: "gemini-1.5-pro",
+    model: "gemini-2.5-flash",
 });
 const generationConfig = {
     temperature: 1,

--- a/backend/src/app/modules/ai_model/ai_model.utils.ts
+++ b/backend/src/app/modules/ai_model/ai_model.utils.ts
@@ -10,7 +10,7 @@ import { v4 as uuidv4 } from "uuid";
 const genAI = new GoogleGenerativeAI(config.gemini_api_key as string);
 
 const model = genAI.getGenerativeModel({
-  model: "gemini-1.5-pro",
+  model: "gemini-2.5-flash",
 });
 
 const generationConfig = {


### PR DESCRIPTION
This updates the Gemini model configuration from the deprecated `gemini-1.5-pro` value to `gemini-2.5-flash` in both the TypeScript source and the committed build output so the runtime uses the current model name consistently. Fixes #6.
