### PR TITLE
Fix: sorting Most Discussed by Ascending order now works correctly

### DIFF
--- a/backend/src/app/modules/post/post.service.ts
+++ b/backend/src/app/modules/post/post.service.ts
@@ -89,7 +89,7 @@ const getPosts = async (
   }
 
   if (sortBy && orderBy) {
-    sortCondition[sortBy] = orderBy;
+    sortCondition[sortBy] = orderBy === "asc" ? 1 : -1;
   }
 
   const result = await Post.find(whereCondition)

--- a/backend/src/constants/pagination.ts
+++ b/backend/src/constants/pagination.ts
@@ -1,1 +1,1 @@
-export const paginationFields = ["page", "limit", "sortBy", "orderBy"];
+export const paginationFields = ["page", "limit", "sortBy", "orderBy","sortOrder"];

--- a/backend/src/utils/pagination_helper.ts
+++ b/backend/src/utils/pagination_helper.ts
@@ -5,6 +5,7 @@ interface IOptions {
   limit?: number;
   sortBy?: string;
   orderBy?: SortOrder;
+  sortOrder?: SortOrder;
 }
 
 interface PGOptions {
@@ -20,7 +21,7 @@ const paginationHelper = (option: IOptions): PGOptions => {
   const limit = Number(option.limit || 10);
   const skip = (page - 1) * limit;
   const sortBy = option.sortBy || "createdAt";
-  const orderBy = option.orderBy || "desc";
+  const orderBy = option.sortOrder || option.orderBy || "desc";
   return {
     page,
     limit,


### PR DESCRIPTION
Fixes #63

## Root Cause
1. `sortOrder` was not included in `paginationFields` so it was not picked from request query
2. `pagination_helper.ts` was defaulting to "desc" always
3. sortCondition was passing "asc"/"desc" instead of MongoDB's 1/-1

## Changes Made
1. Added `sortOrder` to `paginationFields` in `pagination.ts`
2. Added `sortOrder?: SortOrder` to IOptions interface
3. Fixed orderBy to read `option.sortOrder || option.orderBy || "desc"`
4. Fixed sortCondition to use `orderBy === "asc" ? 1 : -1`

## Screenshots
1. Ascending Order: 
<img width="1472" height="748" alt="image" src="https://github.com/user-attachments/assets/71075c5f-58ce-4a1a-a602-5be885fa206c" />

2. Descending Order: 
<img width="1432" height="723" alt="image" src="https://github.com/user-attachments/assets/c8cd55f0-4a76-41c0-b8d5-94133eb1aa88" />
