### PR TITLE
fix: make recommended writers section dynamic

### DIFF
--- a/frontend/src/components/home/recommended_writers/recommended_writers.component.tsx
+++ b/frontend/src/components/home/recommended_writers/recommended_writers.component.tsx
@@ -1,33 +1,72 @@
 import React, { useState } from "react";
 
 const RecommendedWritersComponent = () => {
-  const [isFollowing, setIsFollowing] = useState(false);
+  const recommendedWriters = [
+    {
+      name: "Roni Sarkar",
+      role: "AI Writer",
+      image: "https://avatars.githubusercontent.com/u/76697055?v=4",
+    },
+    {
+      name: "Sarah Lee",
+      role: "Content Creator",
+      image: "https://i.pravatar.cc/150?img=5",
+    },
+    {
+      name: "John Doe",
+      role: "Story Writer",
+      image: "https://i.pravatar.cc/150?img=8",
+    },
+  ];
+
+  const [following, setFollowing] = useState<number[]>([]);
+
+  const toggleFollow = (index: number) => {
+    if (following.includes(index)) {
+      setFollowing(following.filter((id) => id !== index));
+    } else {
+      setFollowing([...following, index]);
+    }
+  };
 
   return (
     <section className="bg-blue-500/10 rounded-lg shadow-sm p-6">
       <h3 className="text-lg font-semibold text-gray-300 mb-4">
         Recommended Writers
       </h3>
+
       <div className="space-y-4">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center">
-            <img
-              className="h-10 w-10 rounded-full"
-              src="https://avatars.githubusercontent.com/u/76697055?v=4"
-              alt=""
-            />
-            <div className="ml-3">
-              <p className="text-sm font-medium text-gray-400">Lisa Wang</p>
-              <p className="text-xs text-gray-500">Tech Writer</p>
-            </div>
-          </div>
-          <button 
-            onClick={() => setIsFollowing(!isFollowing)}
-            className="!rounded-button text-indigo-600 text-sm font-medium hover:text-indigo-700 cursor-pointer"
+        {recommendedWriters.map((writer, index) => (
+          <div
+            key={index}
+            className="flex items-center justify-between"
           >
-            {isFollowing ? "Following" : "Follow"}
-          </button>
-        </div>
+            <div className="flex items-center">
+              <img
+                className="h-10 w-10 rounded-full"
+                src={writer.image}
+                alt={writer.name}
+              />
+
+              <div className="ml-3">
+                <p className="text-sm font-medium text-gray-400">
+                  {writer.name}
+                </p>
+
+                <p className="text-xs text-gray-500">
+                  {writer.role}
+                </p>
+              </div>
+            </div>
+
+            <button
+              onClick={() => toggleFollow(index)}
+              className="!rounded-button text-indigo-600 text-sm font-medium hover:text-indigo-700 cursor-pointer"
+            >
+              {following.includes(index) ? "Following" : "Follow"}
+            </button>
+          </div>
+        ))}
       </div>
     </section>
   );


### PR DESCRIPTION
Screenshot (when helpful)

Added dynamic rendering for the Recommended Writers section using reusable writer data.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/095a2431-7763-436f-88b3-a7cffe6a823e" />


What this PR does
Replaced the static hardcoded Recommended Writers section with dynamic rendering using mapped writer data.
Added reusable writer objects for cleaner and maintainable code.
Implemented individual Follow/Following toggle functionality for writers.
Preserved the existing UI layout and responsiveness without affecting other homepage components.
Improved scalability so additional writers can be added easily in the future.
Type of change
 Bug fix
 Code refactor
Related issue

Fixes #137

More screenshots (optional)

N/A

Checklist
 I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
 I have filled in the related issue number when there is one.
 I have tested my changes.
 I have done a self-review of the code.