### PR TITLE
fix: add role-based redirects after login

### DIFF
--- a/frontend/src/components/login/login.component.tsx
+++ b/frontend/src/components/login/login.component.tsx
@@ -7,6 +7,7 @@ import {
   useGoogleLoginMutation,
 } from "../../redux/apis/auth.api";
 import { storeUserInfo, getUserInfo } from "../../services/auth.service";
+import { USER_ROLE } from "../../constants/role";
 import RedirectComponent from "../redirect.component";
 import toast, { Toaster } from "react-hot-toast";
 import { GoogleLogin } from "@react-oauth/google";
@@ -96,8 +97,8 @@ const LoginComponent = () => {
     const userInfo = getUserInfo();
 
     const isDashboardUser =
-      userInfo?.role === "admin" ||
-      userInfo?.role === "super_admin";
+      userInfo?.role === USER_ROLE.ADMIN ||
+      userInfo?.role === USER_ROLE.SUPER_ADMIN;
 
     return (
       <RedirectComponent


### PR DESCRIPTION
What this PR does

This PR fixes the login redirect flow for non-admin users after authentication.

Changes Made
Added role-based redirect handling after login
Redirected admin and super admin users to /dashboard
Redirected regular users and writers to /explore
Fixed redirect flicker and unnecessary bounce to the home page
Replaced hardcoded role strings with USER_ROLE enum values
Type of change

Bug fix

New feature

Code refactor

Documentation update

Related issue

Closes #295

More screenshots (optional)

N/A

Checklist

I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.

I have filled in the related issue number when there is one.

I have tested my changes.

I have done a self-review of the code.