### PR TITLE
fix: add missing VITE_GOOGLE_CLIENT_ID, emailjs keys, and DEV to ImportMetaEnv (#545)

### DIFF
--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -3,6 +3,11 @@
 interface ImportMetaEnv {
   readonly VITE_BASE_URL?: string;
   readonly VITE_SOCKET_URL?: string;
+  readonly VITE_GOOGLE_CLIENT_ID?: string;
+  readonly VITE_SERVICE_KEY?: string;
+  readonly VITE_TEMPLATE_KEY?: string;
+  readonly VITE_PUBLIC_KEY?: string;
+  readonly DEV: boolean;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
Fixes #545 — TypeScript was throwing `TS2339: Property does not exist on type 'ImportMetaEnv'` errors because several environment variables used across the codebase were not declared in `vite-env.d.ts`.

## Root Cause
The `ImportMetaEnv` interface in `frontend/src/vite-env.d.ts` only declared `VITE_BASE_URL` and `VITE_SOCKET_URL`, but the following were also actively used:

| Variable | Used In |
|---|---|
| `VITE_GOOGLE_CLIENT_ID` | `main.tsx` |
| `DEV` | `helpers/config.ts` |
| `VITE_SERVICE_KEY` | `components/contactus/contactus.tsx` |
| `VITE_TEMPLATE_KEY` | `components/contactus/contactus.tsx` |
| `VITE_PUBLIC_KEY` | `components/contactus/contactus.tsx` |

## Changes Made

### `frontend/src/vite-env.d.ts`
- Added `VITE_GOOGLE_CLIENT_ID?: string` (Google OAuth)
- Added `DEV: boolean` (built-in Vite boolean, used to suppress config warnings in dev mode)
- Added `VITE_SERVICE_KEY`, `VITE_TEMPLATE_KEY`, `VITE_PUBLIC_KEY` (EmailJS keys used in contact form)

## Screenshot:
NA

## Verification
- `tsc --noEmit` passes without `TS2339` errors on the affected files
- All environment variable accesses are now properly typed

## Related Issue
Closes #545

---
*Contributing under GSSoC'26*