### PR TITLE
feat: add one-click clear button to prompt input field

### DIFF
--- a/frontend/src/components/stories/stories.component.tsx
+++ b/frontend/src/components/stories/stories.component.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import StoriesViewComponent, { IStories } from "./stories.view.component";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { getUserInfo, isLoggedIn } from "../../services/auth.service";
@@ -29,6 +29,7 @@ const StoriesComponent = () => {
   const [generateFreeModel] = useGenerateFreeModelMutation();
   const [selectedPrompt, setSelectedPrompt] = useState<string>("");
   const [textareaValue, setTextareaValue] = useState<string>("");
+  const inputRef = useRef<HTMLTextAreaElement>(null);
   const [guestRequestCount, setGuestRequestCount] = useState<number>(() =>
     parseInt(localStorage.getItem("guestRequestCount") || "0", 10)
   );
@@ -95,6 +96,15 @@ const StoriesComponent = () => {
     setTextareaValue(selectedValue);
   };
 
+  const handleClearPrompt = () => {
+    setTextareaValue("");
+    setSelectedPrompt("");
+    setValue("prompt", "");
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  };
+
   return (
     <div className="bg-gradient-to-br animate-gradient-slow min-h-screen">
       <div className="max-w-8xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -152,20 +162,37 @@ const StoriesComponent = () => {
             <div className="bg-blue-500/10 rounded-md p-4 border border-gray-400">
               <div className="relative">
                 <form className="space-y-4" onSubmit={handleSubmit(onSubmit)}>
-                  <textarea
-                    {...register("prompt")}
-                    className="w-full h-32 sm:h-40 resize-none border-none outline-none bg-transparent text-gray-300 focus:ring-0 text-lg leading-relaxed tracking-wide placeholder:italic placeholder:text-gray-500"
-                    placeholder="Every great story begins with a single idea. What’s yours?"
-                    value={textareaValue}
-                    onChange={(e) => setTextareaValue(e.target.value)}
-                  ></textarea>
+                  <div className="relative">
+                    <textarea
+                      {...register("prompt")}
+                      ref={inputRef}
+                      className="w-full h-32 sm:h-40 resize-none border-none outline-none bg-transparent text-gray-300 focus:ring-0 text-lg leading-relaxed tracking-wide placeholder:italic placeholder:text-gray-500 pr-10"
+                      placeholder="Every great story begins with a single idea. What's yours?"
+                      value={textareaValue}
+                      onChange={(e) => setTextareaValue(e.target.value)}
+                    ></textarea>
+                    
+                    {textareaValue.length > 0 && (
+                      <button
+                        type="button"
+                        onClick={handleClearPrompt}
+                        className="absolute right-2 top-2 text-gray-400 hover:text-red-500 transition-colors duration-200"
+                        aria-label="Clear prompt"
+                        title="Clear prompt"
+                      >
+                        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                        </svg>
+                      </button>
+                    )}
+                  </div>
                   <p className="text-xs text-gray-500 mt-1 px-1">
-  💡 <span className="font-medium">Keyboard tip:</span> Press{" "}
-  <kbd className="px-1 py-0.5 text-xs bg-gray-700 rounded border border-gray-600">Tab</kbd>{" "}
-  to navigate fields and{" "}
-  <kbd className="px-1 py-0.5 text-xs bg-gray-700 rounded border border-gray-600">Enter</kbd>{" "}
-  to generate your story.
-</p>
+                    💡 <span className="font-medium">Keyboard tip:</span> Press{" "}
+                    <kbd className="px-1 py-0.5 text-xs bg-gray-700 rounded border border-gray-600">Tab</kbd>{" "}
+                    to navigate fields and{" "}
+                    <kbd className="px-1 py-0.5 text-xs bg-gray-700 rounded border border-gray-600">Enter</kbd>{" "}
+                    to generate your story.
+                  </p>
                   <div className="flex justify-end mt-2 w-full">
                     <button
                       type="submit"


### PR DESCRIPTION
What this PR does
Adds a one-click clear button (X) inside the prompt textarea on the story generation page. When clicked, it clears all text, resets the character counter, and refocuses the input field for a new prompt. Improves user experience by eliminating manual deletion of long prompts.

Type of change
- [ ] Bug fix
- [* ] New feature
- [ ] Code refactor
- [ ] Documentation update

Related issue
Fixes #112

Checklist
- I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- I have filled in the related issue number when there is one.
- I have tested my changes.
- I have done a self-review of the code.

Screenshot
<img width="1274" height="826" alt="Screenshot 2026-05-17 230008" src="https://github.com/user-attachments/assets/d9862796-8c91-409a-91e8-ef2c18163695" />

