### PR TITLE
Fix:  community page URL is broken #195

### DIFF
--- a/frontend/src/components/hero/nav_list.component.tsx
+++ b/frontend/src/components/hero/nav_list.component.tsx
@@ -61,7 +61,7 @@ const NavListComponent: React.FC = () => {
             <Link to="/" className="text-gray-400 hover:text-custom transition">HOME</Link>
             <Link to="/explore" className="text-gray-400 hover:text-custom transition">EXPLORE</Link>
             <Link to="/contact-us" className="text-gray-400 hover:text-custom transition">CONTACT US</Link>
-            <Link to="/conmunity" className="text-gray-400 hover:text-custom transition">COMMUNITY</Link>
+            <Link to="/community" className="text-gray-400 hover:text-custom transition">COMMUNITY</Link>
             {isLogin && (
               <>
                 <Link to="/bookmarks" className="text-gray-400 hover:text-custom transition">SAVED STORIES</Link>


### PR DESCRIPTION
Closes issue #195 

Screenshot:
<img width="1470" height="956" alt="Screenshot 2026-05-19 at 9 15 10 PM" src="https://github.com/user-attachments/assets/e8c8f13e-2782-4a70-bca1-09c3cc1190bc" />
