### PR TITLE
fix: remove footer from signup page(#207)

### DIFF
--- a/frontend/src/components/layout/root_layout.component.tsx
+++ b/frontend/src/components/layout/root_layout.component.tsx
@@ -9,7 +9,7 @@ interface RootLayoutProps {
 
 const RootLayout: React.FC<RootLayoutProps> = ({ children }) => {
   const { pathname } = useLocation();
-  const hideFooter = pathname === "/login";
+  const hideFooter = pathname === "/login" || pathname === "/signup";
 
   return (
     <div className="flex flex-col min-h-screen">


### PR DESCRIPTION
Fixes #207 

The footer was visible on the signup page, which is undesirable for auth pages. 
Fixed by adding `/signup` to the `hideFooter` condition in `root_layout.component.tsx`, 
alongside the existing `/login` exclusion.

N/A — single line logic change, no visual screenshot needed (footer is simply absent on signup page after fix)