### PR TITLE
fix: hide footer on login page

### DIFF
--- a/frontend/src/components/layout/root_layout.component.tsx
+++ b/frontend/src/components/layout/root_layout.component.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from "react";
+import { useLocation } from "react-router-dom";
 import NavListComponent from "../hero/nav_list.component";
 import FooterComponent from "../footer/footer.component";
 
@@ -7,11 +8,14 @@ interface RootLayoutProps {
 }
 
 const RootLayout: React.FC<RootLayoutProps> = ({ children }) => {
+  const { pathname } = useLocation();
+  const hideFooter = pathname === "/login";
+
   return (
     <div className="flex flex-col min-h-screen">
       <NavListComponent />
       <div className="flex-grow">{children}</div>
-      <FooterComponent />
+      {!hideFooter && <FooterComponent />}
     </div>
   );
 };


### PR DESCRIPTION
## Description
Closes #200

This removes the global footer from the `/login` route so the login screen no longer shows the footer newsletter/email form below the authentication panel. The footer remains unchanged on the rest of the public pages.

## Changes made
- Read the current route inside `RootLayout` with `useLocation()`.
- Hide `FooterComponent` only when `pathname === "/login"`.
- Kept the navigation and login form layout untouched.

## Validation
- `npm install` in `frontend/`
- `npx eslint src/components/layout/root_layout.component.tsx` passed
- `git diff --check` passed

Also attempted:
- `npm run build` reached the Vite/Rollup phase after TypeScript and then failed on the local macOS Rollup optional native binding/code-signature issue for `@rollup/rollup-darwin-arm64`.
- `npm run lint` is blocked by existing repo-wide lint errors outside this PR; the touched file passes targeted ESLint.

## GSSoC labels requested
Please add/keep `gssoc:approved`, `level:beginner`, `quality:clean`, and `type:bug`/`type:design` if this fix is accepted.
