### PR TITLE
fix: improve text visiblity in pricing cards

### DIFF
--- a/frontend/src/components/home/pricing/pricing.component.tsx
+++ b/frontend/src/components/home/pricing/pricing.component.tsx
@@ -95,10 +95,10 @@ const PricingComponent = () => {
             )}
             <h3 className="text-xl font-semibold mb-2 text-gray-300">{plan.title}</h3>
             <div className="mb-4">
-              <span className="text-4xl font-bold text-gray-500">{plan.price}</span>
+              <span className="text-4xl font-bold text-gray-300">{plan.price}</span>
               <span className="text-gray-500">{plan.duration}</span>
             </div>
-            <ul className="space-y-3 mb-8">
+            <ul className="space-y-3 mb-8 text-gray-500">
               {plan.features.map((feature, i) => (
                 <li key={i} className="flex items-center">
                   <i className="fas fa-check text-green-500 mr-2"></i>


### PR DESCRIPTION

## Screenshot
<img width="1608" height="622" alt="image" src="https://github.com/user-attachments/assets/0ab67905-5c41-4967-a9c4-65e7f9f026f4" />



## What this PR does
Improves pricing section text visibility by updating gray  and black text colors to improve readability and contrast.



## Type of change
- [x] Bug fix


## Related issue

Closes #270 



## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
