### PR TITLE
fix: resolve search bar visibility issue in light mode

### DIFF
--- a/frontend/src/components/help_center/help_search_bar/help_search_bar.component.tsx
+++ b/frontend/src/components/help_center/help_search_bar/help_search_bar.component.tsx
@@ -24,7 +24,7 @@ const HelpSearchBar: FC<HelpSearchBarProps> = ({
       </label>
       <div className="relative before:absolute before:inset-0 before:-z-10 before:bg-gradient-to-r before:from-purple-500/20 before:via-indigo-500/20 before:to-blue-500/20 before:blur-xl before:rounded-2xl">
         <div className="absolute inset-y-0 left-0 pl-5 flex items-center pointer-events-none">
-          <i className="fas fa-search text-gray-400" aria-hidden="true"></i>
+          <i className="fas fa-search text-gray-400 dark:text-gray-400" aria-hidden="true"></i>
         </div>
         <input
           id="help-search"
@@ -32,14 +32,14 @@ const HelpSearchBar: FC<HelpSearchBarProps> = ({
           value={value}
           onChange={(e) => onChange(e.target.value)}
           placeholder={placeholder}
-          className="w-full bg-white/5 backdrop-blur-sm border border-white/20 rounded-2xl py-4 pl-12 pr-12 text-gray-200 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500/50 transition-all duration-300"
+          className="w-full bg-white border border-gray-300 text-gray-800 placeholder-gray-400 dark:bg-white/5 dark:backdrop-blur-sm dark:border-white/20 dark:text-gray-200 dark:placeholder-gray-500 rounded-2xl py-4 pl-12 pr-12 focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500/50 transition-all duration-300"
           autoComplete="off"
         />
         {value && (
           <button
             type="button"
             onClick={() => onChange("")}
-            className="absolute inset-y-0 right-0 pr-5 flex items-center text-gray-400 hover:text-white transition-colors"
+            className="absolute inset-y-0 right-0 pr-5 flex items-center text-gray-400 hover:text-gray-700 dark:hover:text-white transition-colors"
             aria-label="Clear search"
           >
             <i className="fas fa-times" aria-hidden="true"></i>
@@ -47,7 +47,7 @@ const HelpSearchBar: FC<HelpSearchBarProps> = ({
         )}
       </div>
       {value && resultCount !== undefined && (
-        <p className="mt-3 text-sm text-gray-500 text-center" aria-live="polite">
+        <p className="mt-3 text-sm text-gray-500 dark:text-gray-500 text-center" aria-live="polite">
           {resultCount === 0
             ? "No results found — try different keywords"
             : `${resultCount} result${resultCount === 1 ? "" : "s"} found`}


### PR DESCRIPTION
## Screenshot (when helpful)

<img width="1908" height="531" alt="image" src="https://github.com/user-attachments/assets/4f4baef4-90c2-4eeb-9ce1-fd720ce19f17" />



## What this PR does

Fixed the search bar visibility issue in light mode where the search text/input was not visible.

Changes made:
- Updated styling for better visibility in light mode
- Kept dark mode behavior unchanged
- Verified the search bar works correctly in both themes


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update


## Related issue

Fixes #522 


## More screenshots (optional)

Before:
<img width="1919" height="534" alt="Screenshot 2026-05-26 135236" src="https://github.com/user-attachments/assets/d66462a8-9d7e-4446-ba51-6b70cf93a7bb" />



After:
<img width="1908" height="531" alt="image" src="https://github.com/user-attachments/assets/f58195fe-fda6-4666-8c22-4bb376dd6372" />



## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.