### PR TITLE
fix: apply box-sizing to all elements

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -545,10 +545,15 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
   padding: 0;
-  box-sizing: border-box;
   scroll-behavior: smooth;
 }
 


### PR DESCRIPTION
📌 Related Issue
Closes #580 

🐛 What was the bug?
In frontend/src/index.css, the box-sizing property was applied only to the body element. This caused inconsistent sizing behavior across different elements since other elements were still using the default content-box model.

✅ What was fixed?
Moved box-sizing: border-box from the body element to a global selector so it applies to all elements and pseudo-elements.

🔴 Before

body {
  margin: 0;
  padding: 0;
  box-sizing: border-box;
  scroll-behavior: smooth;
}

✅ After

*,
*::before,
*::after {
  box-sizing: border-box;
}

body {
  margin: 0;
  padding: 0;
  scroll-behavior: smooth;
}

🧪 Testing Done
Ran npm run dev locally
Verified layouts and component sizing behave correctly across the application
Confirmed no visual regressions in UI
Checked spacing and overflow behavior in multiple components