### PR TITLE
feat(backend): implement email utility for newsletter verification

### DIFF
--- a/backend/src/app/modules/newsletter/newsletter.service.ts
+++ b/backend/src/app/modules/newsletter/newsletter.service.ts
@@ -1,5 +1,6 @@
 import crypto from "crypto";
 import { NewsletterSubscriber } from "./newsletter.model";
+import { sendVerificationEmail } from "../../../utils/email.util";
 
 export const subscribeNewsletter = async (
   email: string,
@@ -20,6 +21,10 @@ export const subscribeNewsletter = async (
       existing.verificationToken = crypto.randomBytes(32).toString("hex");
       existing.verificationTokenExpires = new Date(Date.now() + 24 * 60 * 60 * 1000);
       await existing.save();
+
+      // Send verification email
+      await sendVerificationEmail(normalizedEmail, existing.verificationToken);
+
       return { message: "Re-subscribed. Please verify your email.", subscriber: existing };
     }
   }
@@ -37,7 +42,9 @@ export const subscribeNewsletter = async (
     verificationTokenExpires: new Date(Date.now() + 24 * 60 * 60 * 1000),
   });
 
-  // TODO: send verification email using project's email utility
+  // Send verification email
+  await sendVerificationEmail(normalizedEmail, token);
+
   return { message: "Subscribed! Please verify your email.", subscriber };
 };
 

--- a/backend/src/utils/email.util.ts
+++ b/backend/src/utils/email.util.ts
@@ -1,0 +1,48 @@
+import nodemailer from "nodemailer";
+import config from "../config";
+
+export const sendVerificationEmail = async (to: string, token: string) => {
+  if (!config.verify_email || !config.verify_password) {
+    console.warn("Email configuration missing. Verification email not sent.");
+    return;
+  }
+
+  const transporter = nodemailer.createTransport({
+    service: "gmail",
+    auth: {
+      user: config.verify_email,
+      pass: config.verify_password,
+    },
+  });
+
+  const frontendUrl = config.cors_origins?.[0] || "http://localhost:4001";
+  const verifyLink = `${frontendUrl}/verify-newsletter?token=${token}`;
+
+  const mailOptions = {
+    from: `"Story Spark AI" <${config.verify_email}>`,
+    to,
+    subject: "Verify your Newsletter Subscription",
+    html: `
+      <div style="font-family: Arial, sans-serif; padding: 20px; color: #333;">
+        <h2>Welcome to the Story Spark AI Newsletter!</h2>
+        <p>Thank you for subscribing. Please verify your email address to confirm your subscription by clicking the button below:</p>
+        <p style="margin: 30px 0;">
+          <a href="${verifyLink}" style="display: inline-block; padding: 12px 24px; background-color: #6366f1; color: #ffffff; text-decoration: none; border-radius: 6px; font-weight: bold;">Verify Email Address</a>
+        </p>
+        <p>If the button doesn't work, you can copy and paste this link into your browser:</p>
+        <p><a href="${verifyLink}" style="color: #6366f1;">${verifyLink}</a></p>
+        <p style="color: #666; font-size: 14px;">This link will expire in 24 hours.</p>
+        <hr style="border: none; border-top: 1px solid #eaeaea; margin: 30px 0;" />
+        <p style="color: #888; font-size: 12px;">Best regards,<br/>The Story Spark AI Team</p>
+      </div>
+    `,
+  };
+
+  try {
+    await transporter.sendMail(mailOptions);
+  } catch (error) {
+    console.error("Error sending verification email:", error);
+    // Don't throw an error here, so we don't break the subscription flow if email fails.
+    // The user record will still be created and they can request another verification if needed.
+  }
+};


### PR DESCRIPTION
## What this PR does

<!-- Short summary: what problem does this solve, and how? -->
Resolves an unfulfilled `TODO` in `newsletter.service.ts` by implementing the missing email utility. When a user subscribes or re-subscribes to the newsletter, the backend now dispatches a formatted HTML verification email using `nodemailer` to ensure the authenticity of the subscriber.

## Changes Made
- **Created `email.util.ts`**: Configured a `nodemailer` transporter utilizing `VERIFY_EMAIL` and `VERIFY_PASSWORD` from the environment.
- **Updated `newsletter.service.ts`**: Replaced the `TODO` block with the `sendVerificationEmail` function call during new subscriptions and re-subscriptions.
- **Error Handling**: Wrapped the email dispatch in a `try...catch` block to ensure API stability in case the SMTP server or credentials fail.


## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

<!-- Example: Closes #123 or Fixes #45. Use “None” if there is no issue. -->
Closes #238 


## Checklist

- [ ] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
