### PR TITLE
Fix footer navigation scroll reset behavior

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import {
   Route,
   Navigate,
 } from "react-router-dom";
+import ScrollToTop from "./components/ScrollToTop";
 
 
 import HeroSectionComponent from "./components/hero/hero_section.component";
@@ -77,6 +78,7 @@ function App() {
 
   return (
     <Router>
+      <ScrollToTop />
       {/* Dark Mode Toggle Button */}
       {/* <div className="fixed top-4 right-4 z-50">
         <button

--- a/frontend/src/components/ScrollToTop.tsx
+++ b/frontend/src/components/ScrollToTop.tsx
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+      left: 0,
+      behavior: "smooth",
+    });
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollToTop;

--- a/frontend/src/components/footer/footer.component.tsx
+++ b/frontend/src/components/footer/footer.component.tsx
@@ -84,7 +84,6 @@ const FooterComponent = () => {
           <div className="col-span-12 md:col-span-5 flex flex-col gap-5">
             <Link
               to="/"
-              onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
               className="group inline-block w-fit"
             >
               <img


### PR DESCRIPTION
## Screenshot

Added screenshots demonstrating the footer navigation behavior before and after the fix.
### Before Fix
- Route changes correctly
- Scroll position remains near footer
<img width="1919" height="940" alt="image" src="https://github.com/user-attachments/assets/bad4382a-d58b-4bf5-a206-8926f08364fc" />


### After Fix
- Route changes correctly
- Page scrolls to top automatically
STEP 1:
<img width="1916" height="937" alt="image" src="https://github.com/user-attachments/assets/7f434a30-9b69-47fa-8607-4754c33eaad0" />
STEP 2: 
<img width="1919" height="942" alt="image" src="https://github.com/user-attachments/assets/0e613879-8bcc-46de-aee4-dc58a4c699a3" />


---

## What this PR does

This PR fixes the inconsistent scroll behavior during route navigation from footer links.

Previously, when users clicked footer links such as:

* About Us
* Careers
* Community
* Guidelines

the route changed successfully, but the scroll position remained at the previous location instead of resetting to the top of the page.

### Changes made:

* Added a reusable `ScrollToTop` component using `useLocation` and `useEffect`
* Implemented global scroll restoration for all route changes
* Removed redundant inline scroll handling from the footer logo link
* Ensured consistent navigation behavior across the application

### Result:

All route navigations now smoothly scroll to the top of the page, improving overall user experience and navigation consistency.

---

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

---

## Related issue

Fixes #276

---

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.
