### PR TITLE
feat: add scroll to top and bottom FAB buttons (closes #354)

### DIFF
--- a/frontend/src/components/ScrollFAB.tsx
+++ b/frontend/src/components/ScrollFAB.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+import { ArrowUp, ArrowDown } from "lucide-react";
+
+const ScrollFAB = () => {
+  const [showTop, setShowTop] = useState(false);
+  const [showBottom, setShowBottom] = useState(true);
+
+  useEffect(() => {
+    const onScroll = () => {
+      const scrolled = window.scrollY;
+      const atBottom =
+        window.innerHeight + scrolled >= document.body.scrollHeight - 10;
+      setShowTop(scrolled > 300);
+      setShowBottom(!atBottom);
+    };
+    window.addEventListener("scroll", onScroll);
+    onScroll();
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  const scrollToTop = () => window.scrollTo({ top: 0, behavior: "smooth" });
+  const scrollToBottom = () =>
+    window.scrollTo({ top: document.body.scrollHeight, behavior: "smooth" });
+
+  return (
+    <div className="fixed bottom-6 right-6 flex flex-col gap-2 z-50">
+      {showTop && (
+        <button
+          onClick={scrollToTop}
+          aria-label="Scroll to top"
+          className="w-10 h-10 rounded-full bg-white border border-gray-200 shadow-md flex items-center justify-center text-gray-600 hover:bg-gray-50 hover:text-black transition-all duration-200"
+        >
+          <ArrowUp size={18} />
+        </button>
+      )}
+      {showBottom && (
+        <button
+          onClick={scrollToBottom}
+          aria-label="Scroll to bottom"
+          className="w-10 h-10 rounded-full bg-white border border-gray-200 shadow-md flex items-center justify-center text-gray-600 hover:bg-gray-50 hover:text-black transition-all duration-200"
+        >
+          <ArrowDown size={18} />
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default ScrollFAB;

--- a/frontend/src/components/layout/root_layout.component.tsx
+++ b/frontend/src/components/layout/root_layout.component.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from "react";
 import { useLocation } from "react-router-dom";
 import NavListComponent from "../hero/nav_list.component";
 import FooterComponent from "../footer/footer.component";
+import ScrollFAB from "../ScrollFAB";
 
 interface RootLayoutProps {
   children: ReactNode;
@@ -17,6 +18,7 @@ const RootLayout: React.FC<RootLayoutProps> = ({ children }) => {
       {!hideHeader && <NavListComponent />}
       <div className="flex-grow">{children}</div>
       {!hideFooter && <FooterComponent />}
+      <ScrollFAB />
     </div>
   );
 };


### PR DESCRIPTION
Closes #354

## Changes
- Created `ScrollFAB.tsx` component with floating action buttons
- Scroll to Top button appears after scrolling 300px down
- Scroll to Bottom button hides when page bottom is reached
- Smooth native scroll behavior on click
- Injected into `root_layout.component.tsx` so it works on all pages