### PR TITLE
UI Enhancement: Center align navigation links in the main Navbar

### DIFF
--- a/frontend/src/components/hero/nav_list.component.tsx
+++ b/frontend/src/components/hero/nav_list.component.tsx
@@ -66,13 +66,17 @@ const NavListComponent: React.FC = () => {
   return (
     <header className="sticky top-0 z-50 w-full bg-white/90 dark:bg-[#0B1120]/80 backdrop-blur-md border-b border-slate-200/70 dark:border-white/10 transition-colors duration-300">
       <div className="relative z-10 mx-auto max-w-8xl px-5 py-4">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center space-x-8">
+        <div className="flex items-center justify-between w-full">
+          {/* Logo */}
+          <div className="flex items-center shrink-0">
             <Link to="/">
               <img src={logo} alt="logo" className="h-10 w-auto object-contain" />
             </Link>
-            <div className="hidden md:flex items-center space-x-4">
-              <NavLink to="/" end className={({ isActive }) => getLinkClass(isActive)}>
+          </div>
+
+          {/* Navigation Links */}
+          <div className="hidden lg:flex flex-1 items-center justify-center space-x-1.5 xl:space-x-3 px-4">
+            <NavLink to="/" end className={({ isActive }) => getLinkClass(isActive)}>
                 {({ isActive }) => (
                   <>
                     {isActive && (
@@ -166,10 +170,10 @@ const NavListComponent: React.FC = () => {
                   </NavLink>
                 </>
               )}
-            </div>
           </div>
 
-          <div className="flex items-center gap-3">
+          {/* Actions */}
+          <div className="flex items-center shrink-0 gap-3">
             <div className="hidden md:flex items-center gap-3">
               <button
                 type="button"


### PR DESCRIPTION
### What would you like to improve?
Currently, the navigation links in the navbar (`HOME`, `EXPLORE`, `ANALYTICS`, etc.) are grouped together with the logo on the far left side of the header. On wider screens, this leaves a large empty space in the middle of the screen, making the UI look slightly unbalanced.

The navigation menu has been centered in the header, placed evenly between the logo on the left and the action buttons (Search, Theme, Profile/Login) on the right. This was achieved by separating the flex container into three distinct sections (left, center, right) and using `flex-1` with `justify-center` for the middle navigation container.

### Why does this matter?
- **Who benefits:** All users visiting the website on desktop and tablet screens.
- **Pain points:** The previous layout pushed everything to the left and right edges, which reduced readability. Centering the navigation creates a much more balanced, modern, and aesthetically pleasing UI design.

Fixes #618

<img width="1897" height="676" alt="image" src="https://github.com/user-attachments/assets/16eb386e-c2f1-4b90-a049-d6f13db4b37d" />

