### PR TITLE
Feat: Add copy-link share button to featured post cards

### DIFF
--- a/frontend/src/components/home/feature/feature.component.tsx
+++ b/frontend/src/components/home/feature/feature.component.tsx
@@ -5,13 +5,15 @@ import LoadingAnimation from "../../loading/loading.component";
 import SSProfile from "../../ui-component/ss-profile/ss-profile";
 import { useNavigate } from "react-router-dom";
 import BookmarkButton from "../../BookmarkButton";
+import React, { useState } from "react";
 
-import { FaLinkedin, FaEnvelope } from "react-icons/fa";
+import { FaLinkedin, FaEnvelope, FaTwitter, FaLink } from "react-icons/fa";
 import { FaXTwitter } from "react-icons/fa6";
 
 const FeatureComponent = () => {
   const { data, isLoading } = useGetFeaturedListsQuery(undefined);
   const navigate = useNavigate();
+  const [copiedId, setCopiedId] = useState<string | null>(null);
 
   // Dynamic reading calculation logic
   const calculateReadingTime = (content: string): number => {
@@ -20,6 +22,14 @@ const FeatureComponent = () => {
     const words = content.trim().split(/\s+/).length;
 
     return Math.max(1, Math.ceil(words / 200));
+  };
+
+  const handleCopyLink = (e: React.MouseEvent, postId: string, postUrl: string) => {
+  e.stopPropagation();
+  navigator.clipboard.writeText(postUrl).then(() => {
+    setCopiedId(postId);
+    setTimeout(() => setCopiedId(null), 2000);
+    });
   };
 
   if (isLoading) {
@@ -157,6 +167,19 @@ const FeatureComponent = () => {
                       >
                         <FaEnvelope size={16} />
                       </a>
+                      <button
+                          onClick={(e) => handleCopyLink(e, post._id, postUrl)}
+                          title={copiedId === post._id ? "Link copied!" : "Copy link"}
+                          aria-label="Copy post link"
+                          className={`transition-colors duration-200 ${
+                            copiedId === post._id
+                              ? "text-green-400"
+                              : "hover:text-blue-400"
+                          }`}
+
+                        >
+                          <FaLink size={16} />
+                        </button>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Before you open this PR

## Screenshot (when helpful)

Before:
<img width="1919" height="876" alt="image" src="https://github.com/user-attachments/assets/c703b527-fcee-45ae-ad61-5acb206c3ef6" />


After:
<img width="1902" height="876" alt="image" src="https://github.com/user-attachments/assets/267682df-2fa0-4922-b807-f16f8fdc7a20" />


Before (3 share icons):
[Twitter] [LinkedIn] [Email]

After (4 share icons, green state on copy):
[Twitter] [LinkedIn] [Email] [🔗 → turns green on click]

## What this PR does

Adds a "Copy Link" clipboard button to the share icons row on Featured Post cards
(`feature.component.tsx`). Uses `navigator.clipboard.writeText` — no new dependencies.

The button shows a `FaLink` icon from react-icons (already installed). On click it:
1. Stops the card's click-to-navigate from firing (`e.stopPropagation`)
2. Writes the post URL to the clipboard
3. Turns the icon green for 2 seconds via a `copiedId` state, then resets

## Type of change

- [x] New feature

## Related issue

Closes #570 

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR
- [x] I have filled in the related issue number when there is one
- [x] I have tested my changes
- [x] I have done a self-review of the code