### PR TITLE
fix: add missing env example and correct dashboard role access

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,30 @@
+# Server
+NODE_ENV=development
+PORT=5000
+CORS_ORIGINS=http://localhost:4001
+
+# Database
+DATABASE_URL=mongodb://127.0.0.1:27017/story_spark_ai
+
+# Authentication
+SALT_ROUNDS=10
+JWT_SECRET=replace_with_access_token_secret
+JWT_REFRESH_SECRET=replace_with_refresh_token_secret
+JWT_EXPIRES_IN=60d
+JWT_REFRESH_EXPIRES_IN=120d
+DEFAULT_ADMIN_PASSWORD=replace_with_default_admin_password
+
+# AI providers
+OPEN_AI_KEY=
+GEMINI_API_KEY=
+
+# Image provider
+UNSPLASH_KEY_API=
+UNSPLASH_KEY_API_SECRET=
+
+# Email verification
+VERIFY_EMAIL=
+VERIFY_PASSWORD=
+
+# Google OAuth
+GOOGLE_CLIENT_ID=

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -124,7 +124,12 @@ function App() {
           element={
             <ProtectedRoute
               element={<DashboardLayout />}
-              allowedRoles={[USER_ROLE.ADMIN]}
+              allowedRoles={[
+                USER_ROLE.USER,
+                USER_ROLE.ADMIN,
+                USER_ROLE.SUPER_ADMIN,
+                USER_ROLE.WRITER,
+              ]}
             />
           }
         >


### PR DESCRIPTION
## What this PR does

This PR fixes two issues related to project setup and dashboard route authorization.

### Changes included

#### 1. Added missing `backend/.env.example`
The README references `backend/.env.example` during setup, but the file was missing from the repository.

This PR adds the missing file with placeholder environment variables to improve onboarding and local development setup.

---

#### 2. Fixed dashboard role protection mismatch
The `/dashboard` route in `frontend/src/App.tsx` was protected using only `USER_ROLE.ADMIN`.

However, nested dashboard routes already support:
- `USER`
- `WRITER`
- `SUPER_ADMIN`

Because of the parent-level restriction, valid users were blocked before child routes could load.

This PR updates the dashboard route protection to allow all intended roles.

---

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

---

## Issue #535 

Fixes: missing `.env.example` file and dashboard role access mismatch


## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
```
