### PR TITLE
Add Help Center page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,6 +26,7 @@ import EmailValidationComponent from "./components/email_validation/email.valida
 import { USER_ROLE } from "./constants/role";
 import PostListsComponent from "./components/dashboard/posts/post_lists.component";
 import ProfileComponent from "./components/dashboard/profile/profile.component";
+import HelpCenterComponent from "./components/help-center/help.center.component";
 
 const ProtectedRoute = ({
   element,
@@ -151,6 +152,7 @@ function App() {
         />
         <Route path="/signup" element={<SignUpComponent />} />
         <Route path="/pricing" element={<PricingComponent />} />
+        <Route path="/help-center" element={<HelpCenterComponent />} />
         <Route path="/explore" element={<ExploreComponent />} />
         <Route path="/post/:id" element={<PostDetailsComponent />} />
         <Route path="*" element={<NotFoundComponent />} />

--- a/frontend/src/components/footer/footer.component.tsx
+++ b/frontend/src/components/footer/footer.component.tsx
@@ -58,7 +58,7 @@ const FooterComponent = () => {
               </li>
               <li>
                 <a
-                  href="#"
+                  href="/help-center"
                   className="text-base text-gray-500 hover:text-gray-900"
                 >
                   Help Center

--- a/frontend/src/components/help-center/help.center.component.tsx
+++ b/frontend/src/components/help-center/help.center.component.tsx
@@ -1,0 +1,71 @@
+const HelpCenterComponent = () => {
+  const faqs = [
+    {
+      question: "How do I start writing a story?",
+      answer:
+        "Create an account, open your dashboard, and use the post tools to draft and publish your story.",
+    },
+    {
+      question: "Where can I manage my profile?",
+      answer:
+        "After signing in, visit the dashboard profile section to update your details and writing preferences.",
+    },
+    {
+      question: "Can readers discover my stories?",
+      answer:
+        "Published stories appear in the explore and stories areas so readers can find new voices and topics.",
+    },
+  ];
+
+  return (
+    <main className="bg-slate-950 text-white">
+      <section className="mx-auto max-w-6xl px-6 py-20 text-center">
+        <p className="mb-4 text-sm font-semibold uppercase tracking-[0.35em] text-blue-300">
+          Help Center
+        </p>
+        <h1 className="text-4xl font-bold md:text-6xl">
+          Support for every StorySpark creator
+        </h1>
+        <p className="mx-auto mt-6 max-w-3xl text-lg text-slate-300">
+          Find quick answers about writing, publishing, profiles, and discovering
+          stories on StorySpark.AI.
+        </p>
+      </section>
+
+      <section className="mx-auto grid max-w-6xl gap-6 px-6 pb-20 md:grid-cols-3">
+        {[
+          ["Getting started", "Set up your account and publish your first story."],
+          ["Writing tools", "Use the dashboard to draft, manage, and review posts."],
+          ["Community", "Explore stories and connect with other writers."],
+        ].map(([title, description]) => (
+          <div
+            key={title}
+            className="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-xl"
+          >
+            <h2 className="text-2xl font-semibold">{title}</h2>
+            <p className="mt-3 text-slate-300">{description}</p>
+          </div>
+        ))}
+      </section>
+
+      <section className="mx-auto max-w-4xl px-6 pb-24">
+        <h2 className="mb-6 text-3xl font-bold">Frequently asked questions</h2>
+        <div className="space-y-4">
+          {faqs.map((faq) => (
+            <div
+              key={faq.question}
+              className="rounded-2xl border border-white/10 bg-slate-900 p-6"
+            >
+              <h3 className="text-xl font-semibold text-blue-200">
+                {faq.question}
+              </h3>
+              <p className="mt-3 text-slate-300">{faq.answer}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+};
+
+export default HelpCenterComponent;


### PR DESCRIPTION
## Screenshot (when helpful)

N/A — routing and page build were verified locally; no screenshot was captured in this environment.

## What this PR does

Adds a new Help Center route with a project-focused support page for StorySpark writers and readers. The page includes getting-started guidance, writing/community support areas, and a small FAQ, and the existing footer Help Center link now points to the new route.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #19

## More screenshots (optional)

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
