### PR TITLE
feat: add keyboard accessibility hint for story input fields

### DIFF
--- a/frontend/src/components/stories/stories.component.tsx
+++ b/frontend/src/components/stories/stories.component.tsx
@@ -159,6 +159,13 @@ const StoriesComponent = () => {
                     value={textareaValue}
                     onChange={(e) => setTextareaValue(e.target.value)}
                   ></textarea>
+                  <p className="text-xs text-gray-500 mt-1 px-1">
+  💡 <span className="font-medium">Keyboard tip:</span> Press{" "}
+  <kbd className="px-1 py-0.5 text-xs bg-gray-700 rounded border border-gray-600">Tab</kbd>{" "}
+  to navigate fields and{" "}
+  <kbd className="px-1 py-0.5 text-xs bg-gray-700 rounded border border-gray-600">Enter</kbd>{" "}
+  to generate your story.
+</p>
                   <div className="flex justify-end mt-2 w-full">
                     <button
                       type="submit"


### PR DESCRIPTION
Closes #37

## Changes Made
- Added keyboard accessibility hint below the story 
  prompt textarea
- Shows Tab and Enter key tips so users are aware 
  of keyboard navigation

## Screenshot
<img width="1920" height="1080" alt="Screenshot 2026-05-17 174530" src="https://github.com/user-attachments/assets/bb242435-c7ce-4419-bc60-35b2c31a169d" />
