### PR TITLE
fix: remove social media icons from footer (#79)

### DIFF
--- a/frontend/src/components/footer/footer.component.tsx
+++ b/frontend/src/components/footer/footer.component.tsx
@@ -140,37 +140,7 @@ const FooterComponent = () => {
           <p className="text-base text-gray-400">
             &copy; 2025 StorySpark.AI - All rights reserved.
           </p>
-
-          <div className="flex space-x-6">
-            <a
-              href="#"
-              className="text-gray-400 hover:text-white transition-colors duration-200"
-            >
-              <i className="fab fa-twitter"></i>
-            </a>
-
-            <a
-              href="#"
-              className="text-gray-400 hover:text-white transition-colors duration-200"
-            >
-              <i className="fab fa-facebook"></i>
-            </a>
-
-            <a
-              href="#"
-              className="text-gray-400 hover:text-white transition-colors duration-200"
-            >
-              <i className="fab fa-instagram"></i>
-            </a>
-
-            <a
-              href="#"
-              className="text-gray-400 hover:text-white transition-colors duration-200"
-            >
-              <i className="fab fa-github"></i>
-            </a>
-          </div>
-        </div>
+ </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Screenshot (when helpful)
N/A - Removing UI elements (icons) from the footer, no functional change.

## What this PR does
Removes the social media icons (Twitter, Facebook, Instagram, and GitHub) from the footer section as requested in issue #79.

## Type of change
- [x] Bug fix

## Related issue
Closes #79

## More screenshots (optional)
N/A

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.