### PR TITLE
fix: Use toast notifications for review approval

### DIFF
--- a/frontend/src/components/admin/review_approval.component.tsx
+++ b/frontend/src/components/admin/review_approval.component.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import toast, { Toaster } from "react-hot-toast";
 
 import {
   useApproveReviewMutation,
@@ -10,14 +11,16 @@ const ReviewApprovalComponent = () => {
   const { data: reviews = [], isLoading } =
     useGetPendingReviewsQuery({});
 
-  const [approveReview] = useApproveReviewMutation();
+  const [approveReview, { isLoading: isApproving }] =
+    useApproveReviewMutation();
 
   const handleApprove = async (id: string) => {
     try {
-      await approveReview(id);
+      await approveReview(id).unwrap();
 
-      alert("Review approved successfully!");
+      toast.success("Review approved successfully!");
     } catch (error) {
+      toast.error("Failed to approve review. Please try again.");
       console.error(error);
     }
   };
@@ -32,6 +35,8 @@ const ReviewApprovalComponent = () => {
 
   return (
     <div className="max-w-6xl mx-auto py-10 px-4">
+      <Toaster position="top-right" reverseOrder={false} />
+
       <h2 className="text-3xl font-bold mb-8 text-center">
         Pending Reviews
       </h2>
@@ -66,6 +71,7 @@ const ReviewApprovalComponent = () => {
 
             <button
               onClick={() => handleApprove(review._id)}
+              disabled={isApproving}
               className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700"
             >
               Approve


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Open or link a related issue when there is one (`Closes #123`, `Fixes #45`, or write **None** under Related issue below).
- **Description:** Fill in **What this PR does** so a reviewer can understand the change without your local context.
- **Screenshots:**Before: Native browser alert() blocking the UI on approval success.
After: Non-blocking toast notification appearing in the corner — success in green, error in red.

## Screenshot (when helpful)

<!-- Drag & drop or paste. For non-UI work, you can use tests output, logs, or API responses. Write “N/A” in the checklist if you skip this section. -->



## What this PR does
The admin review approval flow was using a native browser alert() to confirm successful approvals. This blocked the UI, required manual dismissal, and gave no feedback when approval failed.
This PR replaces that alert() with react-hot-toast success and error toasts, switches the mutation call to unwrap() so try/catch handles both outcomes cleanly, and disables the approve button while the mutation is in progress to prevent duplicate submissions.




## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [X] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue
Fixes #569 



## More screenshots (optional)

<!-- Extra before/after images, flows, or recordings for reviewers. -->



## Checklist

- [X] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [X] I have filled in the related issue number when there is one.
- [X] I have tested my changes.
- [X] I have done a self-review of the code.
