### PR TITLE
fix: hide magic cursor sparkle and glow for prefers-reduced-motion users

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -715,4 +715,9 @@ html.dark .scroll-fab-btn:active {
   .magic-cursor-sparkle {
     transform: none;
   }
+  .magic-cursor-sparkle,
+  .magic-cursor-dot,
+  .magic-cursor-glow {
+    display: none;
+  }
 }


### PR DESCRIPTION
## 📌 Related Issue
Closes #574 

## 🐛 What was the bug?
In `frontend/src/index.css`, the `prefers-reduced-motion` media block only 
reset `transform: none` for the magic cursor elements but did not hide them. 
Users with motion sensitivity could still see the animated sparkle and glow 
cursor effects, which can cause discomfort for users with vestibular disorders.

## ✅ What was fixed?
Added `display: none` for `.magic-cursor-sparkle`, `.magic-cursor-dot`, 
and `.magic-cursor-glow` inside the `prefers-reduced-motion` block.

## 🔴 Before
```css
@media (prefers-reduced-motion: reduce) {
  .magic-cursor-dot,
  .magic-cursor-glow,
  .magic-cursor-sparkle {
    transform: none;
  }
}
```

## ✅ After
```css
@media (prefers-reduced-motion: reduce) {
  .magic-cursor-sparkle,
  .magic-cursor-dot,
  .magic-cursor-glow {
    display: none;
  }
}
```

## 🧪 Testing Done
- Ran `npm run dev` locally
- Verified site loads correctly at `http://localhost:4001`
- Tested using DevTools → Rendering → prefers-reduced-motion: reduce
- Confirmed cursor sparkle and glow effects are hidden
- No console errors