### PR TITLE
fix: correct middleware order and remove unsafe next() call in app.ts (closes #289)

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -36,10 +36,7 @@ app.use(cookieParser());
 app.use("/api/v1", Routers);
 
 // Global error handler
-app.use(globalErrorHandler);
-
-// Handle API not found
-app.use((req: Request, res: Response, next: NextFunction) => {
+app.use((req: Request, res: Response) => {
   res.status(httpStatus.NOT_FOUND).json({
     success: false,
     message: "Not Found",
@@ -50,9 +47,9 @@ app.use((req: Request, res: Response, next: NextFunction) => {
       },
     ],
   });
-  next();
 });
 
+app.use(globalErrorHandler);
 // Cron job to reset request counts at the beginning of each month (skip on Vercel serverless)
 if (!process.env.VERCEL) {
   cron.schedule("0 0 1 * *", async () => {


### PR DESCRIPTION
## What this PR does:
Fixes two bugs in backend/src/app.ts:

1. Incorrect Middleware Order — globalErrorHandler was 
registered BEFORE the 404 handler. Express executes 
middleware in registration order, so the 404 handler 
was never reached for unmatched routes. Fixed by moving 
the 404 handler BEFORE globalErrorHandler.

2. Unsafe next() Call — next() was called after 
res.json() already sent the response, which can cause 
ERR_HTTP_HEADERS_SENT errors. Fixed by removing next() 
and NextFunction from the 404 handler.

## Type of change:
✅ Bug fix

## Related issue:
Closes #289

## Screenshot:
N/A — backend middleware order fix, no UI changes.

## Checklist:
✅ N/A — no UI changes needed for screenshots
✅ Related issue: Closes #289
✅ Tested by verifying middleware execution order in Express
✅ Self-reviewed the code changes