### PR TITLE
Remove duplicate navbar from landing page

### DIFF
--- a/frontend/src/components/hero/hero_section.component.tsx
+++ b/frontend/src/components/hero/hero_section.component.tsx
@@ -1,6 +1,5 @@
 import { Link } from "react-router-dom";
 import { useEffect, useRef, useState, type MouseEvent } from "react";
-import NavListComponent from "./nav_list.component";
 
 const HeroSectionComponent = () => {
   const [stars, setStars] = useState<Array<{ id: number; x: number; y: number; size: number }>>([]);
@@ -37,8 +36,6 @@ const HeroSectionComponent = () => {
     <div className="relative min-h-screen bg-slate-900 text-slate-100 overflow-hidden font-sans">
       <div className="absolute top-[-10%] left-[-10%] w-[500px] h-[500px] bg-blue-600/20 rounded-full blur-[120px] pointer-events-none -z-10" />
       <div className="absolute top-[20%] right-[-10%] w-[500px] h-[500px] bg-purple-600/20 rounded-full blur-[120px] pointer-events-none -z-10" />
-
-      <NavListComponent />
 
       <div className="relative overflow-hidden" onMouseMove={handleMouseMove}>
         <div className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-20 pb-20 text-center">


### PR DESCRIPTION
Hey @ronisarkarexe 
##  Fix Duplicate Navbar Rendering on Landing Page

### Description
Resolved the issue where the landing page displayed two identical navigation bars stacked vertically.

### Issue Fixed
Closes #300 

### Root Cause
`HeroSectionComponent` was rendering `NavListComponent` inside the hero section, while the same navbar was already being rendered globally through `RootLayout`.

This caused:
- Duplicate navigation headers
- Extra vertical spacing above the hero section
- UI inconsistency on the homepage

### Changes Made
- Removed the redundant `NavListComponent` mount from:
  - `hero_section.component.tsx`
- Kept the globally shared navbar rendered through `RootLayout`

### Result
- Homepage now renders only a single navbar
- Header spacing/layout is corrected
- Cleaner and more consistent landing page UI

### Validation
- Verified the updated file using `get_errors`
- No errors found after the change

### Before
- Two stacked navbars visible on homepage
<img width="2048" height="1160" alt="image" src="https://github.com/user-attachments/assets/a0c0e5e1-d10e-4806-a4b1-60e94d0b7b8a" />

### After
- Only one shared navbar is rendered correctly
<img width="1440" height="816" alt="image" src="https://github.com/user-attachments/assets/ed059dfd-8aac-4a56-89ac-ebcf26a16026" />

Thank you!  
Pranshu Pujara🕵️‍♂️