### PR TITLE
feat: add abuse reporting mechanism for posts and comments

### DIFF
--- a/.postman/resources.yaml
+++ b/.postman/resources.yaml
@@ -1,0 +1,9 @@
+# Use this workspace to collaborate
+workspace:
+  id: 5a960c38-c291-4e27-8cd3-b7c657dde558
+
+# All resources in the `postman/` folder are automatically registered in Local View.
+# Point to additional files outside the `postman/` folder to register them individually. Example:
+#localResources:
+#  collections:
+#    - ../tests/E2E Test Collection/

--- a/backend/src/app/modules/report/report.controller.ts
+++ b/backend/src/app/modules/report/report.controller.ts
@@ -1,0 +1,19 @@
+import { Request, Response } from "express";
+import catchAsync from "../../../shared/catch_async";
+import sendResponse from "../../../shared/send_response";
+import { ReportService } from "./report.service";
+import { ReportTargetType } from "../../../enums/report.enum";
+
+const createReport = catchAsync(async (req: Request, res: Response) => {
+  const reportedBy = req.user?.userId;
+  const payload = { ...req.body, reportedBy };
+  const result = await ReportService.createReport(payload);
+  sendResponse(res, {
+    statusCode: 201,
+    success: true,
+    message: "Report submitted successfully",
+    data: result,
+  });
+});
+
+export const ReportController = { createReport };

--- a/backend/src/app/modules/report/report.interface.ts
+++ b/backend/src/app/modules/report/report.interface.ts
@@ -1,0 +1,12 @@
+import { ReportReason, ReportStatus, ReportTargetType } from "../../../enums/report.enum";
+import { Types } from "mongoose";
+
+export interface IReport {
+  reportedBy: Types.ObjectId;
+  targetId: Types.ObjectId;
+  targetType: ReportTargetType;
+  reason: ReportReason;
+  description?: string;
+  status: ReportStatus;
+  createdAt?: Date;
+}

--- a/backend/src/app/modules/report/report.model.ts
+++ b/backend/src/app/modules/report/report.model.ts
@@ -1,0 +1,17 @@
+import mongoose, { Schema } from "mongoose";
+import { IReport } from "./report.interface";
+import { ReportReason, ReportStatus, ReportTargetType } from "../../../enums/report.enum";
+
+const reportSchema = new Schema<IReport>(
+  {
+    reportedBy: { type: Schema.Types.ObjectId, ref: "User", required: true },
+    targetId: { type: Schema.Types.ObjectId, required: true },
+    targetType: { type: String, enum: Object.values(ReportTargetType), required: true },
+    reason: { type: String, enum: Object.values(ReportReason), required: true },
+    description: { type: String },
+    status: { type: String, enum: Object.values(ReportStatus), default: ReportStatus.PENDING },
+  },
+  { timestamps: true }
+);
+
+export const Report = mongoose.model<IReport>("Report", reportSchema);

--- a/backend/src/app/modules/report/report.router.ts
+++ b/backend/src/app/modules/report/report.router.ts
@@ -1,0 +1,22 @@
+import express from "express";
+import { ReportController } from "./report.controller";
+import { ReportValidation } from "./report.validation";
+import auth from "../../middleware/auth.middleware";
+import validateRequest from "../../middleware/validate.request";
+import { ENUM_USER_ROLE } from "../../../enums/user";
+
+const router = express.Router();
+
+router.post(
+  "/",
+  auth(
+    ENUM_USER_ROLE.WRITER,
+    ENUM_USER_ROLE.ADMIN,
+    ENUM_USER_ROLE.SUPER_ADMIN,
+    ENUM_USER_ROLE.USER
+  ),
+  validateRequest(ReportValidation.createReport),
+  ReportController.createReport
+);
+
+export const ReportRouter = router;

--- a/backend/src/app/modules/report/report.service.ts
+++ b/backend/src/app/modules/report/report.service.ts
@@ -1,0 +1,14 @@
+import { IReport } from "./report.interface";
+import { Report } from "./report.model";
+
+const createReport = async (payload: IReport) => {
+  const result = await Report.create(payload);
+  return result;
+};
+
+const getAllReports = async () => {
+  const result = await Report.find().populate("reportedBy", "name email");
+  return result;
+};
+
+export const ReportService = { createReport, getAllReports };

--- a/backend/src/app/modules/report/report.validation.ts
+++ b/backend/src/app/modules/report/report.validation.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+import { ReportReason, ReportTargetType } from "../../../enums/report.enum";
+
+const createReport = z.object({
+  body: z.object({
+    targetId: z.string(),
+    targetType: z.nativeEnum(ReportTargetType),
+    reason: z.nativeEnum(ReportReason),
+    description: z.string().optional(),
+  }),
+});
+
+export const ReportValidation = { createReport };

--- a/backend/src/enums/report.enum.ts
+++ b/backend/src/enums/report.enum.ts
@@ -1,0 +1,18 @@
+export enum ReportReason {
+  SPAM = "SPAM",
+  HATE_SPEECH = "HATE_SPEECH",
+  INAPPROPRIATE = "INAPPROPRIATE",
+  MISINFORMATION = "MISINFORMATION",
+  OTHER = "OTHER",
+}
+
+export enum ReportStatus {
+  PENDING = "PENDING",
+  REVIEWED = "REVIEWED",
+  DISMISSED = "DISMISSED",
+}
+
+export enum ReportTargetType {
+  POST = "POST",
+  COMMENT = "COMMENT",
+}

--- a/backend/src/router/index.ts
+++ b/backend/src/router/index.ts
@@ -10,7 +10,7 @@ import { AnalysisRouter } from "../app/modules/analysis/analysis.router";
 import { ReviewRouter } from "../app/modules/review/review.router";
 import { ReactionRouter } from "../app/modules/reaction/reaction.router";
 import { ContactRoutes } from "../app/modules/contact/contact.route";
-
+import { ReportRouter } from "../app/modules/report/report.router";
 import { NewsletterRouter } from "../app/modules/newsletter/newsletter.route";
 
 
@@ -79,6 +79,10 @@ const modules = [
   {
     path: "/contact",
     router: ContactRoutes,
+  },
+  {
+    path: "/reports",
+    router: ReportRouter,
   },
 ];
 modules.forEach((route) => router.use(route.path, route.router));

--- a/postman/globals/workspace.globals.yaml
+++ b/postman/globals/workspace.globals.yaml
@@ -1,0 +1,2 @@
+name: Globals
+values: []


### PR DESCRIPTION
## Screenshot (when helpful)
N/A — this is a backend-only change with no UI. No screenshots needed.

## What this PR does
Adds a complete abuse reporting mechanism to the platform. Previously, users had
no way to flag harmful, offensive, or inappropriate posts and comments. This PR
introduces a new `report` module with its own model, service, controller, router,
validation, and interface — following the exact same structure as existing modules
like `post` and `comment`. It also adds a `report.enum.ts` file in the `enums/`
folder defining report reasons (SPAM, HATE_SPEECH, INAPPROPRIATE, MISINFORMATION,
OTHER), target types (POST, COMMENT), and statuses (PENDING, REVIEWED, DISMISSED).
Authenticated users of any role can now submit a report via `POST /api/v1/reports`.

## Type of change
- [x] New feature

## Related issue
Closes #608 

## More screenshots (optional)
N/A

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.