### PR TITLE
feat: implement semantic blog post redirection and UX hover effects(#77)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -221,7 +221,14 @@ function App() {
             </RootLayout>
           }
         />
-        <Route path="/post/:id" element={<PostDetailsComponent />} />
+        <Route
+          path="/post/:id"
+          element={
+            <RootLayout>
+              <PostDetailsComponent />
+            </RootLayout>
+          }
+        />
         <Route path="*" element={<NotFoundComponent />} />
       </Routes>
 

--- a/frontend/src/components/home/feature/feature.component.tsx
+++ b/frontend/src/components/home/feature/feature.component.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import { Post } from "../../../models/post";
 import { useGetFeaturedListsQuery } from "../../../redux/apis/post.api";
 import { formatDateShort } from "../../../utils/time-formate";
@@ -15,9 +16,10 @@ const FeatureComponent = () => {
       <div className="grid gap-8 sm:grid-cols-2">
         {data?.posts?.length ?? 0 > 0 ? (
           data?.posts?.map((post: Post) => (
-            <div
+            <Link
+              to={`/post/${post._id}`}
               key={post._id}
-              className="h-full bg-blue-500/10 rounded-lg shadow-sm overflow-hidden"
+              className="block h-full bg-blue-500/10 rounded-lg shadow-sm overflow-hidden transition-all duration-300 hover:bg-blue-500/20 hover:scale-[1.01] hover:shadow-lg group cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-500/40"
             >
               <img
                 className="h-48 w-full object-cover"
@@ -36,7 +38,7 @@ const FeatureComponent = () => {
                     </p>
                   </div>
                 </div>
-                <h3 className="text-xl font-semibold text-gray-300 mb-2">
+                <h3 className="text-xl font-semibold text-gray-300 mb-2 group-hover:text-blue-400 transition-colors duration-300">
                   {post.title}
                 </h3>
                 <p className="text-gray-400 mb-4">
@@ -54,7 +56,7 @@ const FeatureComponent = () => {
                   </span> */}
                 </div>
               </div>
-            </div>
+            </Link>
           ))
         ) : (
           <div>Feature Post is not available!</div>

--- a/frontend/src/components/home/latest_posts/latest_posts.component.tsx
+++ b/frontend/src/components/home/latest_posts/latest_posts.component.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import { useGetLatestListsQuery } from "../../../redux/apis/post.api";
 import { Post } from "../../../models/post";
 import LoadingAnimation from "../../loading/loading.component";
@@ -15,9 +16,10 @@ const LatestPostsComponent = () => {
       <div className="space-y-6">
         {data?.posts?.length ?? 0 > 0 ? (
           data?.posts?.map((post: Post) => (
-            <div
+            <Link
+              to={`/post/${post._id}`}
               key={post._id}
-              className="bg-blue-500/10 rounded-lg shadow-sm p-6"
+              className="block bg-blue-500/10 rounded-lg shadow-sm p-6 transition-all duration-300 hover:bg-blue-500/20 hover:scale-[1.01] hover:shadow-lg group cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-500/40"
             >
               <div className="flex items-center mb-4">
                 <SSProfile name={post.author.name} size="h-8 w-8" />
@@ -30,7 +32,7 @@ const LatestPostsComponent = () => {
                   </p>
                 </div>
               </div>
-              <h3 className="text-xl font-semibold text-gray-300 mb-2">
+              <h3 className="text-xl font-semibold text-gray-300 mb-2 group-hover:text-blue-400 transition-colors duration-300">
                 {post.title}
               </h3>
               <p className="text-gray-400 mb-4">
@@ -56,7 +58,7 @@ const LatestPostsComponent = () => {
                   ))}
                 </div>
               </div>
-            </div>
+            </Link>
           ))
         ) : (
           <div>Post is not available!</div>


### PR DESCRIPTION
## 📌 Description

While reviewing the homepage feeds, I noticed that the cards in the "Latest Posts" and "Featured Posts" sections looked interactive but were not actually connected to the existing post details route.

This PR fixes the issue by connecting the homepage cards to the `/post/:id` route using semantic React Router `Link` wrappers and improving the overall interaction experience.

---

## 🔗 Related Issue

Closes #77

---

## 🛠 Changes Made

* Connected homepage post cards to the existing `/post/:id` route
* Replaced static card wrappers with semantic React Router `Link` components
* Added hover interactions and clickable feedback for smoother UX
* Added focus states for keyboard accessibility
* Wrapped the `/post/:id` route inside `RootLayout`
* Ensured post details pages retain global layout structure and scroll-to-top support
* Kept the implementation lightweight and scoped only to frontend routing/UI

---

## 📸 Screen Recording

https://github.com/user-attachments/assets/9a370269-8dcd-4311-be7b-9064ab8f7ff1


Tested navigation flow from both Featured Posts and Latest Posts sections on desktop and mobile layouts.

---

## ✅ Checklist

* [x] Code runs locally
* [x] Followed project structure
* [x] No unrelated file changes
* [x] Properly tested navigation flow
* [x] Accessibility considerations added
* [x] Responsive behavior verified
* [x] Linked the issue

---

## 🚀 Notes for Reviewers

Verified that homepage cards correctly redirect to the related post details page, including keyboard navigation, hover states, and direct route access behavior.
