### PR TITLE
Fix/follow state persistence

### DIFF
--- a/backend/src/app/modules/user/user.controller.ts
+++ b/backend/src/app/modules/user/user.controller.ts
@@ -119,6 +119,30 @@ const getProfileInfo = catchAsync(async (req: Request, res: Response) => {
   });
 });
 
+const toggleFollow = catchAsync(async (req: Request, res: Response) => {
+  const token = await getToken(req);
+  const { authorId } = req.params;
+  const result = await UserService.toggleFollow(token, authorId);
+  sendResponse(res, {
+    statusCode: httpStatus.OK,
+    success: true,
+    message: result.isFollowing ? "Followed successfully!" : "Unfollowed successfully!",
+    data: result,
+  });
+});
+
+const getFollowStatus = catchAsync(async (req: Request, res: Response) => {
+  const token = await getToken(req);
+  const { authorId } = req.params;
+  const result = await UserService.getFollowStatus(token, authorId);
+  sendResponse(res, {
+    statusCode: httpStatus.OK,
+    success: true,
+    message: "Follow status fetched successfully!",
+    data: result,
+  });
+});
+
 export const UserController = {
   getAllUsers,
   getUser,
@@ -128,4 +152,6 @@ export const UserController = {
   applyForWriter,
   approveWriterApplication,
   getAllWriterApplicationUsers,
+  toggleFollow,
+  getFollowStatus,
 };

--- a/backend/src/app/modules/user/user.router.ts
+++ b/backend/src/app/modules/user/user.router.ts
@@ -54,4 +54,28 @@ router.post(
   UserController.approveWriterApplication
 );
 
+// Follow / Unfollow
+router.post(
+  "/follow/:authorId",
+  auth(
+    ENUM_USER_ROLE.USER,
+    ENUM_USER_ROLE.WRITER,
+    ENUM_USER_ROLE.ADMIN,
+    ENUM_USER_ROLE.SUPER_ADMIN
+  ),
+  UserController.toggleFollow
+);
+
+// Get Follow Status
+router.get(
+  "/follow-status/:authorId",
+  auth(
+    ENUM_USER_ROLE.USER,
+    ENUM_USER_ROLE.WRITER,
+    ENUM_USER_ROLE.ADMIN,
+    ENUM_USER_ROLE.SUPER_ADMIN
+  ),
+  UserController.getFollowStatus
+);
+
 export const UserRouter = router;

--- a/backend/src/app/modules/user/user.service.ts
+++ b/backend/src/app/modules/user/user.service.ts
@@ -110,6 +110,51 @@ const getProfileInfo = async (token: ITokenPayload) => {
   return user;
 };
 
+const toggleFollow = async (token: ITokenPayload, authorId: string) => {
+  const currentUser = await User.findOne({ email: token.email });
+  if (!currentUser) {
+    throw new ApiError(httpStatus.BAD_REQUEST, "User not found!");
+  }
+
+  const author = await User.findById(authorId);
+  if (!author) {
+    throw new ApiError(httpStatus.BAD_REQUEST, "Author not found!");
+  }
+
+  const isFollowing = currentUser.following.includes(author._id);
+
+  if (isFollowing) {
+    // Unfollow
+    await User.findByIdAndUpdate(currentUser._id, {
+      $pull: { following: author._id },
+    });
+    await User.findByIdAndUpdate(author._id, {
+      $pull: { followers: currentUser._id },
+    });
+    return { isFollowing: false };
+  } else {
+    // Follow
+    await User.findByIdAndUpdate(currentUser._id, {
+      $addToSet: { following: author._id },
+    });
+    await User.findByIdAndUpdate(author._id, {
+      $addToSet: { followers: currentUser._id },
+    });
+    return { isFollowing: true };
+  }
+};
+
+const getFollowStatus = async (token: ITokenPayload, authorId: string) => {
+  const currentUser = await User.findOne({ email: token.email });
+  if (!currentUser) {
+    return { isFollowing: false };
+  }
+  const isFollowing = currentUser.following.some(
+    (id) => id.toString() === authorId
+  );
+  return { isFollowing };
+};
+
 export const UserService = {
   getAllUsers,
   getUser,
@@ -119,4 +164,6 @@ export const UserService = {
   applyForWriter,
   approveWriterApplication,
   getAllWriterApplicationUsers,
+  toggleFollow,
+  getFollowStatus,
 };

--- a/frontend/src/components/post/post.details.component.tsx
+++ b/frontend/src/components/post/post.details.component.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect } from "react";
 import { useParams } from "react-router-dom";
 import {
   useGetPostByIdQuery,
@@ -13,8 +13,11 @@ import { formatDateShort } from "../../utils/time-formate";
 import { getUserInfo } from "../../services/auth.service";
 import { useToggleReactionMutation } from "../../redux/apis/reaction.api";
 import { toast } from "react-hot-toast";
-
 import BookmarkButton from "../BookmarkButton";
+import {
+  useToggleFollowMutation,
+  useGetFollowStatusQuery,
+} from "../../redux/apis/user.api";
 
 const PostDetailsComponent = () => {
   const navigate = useNavigate();
@@ -24,7 +27,28 @@ const PostDetailsComponent = () => {
   const { data: relatedPost } = useGetPostByTagQuery(tag || "");
   const [toggleReaction] = useToggleReactionMutation();
   const currentUser = getUserInfo();
-  const [isFollowing, setIsFollowing] = useState(false);
+  const authorId = post?.author?._id;
+
+  const { data: followData } = useGetFollowStatusQuery(authorId || "", {
+    skip: !authorId || !currentUser,
+  });
+
+  const [toggleFollow] = useToggleFollowMutation();
+
+  const isFollowing = followData?.isFollowing ?? false;
+
+  const handleFollow = async () => {
+    if (!currentUser) {
+      toast.error("You need to login to follow this author");
+      return;
+    }
+    if (!authorId) return;
+    try {
+      await toggleFollow(authorId).unwrap();
+    } catch (error) {
+      toast.error("Failed to update follow status");
+    }
+  };
 
   const handleLike = async () => {
     if (!id) return;
@@ -39,6 +63,7 @@ const PostDetailsComponent = () => {
   if (isLoading) {
     return <LoadingAnimation />;
   }
+
   return (
     <div>
       <div className="max-w-6xl mx-auto px-4">
@@ -49,7 +74,6 @@ const PostDetailsComponent = () => {
           >
             <i className="fa-solid fa-left-long"></i> BACK
           </div>
-
           <div className=""></div>
         </div>
         <div className="rounded-lg shadow-sm bg-blue-500/10 mb-10">
@@ -57,12 +81,12 @@ const PostDetailsComponent = () => {
             <div className="flex justify-between">
               <div className="flex items-center space-x-4 mb-6">
                 <SSProfile
-                  name={post?.author?.name || 'Unknown User'}
+                  name={post?.author?.name || "Unknown User"}
                   size="h-12 w-12"
                 />
                 <div>
                   <h3 className="font-medium text-gray-400">
-                    {post?.author?.name || 'Unknown User'}
+                    {post?.author?.name || "Unknown User"}
                   </h3>
                   <div className="flex items-center text-sm text-gray-500">
                     <span>{formatDateShort(post ? post?.createdAt : "")}</span>
@@ -70,12 +94,18 @@ const PostDetailsComponent = () => {
                 </div>
               </div>
               <div className="">
-                <button 
-                  onClick={() => setIsFollowing(!isFollowing)}
-                  className="mt-2 rounded bg-blue-500/30 text-gray-300 px-4 py-1 text-sm cursor-pointer hover:bg-blue-500/40"
-                >
-                  {isFollowing ? "Following" : "Follow"}
-                </button>
+                {currentUser && authorId !== currentUser?.id && (
+                  <button
+                    onClick={handleFollow}
+                    className={`mt-2 rounded px-4 py-1 text-sm cursor-pointer transition-all ${
+                      isFollowing
+                        ? "bg-blue-500/50 text-white hover:bg-red-500/30"
+                        : "bg-blue-500/30 text-gray-300 hover:bg-blue-500/40"
+                    }`}
+                  >
+                    {isFollowing ? "Following" : "Follow"}
+                  </button>
+                )}
               </div>
             </div>
 
@@ -97,15 +127,25 @@ const PostDetailsComponent = () => {
 
             <div className="flex items-center justify-between border-t border-b border-gray-500 py-4 mb-12">
               <div className="flex items-center space-x-6">
-                <button 
+                <button
                   onClick={handleLike}
                   className={`flex items-center space-x-2 transition-colors cursor-pointer ${
-                    post?.reactions?.some((r: any) => r.userId?.email === currentUser?.email)
+                    post?.reactions?.some(
+                      (r: any) => r.userId?.email === currentUser?.email
+                    )
                       ? "text-red-500 hover:text-red-400"
                       : "text-gray-600 hover:text-gray-400"
                   }`}
                 >
-                  <i className={`${post?.reactions?.some((r: any) => r.userId?.email === currentUser?.email) ? 'fas' : 'far'} fa-heart`}></i>
+                  <i
+                    className={`${
+                      post?.reactions?.some(
+                        (r: any) => r.userId?.email === currentUser?.email
+                      )
+                        ? "fas"
+                        : "far"
+                    } fa-heart`}
+                  ></i>
                   <span>{post?.likesCount}</span>
                 </button>
                 {post && (

--- a/frontend/src/redux/apis/user.api.ts
+++ b/frontend/src/redux/apis/user.api.ts
@@ -45,6 +45,22 @@ const userApi = baseApi.injectEndpoints({
       }),
       invalidatesTags: [tagTypes.user],
     }),
+    toggleFollow: build.mutation({
+      query: (authorId: string) => ({
+        url: `/${USER_URL}/follow/${authorId}`,
+        method: "POST",
+      }),
+      invalidatesTags: [tagTypes.user],
+    }),
+    getFollowStatus: build.query({
+      query: (authorId: string) => ({
+        url: `/${USER_URL}/follow-status/${authorId}`,
+        method: "GET",
+      }),
+      transformResponse: (response: { data: { isFollowing: boolean } }) =>
+        response.data,
+      providesTags: [tagTypes.user],
+    }),
   }),
 });
 
@@ -53,4 +69,6 @@ export const {
   useGetUsersListQuery,
   useGetProfileInfoQuery,
   useUpdateProfileMutation,
+  useToggleFollowMutation,
+  useGetFollowStatusQuery,
 } = userApi;


### PR DESCRIPTION
## Screenshot (when helpful)
N/A - Backend API changes and state management fix, no UI visual changes.

## What this PR does
The follow button was using only local React state (`useState(false)`), 
so the follow status was always reset to "not following" on every page 
reload or navigation.

This fix adds a proper follow/unfollow API and fetches the real follow 
status from the database on component mount.

### Backend Changes
- Added `toggleFollow` function in `user.service.ts`
- Added `toggleFollow` controller in `user.controller.ts`
- Added `POST /follow/:authorId` route in `user.router.ts`
- Added `GET /follow-status/:authorId` route in `user.router.ts`

### Frontend Changes
- Added `toggleFollow` and `getFollowStatus` endpoints in `user.api.ts`
- Updated `post.details.component.tsx` to fetch real follow status 
  on mount using `useGetFollowStatusQuery`
- Follow button now hides when viewing your own post

## Type of change
- [x] Bug fix

## Related issue
Fixes #126

## Checklist
- [x] I have added screenshots or a recording when they help explain 
      this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.