### PR TITLE
fix: cache model and tokenizer at module level to avoid repeated disk I/O

### DIFF
--- a/backend/ml/scorer.py
+++ b/backend/ml/scorer.py
@@ -28,6 +28,9 @@ EMBED_DIM  = 64
 LSTM_UNITS = 64
 SAVE_DIR   = os.path.join(os.path.dirname(__file__), "saved_scorer")
 
+# Module-level cache — model and tokenizer loaded once on first call
+_model     = None
+_tokenizer = None
 
 def build_model() -> Model:
     """
@@ -72,6 +75,27 @@ def build_model() -> Model:
     )
     return model
 
+def _load_artifacts() -> None:
+    """
+    Load model and tokenizer from disk into module-level cache.
+    Called once on the first score() invocation — subsequent calls
+    reuse the already-loaded objects, avoiding repeated disk I/O.
+    """
+    global _model, _tokenizer
+
+    model_path     = os.path.join(SAVE_DIR, "scorer.keras")
+    tokenizer_path = os.path.join(SAVE_DIR, "tokenizer.pkl")
+
+    if not os.path.exists(model_path):
+        raise FileNotFoundError(
+            f"{model_path} not found — run train_scorer.py first."
+        )
+
+    if _model is None:
+        _model = load_model(model_path)
+
+    if _tokenizer is None:
+        _tokenizer = joblib.load(tokenizer_path)
 
 def score(story_text: str, prompt_text: str) -> dict:
     """


### PR DESCRIPTION
## Screenshot (when helpful)
N/A — backend code change, no UI involved.

## What this PR does
In scorer.py, the score() function was loading the BiLSTM model and 
tokenizer from disk on every single API call. This means every POST 
/score request triggered a full model load, causing unnecessary latency 
especially when scoring multiple stories per request.

This PR moves model and tokenizer loading into a module-level 
_load_artifacts() function that uses _model and _tokenizer cache 
variables. The artifacts are loaded from disk only on the first call 
and reused for all subsequent calls.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue
Fixes #639

## More screenshots (optional)
N/A

## Checklist
- [ ] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.