### PR TITLE
fix: Enter key now generates story, Shift+Enter for new line (#281)

### DIFF
--- a/frontend/src/components/stories/stories.component.tsx
+++ b/frontend/src/components/stories/stories.component.tsx
@@ -146,15 +146,14 @@ const handleClearPrompt = () => {
 
   const isOverLimit = textareaValue.length >= MAX_PROMPT_LENGTH;
   const isNearLimit = textareaValue.length >= MAX_PROMPT_LENGTH * WARN_THRESHOLD;
-  console.log("Stories component rendered");
   
   useKeyboardShortcuts({
   onOpenHelp: () => setShowHelpModal(true),
   onCloseHelp: () => setShowHelpModal(false),
   onGenerate: () => {
-    const form = document.querySelector("form");
-    if (form) {
-      form.requestSubmit();
+    if (inputRef.current) {
+      const form = inputRef.current.closest("form");
+      if (form) form.requestSubmit();
     }
   },
   onPublish: () => {
@@ -295,14 +294,15 @@ const handleClearPrompt = () => {
         placeholder="Every great story begins with a single idea. What's yours?"
         value={textareaValue}
         maxLength={MAX_PROMPT_LENGTH}
-onChange={(e) => setTextareaValue(e.target.value)}
+        onChange={(e) => setTextareaValue(e.target.value)}
         onKeyDown={(e) => {
           if (e.key === "Enter" && !e.shiftKey) {
             e.preventDefault();
             const form = e.currentTarget.closest("form");
             if (form) form.requestSubmit();
           }
-        }}      />
+        }}      
+        />
 
       {textareaValue.length > 0 && (
         <button
@@ -362,6 +362,10 @@ onChange={(e) => setTextareaValue(e.target.value)}
         Enter
       </kbd>{" "}
       to generate &bull;{" "}
+      <kbd className="px-1 py-0.5 text-xs bg-gray-700 rounded border border-gray-600">
+        Ctrl + Enter
+      </kbd>{" "}
+      also works &bull;{" "}
       <kbd className="px-1 py-0.5 text-xs bg-gray-700 rounded border border-gray-600">
         Shift + Enter
       </kbd>{" "}

--- a/frontend/src/components/stories/stories.component.tsx
+++ b/frontend/src/components/stories/stories.component.tsx
@@ -295,8 +295,14 @@ const handleClearPrompt = () => {
         placeholder="Every great story begins with a single idea. What's yours?"
         value={textareaValue}
         maxLength={MAX_PROMPT_LENGTH}
-        onChange={(e) => setTextareaValue(e.target.value)}
-      />
+onChange={(e) => setTextareaValue(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && !e.shiftKey) {
+            e.preventDefault();
+            const form = e.currentTarget.closest("form");
+            if (form) form.requestSubmit();
+          }
+        }}      />
 
       {textareaValue.length > 0 && (
         <button
@@ -351,11 +357,15 @@ const handleClearPrompt = () => {
     </div>
 
     <p className="text-xs text-gray-500 mt-1 px-1">
-      💡 <span className="font-medium">Keyboard tip:</span> Press{" "}
+      💡  <span className="font-medium">Keyboard tip:</span> Press{" "}
       <kbd className="px-1 py-0.5 text-xs bg-gray-700 rounded border border-gray-600">
-        Ctrl + Enter
+        Enter
       </kbd>{" "}
-      to generate story
+      to generate &bull;{" "}
+      <kbd className="px-1 py-0.5 text-xs bg-gray-700 rounded border border-gray-600">
+        Shift + Enter
+      </kbd>{" "}
+      for new line
     </p>
 
     <div className="flex justify-end mt-2 w-full">

--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -18,33 +18,25 @@ const useKeyboardShortcuts = ({
   hasStory,
 }: ShortcutHandlers) => {
   useEffect(() => {
-    console.log("keyboard hook mounted");
-
     const handler = (e: KeyboardEvent) => {
-      console.log("KEY:", e.key, "CODE:", e.code, "SHIFT:", e.shiftKey);
-
       const active = document.activeElement;
-
       const isTyping =
         active !== null &&
         ["INPUT", "TEXTAREA", "SELECT"].includes(active.tagName);
 
       if (e.shiftKey && e.code === "Slash") {
-        console.log("OPEN HELP");
         e.preventDefault();
         onOpenHelp();
         return;
       }
 
       if (e.key === "Escape") {
-        console.log("ESC");
         e.preventDefault();
         onCloseHelp();
         return;
       }
 
       if (e.ctrlKey && e.key === "Enter") {
-        console.log("GENERATE");
         e.preventDefault();
         onGenerate();
         return;
@@ -53,16 +45,13 @@ const useKeyboardShortcuts = ({
       if (isTyping) return;
 
       if (e.key === "/") {
-        console.log("FOCUS");
         e.preventDefault();
         focusPrompt();
         return;
       }
 
       if (e.ctrlKey && e.key.toLowerCase() === "s") {
-        console.log("SAVE");
         e.preventDefault();
-
         if (hasStory) {
           onPublish();
         }
@@ -70,7 +59,6 @@ const useKeyboardShortcuts = ({
     };
 
     document.addEventListener("keydown", handler);
-
     return () => {
       document.removeEventListener("keydown", handler);
     };

--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -43,19 +43,19 @@ const useKeyboardShortcuts = ({
         return;
       }
 
+      if (e.ctrlKey && e.key === "Enter") {
+        console.log("GENERATE");
+        e.preventDefault();
+        onGenerate();
+        return;
+      }
+
       if (isTyping) return;
 
       if (e.key === "/") {
         console.log("FOCUS");
         e.preventDefault();
         focusPrompt();
-        return;
-      }
-
-      if (e.ctrlKey && e.key === "Enter") {
-        console.log("GENERATE");
-        e.preventDefault();
-        onGenerate();
         return;
       }
 


### PR DESCRIPTION
Fixes #281

## Problem
The UI displayed "Press Enter to generate your story" but pressing Enter inside the textarea only added a new line instead of generating the story.

## Root Cause
In `useKeyboardShortcuts.ts`, the `Ctrl+Enter` shortcut check was placed after `if (isTyping) return` — so when the textarea was focused, the shortcut was never triggered.

## Changes Made

### `frontend/src/hooks/useKeyboardShortcuts.ts`
- Moved `Ctrl+Enter` check before `if (isTyping) return` so it works inside textarea

### `frontend/src/components/stories/stories.component.tsx`
- Added `onKeyDown` handler to textarea: `Enter` = generate story, `Shift+Enter` = new line
- Updated keyboard tip UI to reflect new behavior

## Behavior After Fix
| Key | Action |
|-----|--------|
| `Enter` | ✅ Generates story |
| `Shift + Enter` | ✅ Adds new line |
| `Ctrl + Enter` | ✅ Also generates story |

## Screenshots

<img width="785" height="395" alt="Screenshot 2026-05-23 at 11 59 13 AM" src="https://github.com/user-attachments/assets/eebb91fb-aeb8-42f2-a273-586b1cd5df01" />


Closes #281