### PR TITLE
feat: Add input validation, batch limit, error isolation & response metadata to /score API

### DIFF
--- a/backend/ml/score_api.py
+++ b/backend/ml/score_api.py
@@ -7,10 +7,32 @@ Called by ai_model.service.ts after Gemini generates stories.
 Place at: backend/ml/score_api.py
 """
 
+import logging
 from flask import Blueprint, request, jsonify
 from scorer import score as score_story
 
 score_bp = Blueprint("score", __name__)
+logger = logging.getLogger(__name__)
+
+MAX_STORIES = 50
+REQUIRED_STORY_FIELDS = {"title", "content", "uuid"}
+
+
+def _validate_story(story: dict) -> str | None:
+    """Returns an error message if invalid, else None."""
+    missing = REQUIRED_STORY_FIELDS - story.keys()
+    if missing:
+        return f"Missing fields: {sorted(missing)}"
+    if not isinstance(story["content"], str) or not story["content"].strip():
+        return "Field 'content' must be a non-empty string"
+    if not isinstance(story["uuid"], str) or not story["uuid"].strip():
+        return "Field 'uuid' must be a non-empty string"
+    return None
+
+
+@score_bp.route("/health", methods=["GET"])
+def health():
+    return jsonify({"status": "ok", "scorer": "loaded"})
 
 
 @score_bp.route("/score", methods=["POST"])
@@ -36,25 +58,58 @@ def score_route():
               "overall": 0.82
             },
             ...
-          ]
+          ],
+          "meta": {
+            "total": 3,
+            "succeeded": 2,
+            "failed": 1
+          }
         }
     """
     data = request.get_json(force=True)
 
     if not data or "stories" not in data or "prompt" not in data:
-        return jsonify({"error": "Missing stories or prompt"}), 400
+        return jsonify({"error": "Missing required fields: 'stories' and 'prompt'"}), 400
 
-    prompt  = data["prompt"]
+    prompt = data["prompt"]
     stories = data["stories"]
+
+    if not isinstance(prompt, str) or not prompt.strip():
+        return jsonify({"error": "Field 'prompt' must be a non-empty string"}), 400
+
+    if not isinstance(stories, list) or len(stories) == 0:
+        return jsonify({"error": "Field 'stories' must be a non-empty list"}), 400
+
+    if len(stories) > MAX_STORIES:
+        return jsonify({"error": f"Too many stories. Maximum allowed is {MAX_STORIES}"}), 413
+
     results = []
 
     for story in stories:
-        try:
-            scores = score_story(story.get("content", ""), prompt)
-            results.append({"uuid": story.get("uuid", ""), **scores})
-        except FileNotFoundError as e:
-            return jsonify({"error": str(e)}), 503
-        except Exception as e:
-            results.append({"uuid": story.get("uuid", ""), "error": str(e)})
+        uuid = story.get("uuid", "unknown")
 
-    return jsonify({"scores": results})
+        # Validate story fields before scoring
+        error_msg = _validate_story(story)
+        if error_msg:
+            logger.warning("Validation failed for uuid=%s: %s", uuid, error_msg)
+            results.append({"uuid": uuid, "error": error_msg})
+            continue
+
+        try:
+            scores = score_story(story["content"], prompt)
+            results.append({"uuid": uuid, **scores})
+        except FileNotFoundError as e:
+            logger.error("Scorer model missing for uuid=%s: %s", uuid, e)
+            results.append({"uuid": uuid, "error": "Scorer model unavailable", "error_code": "MODEL_UNAVAILABLE"})
+        except Exception as e:
+            logger.exception("Unexpected scoring error for uuid=%s", uuid)
+            results.append({"uuid": uuid, "error": str(e)})
+
+    return jsonify({
+        "scores": results,
+        "meta": {
+            "total": len(stories),
+            "succeeded": sum(1 for r in results if "error" not in r),
+            "failed": sum(1 for r in results if "error" in r),
+        }
+    })


### PR DESCRIPTION
## What this PR does

Hardens the `/score` Flask endpoint by adding input validation, a batch size cap, per-story error isolation, response metadata, and a `/health` check endpoint.

Previously, malformed stories silently scored empty strings, a single `FileNotFoundError` aborted the entire batch, and the caller had no way to know how many stories succeeded without re-parsing every result.

**Changes in `backend/ml/score_api.py`:**
- Added `_validate_story()` helper — checks required fields (`title`, `content`, `uuid`) and rejects empty strings before hitting the scorer
- Added batch size guard — returns HTTP 413 if more than 50 stories are sent
- Fixed `FileNotFoundError` handling — now caught per-story with `continue` instead of aborting the whole batch; includes `error_code: MODEL_UNAVAILABLE` for the TS caller
- Added `meta` object to every response (`total`, `succeeded`, `failed`)
- Added `GET /health` endpoint returning `{ status: ok, scorer: loaded }`
- Added structured logging via `logger.exception()` for unexpected errors

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Code refactor

## Related issue

Closes #663 

## Screenshot

API response shape after this change:

```json
{
  "scores": [
    { "uuid": "abc", "coherence": 0.82, "creativity": 0.74, "relevance": 0.91, "overall": 0.82 },
    { "uuid": "xyz", "error": "Missing fields: ['content']" }
  ],
  "meta": {
    "total": 2,
    "succeeded": 1,
    "failed": 1
  }
}
```

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.

I would like to work on this issue under GSSOC'26