### PR TITLE
Fix: Align top layout spacing on home grid wrapper

### DIFF
--- a/frontend/src/components/home/home.component.tsx
+++ b/frontend/src/components/home/home.component.tsx
@@ -13,7 +13,7 @@ const HomeComponent = () => {
   const isLogin = isLoggedIn();
   return (
     <>
-      <div className="grid grid-cols-12 items-start gap-8 px-5 mb-10">
+      <div className="grid grid-cols-12 items-start gap-8 px-5 mb-10 pt-10">
         <div className="col-span-12 lg:col-span-8 min-w-0">
           <FeatureComponent />
           <LatestPostsComponent />


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Open or link a related issue when there is one (`Closes #123`, `Fixes #45`, or write **None** under Related issue below).
- **Description:** Fill in **What this PR does** so a reviewer can understand the change without your local context.
- **Screenshots:** Add screenshots or a short recording when they help (UI changes, confusing flows, or non-code proof). If not needed, say so in the checklist.

## Screenshot (when helpful)

<img width="1518" height="591" alt="fixedalignmentissue" src="https://github.com/user-attachments/assets/0c3357f6-39a2-4424-baa6-6830a8109216" />



## What this PR does

Added "pt-10" (padding-top )to the main grid layout container inside "home.component.tsx".  It balances the horizontal baseline alignment between the Featured Posts Section and the Trending Topics Sidebar.




## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

None



## More screenshots (optional)

<!-- Extra before/after images, flows, or recordings for reviewers. -->



## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
