### PR TITLE
fix: protect GET /api/users/:id with auth and exclude password from response

### DIFF
--- a/backend/src/app/modules/user/user.router.ts
+++ b/backend/src/app/modules/user/user.router.ts
@@ -21,7 +21,16 @@ router.get(
 );
 
 // Get Single User
-router.get("/:id", UserController.getUser);
+router.get(
+  "/:id",
+  auth(
+    ENUM_USER_ROLE.USER,
+    ENUM_USER_ROLE.WRITER,
+    ENUM_USER_ROLE.ADMIN,
+    ENUM_USER_ROLE.SUPER_ADMIN
+  ),
+  UserController.getUser
+);
 
 // Update Single User
 router.patch(

--- a/backend/src/app/modules/user/user.service.ts
+++ b/backend/src/app/modules/user/user.service.ts
@@ -13,7 +13,7 @@ const getAllUsers = async (): Promise<IUser[]> => {
 };
 
 const getUser = async (payload: string): Promise<IUser | null> => {
-  const result = await User.findOne({ _id: payload });
+  const result = await User.findOne({ _id: payload }).select("-password");
   return result;
 };
 


### PR DESCRIPTION
## What this PR does
The `GET /api/users/:id` endpoint had no authentication middleware, allowing any unauthenticated caller to retrieve a full user document including the bcrypt password hash, role, subscription type, and social links.

Two fixes applied:

1. Added `auth()` middleware to the `/:id` route — all authenticated roles (USER, WRITER, ADMIN, SUPER_ADMIN) are allowed
2. Added `.select('-password')` to the `getUser` query to exclude the password hash from the response

## Files Changed
- `backend/src/app/modules/user/user.router.ts`
- `backend/src/app/modules/user/user.service.ts`

## Type of change
- [x] Bug fix

## Related issue
Closes #658 

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.