### PR TITLE
fix: add Firefox scrollbar support using scrollbar-width and scrollba…

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -552,6 +552,12 @@ body {
   scroll-behavior: smooth;
 }
 
+/* Firefox scrollbar support */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: #646c727e #6a78842c;
+}
+
 ::-webkit-scrollbar-thumb {
   background: #646c727e;
 }


### PR DESCRIPTION
## 📌 Related Issue
Closes #576 

## 🐛 What was the bug?
In `frontend/src/index.css`, custom scrollbar styles only used 
`::-webkit-scrollbar-*` properties which are Chrome/Edge specific.
Firefox users saw the default unstyled browser scrollbar, breaking 
the consistent visual design of the application.

## ✅ What was fixed?
Added Firefox standard `scrollbar-width` and `scrollbar-color` properties
using the same color values as the existing webkit scrollbar styles.

## 🔴 Before
```css
/* No Firefox scrollbar support */
::-webkit-scrollbar-thumb {
  background: #646c727e;
}
::-webkit-scrollbar {
  height: 8px;
  width: 8px;
}
::-webkit-scrollbar-track {
  background: #6a78842c;
}
```

## ✅ After
```css
/* Firefox scrollbar support */
* {
  scrollbar-width: thin;
  scrollbar-color: #646c727e #6a78842c;
}

::-webkit-scrollbar-thumb {
  background: #646c727e;
}
::-webkit-scrollbar {
  height: 8px;
  width: 8px;
}
::-webkit-scrollbar-track {
  background: #6a78842c;
}
```

## 🧪 Testing Done
- Ran `npm run dev` locally
- Verified site loads correctly at `http://localhost:4001`
- Tested in Firefox — custom scrollbar now renders correctly
- Tested in Chrome — existing scrollbar styles still work
- No console errors