### PR TITLE
fix: protect GET /api/users/lists with admin auth middleware

### DIFF
--- a/backend/src/app/modules/user/user.router.ts
+++ b/backend/src/app/modules/user/user.router.ts
@@ -6,7 +6,7 @@ import { ENUM_USER_ROLE } from "../../../enums/user";
 const router = express.Router();
 
 // User List
-router.get("/lists", UserController.getAllUsers);
+router.get("/lists", auth(ENUM_USER_ROLE.ADMIN, ENUM_USER_ROLE.SUPER_ADMIN), UserController.getAllUsers);
 
 // Profile
 router.get("/profile", UserController.getProfileInfo);


### PR DESCRIPTION
## Screenshot (when helpful)
N/A — backend route change, no UI impact.

## What this PR does
The `GET /api/users/lists` endpoint had no authentication middleware, allowing any unauthenticated request to retrieve the full user database including emails, roles, and subscription data. This adds `auth(ADMIN, SUPER_ADMIN)` to the route, consistent with how `deleteUser` and `approveWriterApplication` are already protected in the same file.

## Type of change
- [x] Bug fix

## Related issue
Closes #613 

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.