### PR TITLE
fix: resolve genre filtering inconsistency in story inspiration search

### DIFF
--- a/frontend/src/components/story-inspiration/story_inspiration.component.tsx
+++ b/frontend/src/components/story-inspiration/story_inspiration.component.tsx
@@ -20,8 +20,8 @@ const StoryInspirationComponent: React.FC = () => {
       story.title.toLowerCase().includes(searchLower) ||
       story.author.toLowerCase().includes(searchLower) ||
       story.summary.toLowerCase().includes(searchLower) ||
+      story.genre.toLowerCase().includes(searchLower) ||
       story.themes.some((theme) => theme.toLowerCase().includes(searchLower));
-
     return matchesGenre && matchesSearch;
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -770,7 +770,6 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1215,7 +1214,6 @@
     "node_modules/@fortawesome/fontawesome-svg-core": {
       "version": "6.7.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.7.2"
       },
@@ -1652,7 +1650,6 @@
       "version": "5.0.6",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -1705,7 +1702,6 @@
     "node_modules/@types/node": {
       "version": "22.19.19",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1754,7 +1750,6 @@
       "version": "19.2.14",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1872,7 +1867,6 @@
       "version": "8.59.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
@@ -2145,7 +2139,6 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2504,7 +2497,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2670,7 +2662,6 @@
     "node_modules/chart.js": {
       "version": "4.5.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -3047,8 +3038,7 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cycle": {
       "version": "1.0.3",
@@ -3397,7 +3387,6 @@
       "version": "9.39.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5618,7 +5607,6 @@
     "node_modules/react": {
       "version": "19.2.6",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5634,7 +5622,6 @@
     "node_modules/react-dom": {
       "version": "19.2.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5685,7 +5672,6 @@
     "node_modules/react-redux": {
       "version": "9.3.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -5775,8 +5761,7 @@
     },
     "node_modules/redux": {
       "version": "5.0.1",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -6472,7 +6457,6 @@
     "node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.4",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6693,7 +6677,6 @@
       "version": "5.7.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6851,7 +6834,6 @@
     "node_modules/vite": {
       "version": "6.4.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -6939,7 +6921,6 @@
     "node_modules/vite/node_modules/picomatch": {
       "version": "4.0.4",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7160,7 +7141,6 @@
     "node_modules/zod": {
       "version": "3.25.76",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
**Description**

Fixed an inconsistency in the Story Inspiration search functionality where searching for genre names like "Mystery" under the "All" category returned no results even though matching stories existed.

 **Changes Made**

* Added `story.genre` to the search filtering logic
* Improved consistency between genre tags and search behavior
* Ensured genre-based searches now correctly display matching stories

 **Testing**

* Verified genre tag filtering works correctly
* Verified searching genre names now returns expected results
* Tested reset filters functionality

Fixes #174
