### PR TITLE
fix: correct font fallback from serif to sans-serif for Roboto Condensed

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -536,7 +536,7 @@
 
 :root {
   --header-height: 82px;
-  font-family: "Roboto Condensed", serif;
+  font-family: "Roboto Condensed", sans-serif;
   font-optical-sizing: auto;
   font-style: normal;
   font-synthesis: none;


### PR DESCRIPTION
## 📌 Related Issue
Closes #571 

## 🐛 What was the bug?
In `frontend/src/index.css`, the `font-family` declaration in the `:root` block used `serif` as the fallback font for `Roboto Condensed`. Since Roboto Condensed is a sans-serif typeface, this is incorrect.

## ✅ What was fixed?
Changed the fallback font from `serif` to `sans-serif`.

## 🔴 Before
```css
font-family: "Roboto Condensed", serif;
```

## ✅ After
```css
font-family: "Roboto Condensed", sans-serif;
```

## 🧪 Testing Done
- Ran `npm run dev` locally
- Verified site loads correctly at `http://localhost:4001`
- Confirmed no console errors
- Checked font renders correctly in browser