### PR TITLE
feat: add story genre/tone selector to enhance AI story generation

### DIFF
--- a/frontend/src/components/stories/stories.component.tsx
+++ b/frontend/src/components/stories/stories.component.tsx
@@ -29,6 +29,7 @@ const StoriesComponent = () => {
   const [generateModel] = useGenerateModelMutation();
   const [generateFreeModel] = useGenerateFreeModelMutation();
   const [selectedPrompt, setSelectedPrompt] = useState<string>("");
+const [selectedGenre, setSelectedGenre] = useState<string>("");
   const [textareaValue, setTextareaValue] = useState<string>("");
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const [guestRequestCount, setGuestRequestCount] = useState<number>(() =>
@@ -69,9 +70,14 @@ const StoriesComponent = () => {
     setLoading(true);
    
     try {
+      const payload = {
+        prompt: selectedGenre
+          ? `[Genre: ${selectedGenre}] ${data.prompt}`
+          : data.prompt,
+      };
       const res = login
-        ? await generateModel(data).unwrap()
-        : await generateFreeModel(data).unwrap();
+        ? await generateModel(payload).unwrap()
+        : await generateFreeModel(payload).unwrap();
       if (res) {
         toast.success(res.message);
         setStories(res.data as IStories[]);
@@ -171,6 +177,22 @@ const StoriesComponent = () => {
             <div className="bg-blue-500/10 rounded-md p-4 border border-gray-400">
               <div className="relative">
                 <form className="space-y-4" onSubmit={handleSubmit(onSubmit)}>
+                  <div className="flex flex-wrap gap-2 mb-3">
+                    {["🎭 Drama", "😂 Comedy", "😱 Horror", "💕 Romance", "🚀 Sci-Fi", "🧙 Fantasy", "🔍 Mystery", "🌟 Adventure"].map((genre) => (
+                      <button
+                        key={genre}
+                        type="button"
+                        onClick={() => setSelectedGenre(selectedGenre === genre ? "" : genre)}
+                        className={`px-3 py-1 rounded-full text-xs font-medium transition-all duration-200 ${
+                          selectedGenre === genre
+                            ? "bg-indigo-500 text-white shadow-lg shadow-indigo-500/30"
+                            : "bg-white/10 text-gray-400 hover:bg-white/20 hover:text-gray-200"
+                        }`}
+                      >
+                        {genre}
+                      </button>
+                    ))}
+                  </div>
                   <div className="relative">
                     <textarea
                       {...register("prompt")}


### PR DESCRIPTION

- Issue: Closes #152
- Description: Added a Genre/Tone selector above the story prompt input

## Screenshot
<img width="933" height="576" alt="image" src="https://github.com/user-attachments/assets/38f1c720-4718-491e-8187-7472a23c6f32" />

## What this PR does
Adds a Genre/Tone selector above the story prompt input. Users can 
pick from 8 genre chips:
🎭 Drama, 😂 Comedy, 😱 Horror, 💕 Romance, 🚀 Sci-Fi, 🧙 Fantasy, 
🔍 Mystery, 🌟 Adventure

The selected genre is prepended to the AI prompt to guide story generation in the right tone and style. Clicking a genre selects it (highlighted in purple). Clicking again deselects it.

## Type of change
- [x] New feature

## Related issue
Closes #152
