### PR TITLE
fix: remove header from login page

### DIFF
--- a/frontend/src/components/layout/root_layout.component.tsx
+++ b/frontend/src/components/layout/root_layout.component.tsx
@@ -9,11 +9,12 @@ interface RootLayoutProps {
 
 const RootLayout: React.FC<RootLayoutProps> = ({ children }) => {
   const { pathname } = useLocation();
+  const hideHeader = pathname === "/login";
   const hideFooter = pathname === "/login" || pathname === "/signup";
 
   return (
     <div className="flex flex-col min-h-screen">
-      <NavListComponent />
+      {!hideHeader && <NavListComponent />}
       <div className="flex-grow">{children}</div>
       {!hideFooter && <FooterComponent />}
     </div>


### PR DESCRIPTION
## Screenshot

Before: 
<img width="1523" height="581" alt="Screenshot 2026-05-20 at 4 57 17 PM" src="https://github.com/user-attachments/assets/e6e0783c-484e-4aca-9c1e-935fc23776cf" />

After screenshot added showing the login page without the header/navbar.
<img width="1562" height="796" alt="Screenshot 2026-05-20 at 4 59 04 PM" src="https://github.com/user-attachments/assets/42a917ce-5f71-44ef-b0c1-54b97d94aa68" />


## What this PR does

Removes the header/navbar from the login page by conditionally hiding `NavListComponent` on the `/login` route.

The existing footer hiding behavior is unchanged, and other routes are not affected.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Fixes #208

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.