### PR TITLE
fix: display full text in preview section (closes #139)

### DIFF
--- a/frontend/src/components/home/community_spotlight/community_spotlight.component.tsx
+++ b/frontend/src/components/home/community_spotlight/community_spotlight.component.tsx
@@ -46,11 +46,11 @@ const CommunitySpotlightComponent = () => {
                   </p>
                 </div>
               </div>
-              <h3 className="text-lg font-semibold text-gray-200 mb-2 line-clamp-2">
+              <h3 className="text-lg font-semibold text-gray-200 mb-2">
                 {post.title}
               </h3>
-              <p className="text-gray-400 text-sm mb-4 line-clamp-3">
-                {post.content.slice(0, 120)}...
+              <p className="text-gray-400 text-sm mb-4">
+                {post.content}
               </p>
               <div className="flex items-center justify-between">
                 <div className="flex items-center text-xs text-gray-500 gap-3">


### PR DESCRIPTION
Fixes #139

Description
The preview section was unnecessarily truncating story text. This PR removes those layout limits so full titles and content display properly.

Changes-

* Post Title: Removed line-clamp-2 to allow titles to wrap beyond 2 lines.
* Post Content: Replaced post.content.slice(0, 120) with post.content to show the full text.

File Modified:
frontend/src/components/home/community_spotlight/community_spotlight.component.tsx