### PR TITLE
Fix: tags overflow and get clipped on mobile screens

### DIFF
--- a/frontend/src/components/home/latest_posts/latest_posts.component.tsx
+++ b/frontend/src/components/home/latest_posts/latest_posts.component.tsx
@@ -45,7 +45,7 @@ const LatestPostsComponent = () => {
                     <i className="far fa-comment mr-1"></i> {post.commentsCount}
                   </span>
                 </div>
-                <div className="flex space-x-2">
+                <div className="flex flex-wrap gap-2">
                   {post.topic.map((topic) => (
                     <span
                       key={topic._id}


### PR DESCRIPTION
## Screenshot (when helpful)
| Before | After |
| ------- | ------- |
| <img width="410" height="556" alt="Screenshot 2026-05-17 105826" src="https://github.com/user-attachments/assets/c94f86cb-d994-452c-ab19-415afb71c088" /> | <img width="359" height="546" alt="Screenshot 2026-05-18 090442" src="https://github.com/user-attachments/assets/21a8b7c6-31c9-4c8c-9a32-b2d625d2df8c" /> |

## What this PR does
On mobile screens, the hashtag/tag row on story cards was overflowing horizontally and the last tag was getting clipped at the right edge of the card.
Fixed by changing `flex space-x-2` to `flex flex-wrap gap-2` in the tags container inside `latest.posts.component.tsx` so tags wrap to the next line on smaller screens.

## Type of change
- [x] Bug fix

## Related issue
Fixes #102

## More screenshots (optional)
N/A

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.