### PR TITLE
fix: handle MongoDB duplicate key errors in global error handler

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -18,8 +18,7 @@ DEFAULT_ADMIN_PASSWORD=change-me
 
 # AI story generation (at least one provider is typically required)
 OPEN_AI_KEY=
-GEMINI_API_KEY=
-
+GEMINI_API_KEY= 
 # Cover images (Unsplash)
 UNSPLASH_KEY_API=
 UNSPLASH_KEY_API_SECRET=

--- a/backend/src/app/middleware/global.error.handler.ts
+++ b/backend/src/app/middleware/global.error.handler.ts
@@ -6,6 +6,7 @@ import { IGenericErrorMessage } from "../../interfaces/error";
 import handleValidationError from "../../errors/handle_validation_error";
 import handleCastError from "../../errors/handle_cast_error";
 import handleZodError from "../../errors/handle_zod_error";
+import handleDuplicateError from "../../errors/handle_duplicate_error";
 import ApiError from "../../errors/api_error";
 
 const globalErrorHandler: ErrorRequestHandler = (
@@ -29,6 +30,11 @@ const globalErrorHandler: ErrorRequestHandler = (
     errorMessage = simplifiedError.errorMessages;
   } else if (err && err.name === "CastError") {
     const simplifiedError = handleCastError(err);
+    statusCode = simplifiedError.statusCode;
+    message = simplifiedError.message;
+    errorMessage = simplifiedError.errorMessages;
+  } else if (err && err.code === 11000) {
+    const simplifiedError = handleDuplicateError(err);
     statusCode = simplifiedError.statusCode;
     message = simplifiedError.message;
     errorMessage = simplifiedError.errorMessages;

--- a/backend/src/errors/handle_duplicate_error.ts
+++ b/backend/src/errors/handle_duplicate_error.ts
@@ -1,0 +1,19 @@
+import { IGenericErrorResponse } from "../interfaces/common";
+import { IGenericErrorMessage } from "../interfaces/error";
+
+const handleDuplicateError = (err: any): IGenericErrorResponse => {
+  const errors: IGenericErrorMessage[] = Object.keys(err.keyValue).map((key) => {
+    return {
+      path: key,
+      message: `${err.keyValue[key]} is already in use`,
+    };
+  });
+
+  return {
+    statusCode: 400,
+    message: "Duplicate Key Error",
+    errorMessages: errors,
+  };
+};
+
+export default handleDuplicateError;


### PR DESCRIPTION
## Before you open this PR

- **Issue**: Closes #23
- **Description**: Fixes MongoDB 11000 duplicate key error handling in the global error handler.
- **Screenshots**: N/A (Backend logic change verified via API tests).

**Screenshot** 
N/A - This is a backend fix for error status codes and response formatting.



## What this PR does

This PR resolves issue #23 where MongoDB 11000 (Duplicate Key) errors were not being caught by the global error handler, resulting in generic 500 errors.

- Created a handleDuplicateError utility to parse MongoDB driver errors.
- Updated the globalErrorHandler to catch code 11000.
- The API now returns a clean 400 Bad Request with a descriptive message (e.g., "email@example.com"  is already in use") instead of a stack trace.



## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [x] Bug fix


## Related issue

Closes #23



## More screenshots (optional)
 N/A



## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
