### PR TITLE
removed duplicate navbar, fix issue#247

### DIFF
--- a/frontend/src/components/hero/hero_section.component.tsx
+++ b/frontend/src/components/hero/hero_section.component.tsx
@@ -1,6 +1,5 @@
 import { Link } from "react-router-dom";
 import { useEffect, useRef, useState, type MouseEvent } from "react";
-import NavListComponent from "./nav_list.component";
 
 const HeroSectionComponent = () => {
   const [stars, setStars] = useState<Array<{ id: number; x: number; y: number; size: number }>>([]);
@@ -37,8 +36,6 @@ const HeroSectionComponent = () => {
     <div className="relative min-h-screen bg-slate-900 text-slate-100 overflow-hidden font-sans">
       <div className="absolute top-[-10%] left-[-10%] w-[500px] h-[500px] bg-blue-600/20 rounded-full blur-[120px] pointer-events-none -z-10" />
       <div className="absolute top-[20%] right-[-10%] w-[500px] h-[500px] bg-purple-600/20 rounded-full blur-[120px] pointer-events-none -z-10" />
-
-      <NavListComponent />
 
       <div className="relative overflow-hidden" onMouseMove={handleMouseMove}>
         <div className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-20 pb-20 text-center">


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Fixes #247 
- **Description:** This PR removes the extra navbar from the landing page, just a minimal change.
- **Screenshots:** 


## Screenshot (when helpful)
Before
<img width="1913" height="1000" alt="Screenshot 2026-05-23 152715" src="https://github.com/user-attachments/assets/413e437b-2cff-47cf-8abe-70e28e6e920a" />
After
<img width="1919" height="880" alt="Screenshot 2026-05-23 152959" src="https://github.com/user-attachments/assets/9a301b30-b025-4053-9bb2-ef768ecfbe3d" />

## What this PR does

Removes the duplicate navbar on the landing page so only the top header remains.

## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Fixes #247

## More screenshots (optional)

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.  
- [x] I have filled in the related issue number when there is one.  
- [x] I have tested my changes.  
- [x] I have done a self-review of the code.