### PR TITLE
Add reusable error boundary component

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,6 +31,7 @@ import PostListsComponent from "./components/dashboard/posts/post_lists.componen
 import ProfileComponent from "./components/dashboard/profile/profile.component";
 import Contact from "./components/contactus/contactus";
 import HelpCenterComponent from "./components/help_center/help_center.component";
+import ErrorBoundary from "./components/ErrorBoundary";
 
 
 import AboutUsComponent from "./components/footer/about-us.tsx";
@@ -74,6 +75,7 @@ function App() {
   }, [darkMode]);
 
   return (
+     <ErrorBoundary>
     <Router>
       {/* Dark Mode Toggle Button */}
       {/* <div className="fixed top-4 right-4 z-50">
@@ -395,6 +397,7 @@ function App() {
         />
       </Routes>
     </Router>
+    </ErrorBoundary>
   );
 }
 export default App;

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,35 @@
+import React, { Component, ErrorInfo, ReactNode } from "react";
+import ErrorPage from "./ErrorPage";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error("Error caught by ErrorBoundary:", error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <ErrorPage />;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/frontend/src/components/ErrorPage.tsx
+++ b/frontend/src/components/ErrorPage.tsx
@@ -1,0 +1,18 @@
+const ErrorPage = () => {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-slate-950 text-white px-4 text-center">
+      <h1 className="text-5xl font-bold mb-4">Oops!</h1>
+      <p className="text-lg text-slate-300 mb-6">
+        Something went wrong while loading this page.
+      </p>
+      <button
+        onClick={() => window.location.reload()}
+        className="px-5 py-2 bg-blue-600 rounded-lg hover:bg-blue-700 transition"
+      >
+        Reload Page
+      </button>
+    </div>
+  );
+};
+
+export default ErrorPage;


### PR DESCRIPTION

## Screenshot (when helpful)

<img width="1600" height="917" alt="Screenshot 2026-05-20 154910" src="https://github.com/user-attachments/assets/b5a9461e-ef3e-4d78-98fe-b579bb247c32" />
<img width="1600" height="917" alt="Screenshot 2026-05-20 154910" src="https://github.com/user-attachments/assets/b5a9461e-ef3e-4d78-98fe-b579bb247c32" />



## What this PR does

Adds a reusable Error Boundary component to gracefully handle unexpected frontend crashes.

The component displays a fallback UI with a reload button and prevents the entire application from crashing when a React component throws an error.


## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [ ] Bug fix
- [x] New feature
- [x] Code refactor
- [ ] Documentation update

## Related issue

Closes #215 

## More screenshots (optional)

N/A


## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
