### PR TITLE
[GSSoC'26] fix: implement global sticky navbar across all public routes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -201,17 +201,17 @@ function App() {
           />
         </Route>
 
-        <Route path="/stories" element={<StoriesComponent />} />
-        <Route path="/login" element={<LoginComponent />} />
+        <Route path="/stories" element={<RootLayout><StoriesComponent /></RootLayout>} />
+        <Route path="/login" element={<RootLayout><LoginComponent /></RootLayout>} />
 
         <Route
           path="/auth/email-validation"
           element={<EmailValidationComponent />}
         />
 
-        <Route path="/signup" element={<SignUpComponent />} />
-        <Route path="/pricing" element={<PricingComponent />} />
-        <Route path="/explore" element={<ExploreComponent />} />
+        <Route path="/signup" element={<RootLayout><SignUpComponent /></RootLayout>} />
+        <Route path="/pricing" element={<RootLayout><PricingComponent /></RootLayout>} />
+        <Route path="/explore" element={<RootLayout><ExploreComponent /></RootLayout>} />
         <Route
           path="/bookmarks"
           element={
@@ -239,15 +239,15 @@ function App() {
           }
         />
 
-        <Route path="/post/:id" element={<PostDetailsComponent />} />
-        <Route path="/about-us" element={<AboutUsComponent />} />
-        <Route path="/career" element={<CareerComponent />} />
-        <Route path="/contact-us" element={<ContactUsComponent />} />
-        <Route path="/blog" element={<BlogComponent />} />
-        <Route path="/help-center" element={<HelpCenterComponent />} />
-        <Route path="/guidelines" element={<GuidelinesComponent />} />
-        <Route path="/community" element={<CommunityComponent />} />
-        <Route path="*" element={<NotFoundComponent />} />
+        <Route path="/post/:id" element={<RootLayout><PostDetailsComponent /></RootLayout>} />
+        <Route path="/about-us" element={<RootLayout><AboutUsComponent /></RootLayout>} />
+        <Route path="/career" element={<RootLayout><CareerComponent /></RootLayout>} />
+        <Route path="/contact-us" element={<RootLayout><ContactUsComponent /></RootLayout>} />
+        <Route path="/blog" element={<RootLayout><BlogComponent /></RootLayout>} />
+        <Route path="/help-center" element={<RootLayout><HelpCenterComponent /></RootLayout>} />
+        <Route path="/guidelines" element={<RootLayout><GuidelinesComponent /></RootLayout>} />
+        <Route path="/community" element={<RootLayout><CommunityComponent /></RootLayout>} />
+        <Route path="*" element={<RootLayout><NotFoundComponent /></RootLayout>} />
       </Routes>
 
     </Router>

--- a/frontend/src/components/community/community.component.tsx
+++ b/frontend/src/components/community/community.component.tsx
@@ -10,8 +10,6 @@ const CommunityComponent: React.FC = () => {
 
   return (
     <div className="gradient-bg min-h-screen text-white">
-      <NavListComponent />
-      
       {/* Hero Section */}
       <section className="relative pt-32 pb-20 overflow-hidden">
         <div className="absolute top-0 left-1/2 -translate-x-1/2 w-[1000px] h-[600px] bg-blue-600/10 rounded-full blur-[120px] -z-10"></div>

--- a/frontend/src/components/hero/hero_section.component.tsx
+++ b/frontend/src/components/hero/hero_section.component.tsx
@@ -4,9 +4,8 @@ import NavListComponent from "./nav_list.component";
 
 const HeroSectionComponent = () => {
   return (
-    <div className="gradient-bg min-h-screen">
-      <div className="relative overflow-hidden">
-        <NavListComponent />
+    <div className="gradient-bg min-h-screen flex flex-col">
+      <div className="relative overflow-hidden flex-grow">
         <div className="relative z-10 mx-auto max-w-7xl px-6 pt-14 pb-24 text-center">
           <div className="inline-flex items-center justify-center mx-auto px-4 py-1.5 mb-8 rounded-full bg-opacity-10 border border-white/20 opacity-80 bg-blue-500/20 text-white">
             <span className="text-sm font-medium">

--- a/frontend/src/components/hero/nav_list.component.tsx
+++ b/frontend/src/components/hero/nav_list.component.tsx
@@ -50,8 +50,9 @@ const NavListComponent: React.FC = () => {
   }, [close]);
 
   return (
-    <div className="relative z-10 mx-auto max-w-8xl px-5 py-4">
-      <div className="flex items-center justify-between">
+    <header className="sticky top-0 z-50 w-full bg-[#0B1120]/80 backdrop-blur-md border-b border-white/10">
+      <div className="relative z-10 mx-auto max-w-8xl px-5 py-4">
+        <div className="flex items-center justify-between">
         <div className="flex items-center space-x-8">
           <Link to="/">
             <img src={logo} alt="logo" width={50} height={50} />
@@ -146,7 +147,8 @@ const NavListComponent: React.FC = () => {
           }
         </div >
       )}
-    </div >
+      </div>
+    </header>
   );
 };
 

--- a/frontend/src/components/layout/root_layout.component.tsx
+++ b/frontend/src/components/layout/root_layout.component.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from "react";
-// import TopHeaderComponent from "../top_header/top_header.component";
+import NavListComponent from "../hero/nav_list.component";
 import FooterComponent from "../footer/footer.component";
 
 interface RootLayoutProps {
@@ -8,11 +8,11 @@ interface RootLayoutProps {
 
 const RootLayout: React.FC<RootLayoutProps> = ({ children }) => {
   return (
-    <>
-      {/* <TopHeaderComponent /> */}
-      <div className="min-h-screen">{children}</div>
+    <div className="flex flex-col min-h-screen">
+      <NavListComponent />
+      <div className="flex-grow">{children}</div>
       <FooterComponent />
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Before you open this PR

- **Issue:** #156 
- **Description:** 
This PR solves a major navigation issue where the main navbar was not accessible on certain pages or would disappear when scrolling.

## Screenshot (when helpful)

https://github.com/user-attachments/assets/a2f10a32-e6f7-4be7-8c2d-c16a5fafbaa2


## What this PR does

This PR introduces a global sticky navigation bar layout to fix UX limitations across all public pages of the platform.
**Details of the changes:**
1. **Global Layout Refactor:** Extracted the `NavListComponent` from individual pages (such as the Hero and Community components) and added it directly to `RootLayout`.
2. **Universal Coverage:** Wrapped previously un-wrapped public routes (like `/explore`, `/pricing`, `/stories`, `/login`, and `/signup`) inside `RootLayout` in `App.tsx` so the navbar is consistently rendered on all top-level public pages.
3. **Sticky Scroll UX:** Updated the styling container inside `nav_list.component.tsx` to use `<header className="sticky top-0 z-50 w-full bg-[#0B1120]/80 backdrop-blur-md border-b border-white/10">`. This gives the navigation bar a persistent glassmorphism sticky header behavior that stays at the top of the browser viewport during scrolls.

## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [x] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Documentation update

## Related issue

Closes #156 

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
