### PR TITLE
fix: stabilize explore page pagination layout and dark mode visibility (#74)

### DIFF
--- a/frontend/src/components/pagination/pagination.component.tsx
+++ b/frontend/src/components/pagination/pagination.component.tsx
@@ -62,7 +62,7 @@ const PaginationComponent: React.FC<PaginationProps> = ({
         return (
           <span
             key={`ellipsis-${index}`}
-            className="relative inline-flex items-center px-3 py-2 text-sm font-medium text-gray-700"
+            className="relative inline-flex items-center px-3 py-2 text-sm font-medium text-gray-500"
           >
             ...
           </span>
@@ -73,10 +73,10 @@ const PaginationComponent: React.FC<PaginationProps> = ({
         <button
           key={pageNum}
           onClick={() => handlePageChange(pageNum as number)}
-          className={`!rounded-button relative inline-flex items-center px-3 py-1 border text-sm font-medium ${
+          className={`!rounded-button relative inline-flex items-center px-3 py-1 border text-sm font-medium transition-colors ${
             current === pageNum
-              ? "border-custom bg-custom text-gray-400"
-              : "border-gray-300 text-gray-700 hover:bg-gray-400"
+              ? "border-custom bg-custom text-white"
+              : "border-gray-700 text-gray-400 hover:bg-gray-800 hover:text-white"
           }`}
         >
           {pageNum}
@@ -86,16 +86,16 @@ const PaginationComponent: React.FC<PaginationProps> = ({
   };
 
   return (
-    <div className="px-6 py-2">
+    <div>
       <div className="flex items-center justify-between">
-        <div className="flex-1 text-sm text-gray-700">
-          Showing <span className="font-medium">{startItem}</span> to
-          <span className="font-medium"> {endItem}</span> of
-          <span className="font-medium"> {total}</span> results
+        <div className="flex-1 text-sm text-gray-400">
+          Showing <span className="font-medium text-white">{startItem}</span> to
+          <span className="font-medium text-white"> {endItem}</span> of
+          <span className="font-medium text-white"> {total}</span> results
         </div>
         <div className="flex items-center space-x-2">
           <button
-            className="!rounded-button inline-flex items-center px-3 py-1 border border-gray-300 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="!rounded-button inline-flex items-center px-3 py-1 border border-gray-700 text-sm font-medium text-gray-400 hover:bg-gray-800 hover:text-white disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
             disabled={current === 1}
             onClick={() => handlePageChange(current - 1)}
           >
@@ -106,7 +106,7 @@ const PaginationComponent: React.FC<PaginationProps> = ({
             {renderPageNumbers()}
           </span>
           <button
-            className="!rounded-button inline-flex items-center px-3 py-1 border border-gray-300 text-sm font-medium text-gray-700 hover:bg-gray-400"
+            className="!rounded-button inline-flex items-center px-3 py-1 border border-gray-700 text-sm font-medium text-gray-400 hover:bg-gray-800 hover:text-white disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
             disabled={current === totalPages}
             onClick={() => handlePageChange(current + 1)}
           >

--- a/frontend/src/components/post/post.component.tsx
+++ b/frontend/src/components/post/post.component.tsx
@@ -182,7 +182,7 @@ const ExploreComponent = () => {
             </div>
           </div>
 
-          <div className="flex-1 flex flex-col">
+          <div className="flex-1 flex flex-col min-h-[70vh]">
             <div className={`${featuredPost ? "mb-6" : ""}`}>
               <div className="flex justify-between items-center">
                 <div className="flex space-x-4 items-center justify-items-start overflow-x-auto">
@@ -249,21 +249,21 @@ const ExploreComponent = () => {
               </div>
             )}
 
-            <ExploreViewListComponent
-              posts={data?.posts || []}
-              isLoading={isLoading}
-            />
+            <div className="flex-grow">
+              <ExploreViewListComponent
+                posts={data?.posts || []}
+                isLoading={isLoading}
+              />
+            </div>
 
             {!featuredPost && data?.meta && (
-              <div className="sticky bottom-0 bg-gray-900/80 backdrop-blur-sm border-t border-gray-700 z-10 mt-4">
-                <div className="max-w-8xl mx-auto px-4 sm:px-6 lg:px-8 py-1">
-                  <PaginationComponent
-                    current={page}
-                    pageSize={size}
-                    total={data.meta.total}
-                    onChange={onPaginationChange}
-                  />
-                </div>
+              <div className="sticky bottom-0 bg-gray-900/90 backdrop-blur-md border-t border-gray-800 z-10 mt-auto py-4">
+                <PaginationComponent
+                  current={page}
+                  pageSize={size}
+                  total={data.meta.total}
+                  onChange={onPaginationChange}
+                />
               </div>
             )}
           </div>


### PR DESCRIPTION
## 📌 Description

This PR fixes the pagination layout instability issue on the Explore page.

Previously, the pagination section shifted awkwardly when navigating between pages with fewer results, causing inconsistent spacing and alignment issues in the UI. The pagination controls also had poor visibility in dark mode.

The fix focuses on improving layout stability, alignment consistency, and overall pagination readability while keeping the existing design structure intact.

---

## 🔗 Related Issue

Closes #74

---

## 🛠 Changes Made

* Stabilized pagination layout using a consistent container height
* Fixed pagination alignment with the story card grid
* Removed redundant wrapper constraints causing layout shifts
* Improved dark mode visibility and text contrast
* Refined sticky pagination spacing and responsiveness
* Improved overall Explore page pagination consistency

---

## 📸 Screenshots 
<img width="1920" height="1200" alt="Screenshot from 2026-05-17 01-14-58" src="https://github.com/user-attachments/assets/6d193a3e-bfd4-4a20-8187-597c0a22348d" />

Tested pagination behavior across multiple pages and verified alignment consistency on desktop and mobile layouts.

---

## ✅ Checklist

* [x] Code runs locally
* [x] Followed project structure
* [x] No console errors
* [x] Properly tested changes
* [x] Responsive layout verified
* [x] Linked the issue

---

## 🚀 Notes for Reviewers

Tested pagination behavior with different result counts, including pages with fewer cards to ensure the layout remains stable and visually consistent across screen sizes.
