### PR TITLE
Fix signup validation

### DIFF
--- a/frontend/src/components/signup/signup.component.tsx
+++ b/frontend/src/components/signup/signup.component.tsx
@@ -48,7 +48,12 @@ const SignUpComponent = () => {
   const [emailVerify] = useEmailVerifyMutation();
   const [verifyOtp] = useVerifyOtpMutation();
   const [registerUser] = useRegisterUserMutation();
-  const { register, handleSubmit, watch } = useForm<Inputs>();
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<Inputs>({ mode: "onChange" });
   const [isBusy, setIsBusy] = useState<boolean>(false);
   const [showOtpField, setShowOtpField] = useState<boolean>(false);
   const [registerInfo, setRegisterInfo] = useState<IRegisterInfo>();
@@ -181,6 +186,19 @@ const SignUpComponent = () => {
               required={true}
               icon="fas fa-user"
               register={register}
+              validation={{
+                required: "Name is required",
+                minLength: {
+                  value: 8,
+                  message: "Name must be at least 8 characters",
+                },
+                pattern: {
+                  value: /^[A-Za-z0-9._]+$/,
+                  message:
+                    "Only letters, numbers, underscores, and dots are allowed",
+                },
+              }}
+              error={errors.name}
             />
 
             <SSInput
@@ -191,6 +209,7 @@ const SignUpComponent = () => {
               required={true}
               icon="fas fa-envelope"
               register={register}
+              error={errors.email}
             />
 
             <SSInput
@@ -201,6 +220,7 @@ const SignUpComponent = () => {
               required={true}
               icon="fas fa-lock"
               register={register}
+              error={errors.password}
             />
 
             <p className="text-xs text-gray-500 -mt-2">
@@ -216,6 +236,7 @@ const SignUpComponent = () => {
               required={true}
               icon="fas fa-eye"
               register={register}
+              error={errors.confirmPassword}
             />
 
             <SSButton


### PR DESCRIPTION


## Screenshot (when helpful)

<img width="1902" height="871" alt="Screenshot 2026-05-20 221119" src="https://github.com/user-attachments/assets/dc10c3e3-4277-4cff-ba38-ea7ca4dab080" />


## What this PR does
This PR fixes the delayed username validation issue during the signup flow.

Previously, users were able to proceed to OTP verification even with an invalid username (less than the required minimum length). The validation error only appeared after clicking the OTP verification button.

Changes made
 Added frontend username validation on the signup page
 Implemented real-time validation feedback for invalid usernames
 Prevented users from proceeding to OTP verification when validation fails
 Added inline error messages for better user experience



## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update



## More screenshots (optional)

Before PR

<img width="1912" height="827" alt="595410281-7169d330-485d-4d5d-8932-51a6230da9b8" src="https://github.com/user-attachments/assets/b3fab8a8-6839-4d45-9e4b-16e750b14f50" />

After resolving

<img width="1902" height="871" alt="Screenshot 2026-05-20 221119" src="https://github.com/user-attachments/assets/dc10c3e3-4277-4cff-ba38-ea7ca4dab080" />

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.

Fixes #221

