### PR TITLE
feat: improve pagination UI/UX with per-page selector (closes #404)

### DIFF
--- a/frontend/src/components/pagination/pagination.component.tsx
+++ b/frontend/src/components/pagination/pagination.component.tsx
@@ -23,37 +23,24 @@ const PaginationComponent: React.FC<PaginationProps> = ({
     }
   };
 
-  const renderPageNumbers = () => {
-    const pages = [];
-    const maxVisiblePages = 5;
+  const handlePageSizeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    onChange(1, Number(e.target.value));
+  };
 
-    if (totalPages <= maxVisiblePages) {
-      for (let i = 1; i <= totalPages; i++) {
-        pages.push(i);
-      }
+  const renderPageNumbers = () => {
+    const pages: (number | string)[] = [];
+
+    if (totalPages <= 5) {
+      for (let i = 1; i <= totalPages; i++) pages.push(i);
     } else {
       pages.push(1);
-
       let start = Math.max(2, current - 1);
       let end = Math.min(totalPages - 1, current + 1);
-
-      if (current <= 3) {
-        end = 4;
-      } else if (current >= totalPages - 2) {
-        start = totalPages - 3;
-      }
-
-      if (start > 2) {
-        pages.push("...");
-      }
-
-      for (let i = start; i <= end; i++) {
-        pages.push(i);
-      }
-
-      if (end < totalPages - 1) {
-        pages.push("...");
-      }
+      if (current <= 3) end = 4;
+      else if (current >= totalPages - 2) start = totalPages - 3;
+      if (start > 2) pages.push("...");
+      for (let i = start; i <= end; i++) pages.push(i);
+      if (end < totalPages - 1) pages.push("...");
       pages.push(totalPages);
     }
 
@@ -62,21 +49,21 @@ const PaginationComponent: React.FC<PaginationProps> = ({
         return (
           <span
             key={`ellipsis-${index}`}
-            className="relative inline-flex items-center px-3 py-2 text-sm font-medium text-slate-500"
+            className="inline-flex items-center px-2 py-1 text-sm text-slate-500 select-none"
           >
-            ...
+            …
           </span>
         );
       }
-
+      const isActive = current === pageNum;
       return (
         <button
           key={pageNum}
           onClick={() => handlePageChange(pageNum as number)}
-          className={`!rounded-button relative inline-flex items-center px-3 py-1 border text-sm font-medium transition-colors ${
-            current === pageNum
-              ? "border-blue-500 bg-blue-600 text-white shadow-md"
-              : "border-slate-700 bg-slate-800 text-slate-300 hover:bg-slate-700 hover:text-white"
+          className={`inline-flex items-center justify-center w-8 h-8 rounded-md text-sm font-medium transition-colors ${
+            isActive
+              ? "bg-blue-600 text-white shadow-sm"
+              : "bg-slate-800 text-slate-300 border border-slate-700 hover:bg-slate-700 hover:text-white"
           }`}
         >
           {pageNum}
@@ -86,34 +73,49 @@ const PaginationComponent: React.FC<PaginationProps> = ({
   };
 
   return (
-    <div>
-      <div className="flex items-center justify-between">
-        <div className="flex-1 text-sm text-slate-400">
-          Showing <span className="font-medium">{startItem}</span> to
-          <span className="font-medium"> {endItem}</span> of
-          <span className="font-medium"> {total}</span> results
+    <div className="flex flex-col sm:flex-row items-center justify-between gap-3 px-1 py-2">
+      <div className="flex items-center gap-2 text-sm text-slate-400">
+        <span>
+          Showing{" "}
+          <span className="font-medium text-slate-200">{startItem}</span> –{" "}
+          <span className="font-medium text-slate-200">{endItem}</span> of{" "}
+          <span className="font-medium text-slate-200">{total}</span> results
+        </span>
+        <select
+          value={pageSize}
+          onChange={handlePageSizeChange}
+          className="ml-2 bg-slate-800 border border-slate-700 text-slate-300 text-sm rounded-md px-2 py-1 focus:outline-none focus:ring-1 focus:ring-blue-500 cursor-pointer"
+        >
+          {[10, 25, 50, 100].map((size) => (
+            <option key={size} value={size}>
+              {size} / page
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="flex items-center gap-1">
+        <button
+          onClick={() => handlePageChange(current - 1)}
+          disabled={current === 1}
+          className="inline-flex items-center gap-1 px-3 h-8 rounded-md border border-slate-700 bg-slate-800 text-sm text-slate-300 hover:bg-slate-700 hover:text-white transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-slate-800 disabled:hover:text-slate-300"
+        >
+          <i className="fas fa-chevron-left text-xs opacity-70"></i>
+          Prev
+        </button>
+
+        <div className="flex items-center gap-1">
+          {renderPageNumbers()}
         </div>
-        <div className="flex items-center space-x-2">
-          <button
-            className="!rounded-button inline-flex items-center px-3 py-1 border border-slate-700 bg-slate-800 text-sm font-medium text-slate-300 hover:bg-slate-700 hover:text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-slate-800 disabled:hover:text-slate-300"
-            disabled={current === 1}
-            onClick={() => handlePageChange(current - 1)}
-          >
-            <i className="fas fa-chevron-left text-xs mr-2 opacity-70"></i>
-            Previous
-          </button>
-          <span className="relative z-0 inline-flex space-x-1">
-            {renderPageNumbers()}
-          </span>
-          <button
-            className="!rounded-button inline-flex items-center px-3 py-1 border border-slate-700 bg-slate-800 text-sm font-medium text-slate-300 hover:bg-slate-700 hover:text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-slate-800 disabled:hover:text-slate-300"
-            disabled={current === totalPages}
-            onClick={() => handlePageChange(current + 1)}
-          >
-            Next
-            <i className="fas fa-chevron-right text-xs ml-2 opacity-70"></i>
-          </button>
-        </div>
+
+        <button
+          onClick={() => handlePageChange(current + 1)}
+          disabled={current === totalPages}
+          className="inline-flex items-center gap-1 px-3 h-8 rounded-md border border-slate-700 bg-slate-800 text-sm text-slate-300 hover:bg-slate-700 hover:text-white transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-slate-800 disabled:hover:text-slate-300"
+        >
+          Next
+          <i className="fas fa-chevron-right text-xs opacity-70"></i>
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #404

## What this PR does
Improves the pagination component UI/UX as requested in issue #404.

## Changes
- Added items-per-page dropdown (10, 25, 50, 100 per page)
- Resets to page 1 when page size changes
- Cleaner page number buttons with fixed 32px width
- Improved spacing and typography for result count text
- Prev/Next buttons are more compact and consistent

## Note
Pagination is only visible to authenticated users so no live screenshot available. The dropdown options (10, 25, 50, 100) match the reference screenshot provided in the issue.