### PR TITLE
perf: remove unnecessary await from synchronous JwtHalers.verifyToken calls (closes #431)

### DIFF
--- a/backend/src/app/middleware/auth.middleware.ts
+++ b/backend/src/app/middleware/auth.middleware.ts
@@ -18,7 +18,7 @@ const auth =
       }
 
       // verify token
-      const verifiedUser = await JwtHalers.verifyToken(
+      const verifiedUser = JwtHalers.verifyToken(
         token,
         config.jwt.secret as Secret
       );

--- a/backend/src/app/middleware/check.request.limit.ts
+++ b/backend/src/app/middleware/check.request.limit.ts
@@ -17,7 +17,7 @@ const checkRequestLimit =
           "You are not authorized to access"
         );
       }
-      const verifiedUser = await JwtHalers.verifyToken(
+      const verifiedUser = JwtHalers.verifyToken(
         token,
         config.jwt.secret as Secret
       );

--- a/backend/src/app/middleware/token.ts
+++ b/backend/src/app/middleware/token.ts
@@ -15,7 +15,7 @@ export const getToken = async (req: Request): Promise<ITokenPayload> => {
     );
   }
   try {
-    const verifiedUser = await JwtHalers.verifyToken(
+    const verifiedUser = JwtHalers.verifyToken(
       token,
       config.jwt.secret as Secret
     );

--- a/backend/src/app/middleware/token.ts
+++ b/backend/src/app/middleware/token.ts
@@ -6,7 +6,7 @@ import config from "../../config";
 import { Secret } from "jsonwebtoken";
 import { ITokenPayload } from "../../interfaces/token";
 
-export const getToken = async (req: Request): Promise<ITokenPayload> => {
+export const getToken = (req: Request): ITokenPayload => {
   const token = req.headers.authorization as string;
   if (!token) {
     throw new ApiError(


### PR DESCRIPTION
## What this PR does:
JwtHalers.verifyToken calls jwt.verify synchronously and 
returns a JwtPayload directly — not a Promise. Using await 
on it is redundant and introduces unnecessary microtask 
overhead. Additionally, wrapping synchronous throws in 
await slightly changes the stack trace and execution flow.

Removed unnecessary await from 3 files:
- backend/src/app/middleware/auth.middleware.ts
- backend/src/app/middleware/check.request.limit.ts
- backend/src/app/middleware/token.ts

## Type of change:

✅ Bug fix

## Related issue:
Closes #431

## Screenshot:
N/A : backend performance fix, no UI changes.

## Checklist:

✅ N/A — no UI changes needed for screenshots
✅ Related issue: Closes #431
✅ Tested by verifying all 3 files compile correctly
✅ Self-reviewed the code changes