### PR TITLE
fix: prevent password re-hashing in user pre-save hook

### DIFF
--- a/backend/src/app/modules/user/user.model.ts
+++ b/backend/src/app/modules/user/user.model.ts
@@ -62,8 +62,8 @@ export const UserSchema: Schema<IUser> = new Schema<IUser, UserModel>(
 UserSchema.pre("save", async function (next) {
   const user = this;
   if (!user.isModified("password")) {
-  return next();
-}
+    return next();
+  }
   
   // Only hash password if it exists and is not empty (for password-based auth)
   // Skip for Google OAuth users who don't have passwords

--- a/backend/src/app/modules/user/user.model.ts
+++ b/backend/src/app/modules/user/user.model.ts
@@ -61,6 +61,9 @@ export const UserSchema: Schema<IUser> = new Schema<IUser, UserModel>(
 
 UserSchema.pre("save", async function (next) {
   const user = this;
+  if (!user.isModified("password")) {
+  return next();
+}
   
   // Only hash password if it exists and is not empty (for password-based auth)
   // Skip for Google OAuth users who don't have passwords


### PR DESCRIPTION
## Description

This PR fixes a security and performance issue in the User model pre-save hook where passwords were being re-hashed on every `save()` operation, even when the password field was not modified.

### Changes made

* Added `user.isModified("password")` check before hashing
* Prevented already-hashed passwords from being hashed again
* Preserved existing password hashes during unrelated profile updates

### Impact

* Fixes potential login failures caused by hash-of-hash passwords
* Reduces unnecessary bcrypt operations
* Improves authentication stability

Fixes #454
