### PR TITLE
Fix View Guidelines CTA redirect on Community page

### DIFF
--- a/frontend/src/components/community/community.component.tsx
+++ b/frontend/src/components/community/community.component.tsx
@@ -41,7 +41,7 @@ const CommunityComponent: React.FC = () => {
                 JOIN DISCORD
               </button>
             </a>
-            <Link to="/community#guidelines" className="w-full sm:w-auto">
+            <Link to="/guidelines" className="w-full sm:w-auto">
               <button className="w-full !rounded-button bg-transparent border border-white/20 hover:bg-white/5 text-white px-10 py-4 font-bold transition-all cursor-pointer">
                 VIEW GUIDELINES
               </button>


### PR DESCRIPTION
## Description

Fixed Issue #266: View Guidelines CTA redirecting to the incorrect destination on the Community page.

### Bug

Previously, clicking **View Guidelines** redirected users to:

`/community#guidelines`

which only scrolled to the bottom CTA section instead of opening the actual Guidelines page.

### Fix

Updated the CTA redirect to correctly navigate to:

`/guidelines`

### Changes Made

* Fixed incorrect navigation path in Community page CTA
* Preserved existing UI and styling
* No routing or component refactors

### Additional Notes

* Only 1 file changed
* Build passes successfully
* Existing footer guideline links remain unchanged
