### PR TITLE
Feat: Add floating Back to Top button with smooth scroll

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -356,3 +356,21 @@ function handleGoogleSignIn() {
         }
     });
 }
+
+/* ── Back to Top Button ── */
+(function () {
+  var btn = document.getElementById("back-to-top");
+  if (!btn) return;
+
+  window.addEventListener("scroll", function () {
+    if (window.scrollY > 300) {
+      btn.classList.add("visible");
+    } else {
+      btn.classList.remove("visible");
+    }
+  });
+
+  btn.addEventListener("click", function () {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  });
+})();

--- a/auth.js
+++ b/auth.js
@@ -356,21 +356,3 @@ function handleGoogleSignIn() {
         }
     });
 }
-
-/* ── Back to Top Button ── */
-(function () {
-  var btn = document.getElementById("back-to-top");
-  if (!btn) return;
-
-  window.addEventListener("scroll", function () {
-    if (window.scrollY > 300) {
-      btn.classList.add("visible");
-    } else {
-      btn.classList.remove("visible");
-    }
-  });
-
-  btn.addEventListener("click", function () {
-    window.scrollTo({ top: 0, behavior: "smooth" });
-  });
-})();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -42,5 +42,11 @@
   <body class="bg-slate-900">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+
+     <!-- Back to Top Button -->
+    <button id="back-to-top" aria-label="Back to top" title="Back to top">
+      &#8679;
+    </button>
+    
   </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -48,5 +48,25 @@
       &#8679;
     </button>
     
+      <!-- Back to Top Logic -->
+  <script>
+    (function () {
+      var btn = document.getElementById("back-to-top");
+      if (!btn) return;
+
+      window.addEventListener("scroll", function () {
+        if (window.scrollY > 300) {
+          btn.classList.add("visible");
+        } else {
+          btn.classList.remove("visible");
+        }
+      });
+
+      btn.addEventListener("click", function () {
+        window.scrollTo({ top: 0, behavior: "smooth" });
+      });
+    })();
+  </script>
+  
   </body>
 </html>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -592,6 +592,44 @@ html.dark body {
   color: white;
 }
 
+/* ── Back to Top Button ── */
+#back-to-top {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  z-index: 9999;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: none;
+  background: linear-gradient(135deg, #3b82f6, #6366f1);
+  color: #ffffff;
+  font-size: 1.4rem;
+  line-height: 1;
+  cursor: pointer;
+  box-shadow: 0 4px 14px rgba(99, 102, 241, 0.45);
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(12px);
+  transition: opacity 0.3s ease, visibility 0.3s ease, transform 0.3s ease,
+    box-shadow 0.2s ease;
+}
+
+#back-to-top.visible {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+#back-to-top:hover {
+  box-shadow: 0 6px 20px rgba(99, 102, 241, 0.65);
+  transform: translateY(-2px);
+}
+
+#back-to-top:active {
+  transform: translateY(0) scale(0.95);
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1400,9 +1400,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [


### PR DESCRIPTION
## Before you open this PR

- **Issue:** None
- **Description:** Adds a floating "Back to Top" button that appears after scrolling 300px and smoothly scrolls the user back to the top on click.

## Screenshot (when helpful)


https://github.com/user-attachments/assets/c1526da0-e765-4965-bc57-e7475aef2d23



## What this PR does

Adds a fixed floating button in the bottom-right corner of the page. It stays hidden until the user scrolls past 300px, then fades in with a smooth transition. Clicking it scrolls the page back to the top using `scrollTo({ top: 0, behavior: 'smooth' })`. The button is implemented to work across all pages in the app.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

#343 

## More screenshots (optional)

<!-- Before: button hidden. After: button visible at bottom-right after scroll -->

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.