### PR TITLE
fix: add missing form validation errors to login component

### DIFF
--- a/frontend/src/components/login/login.component.tsx
+++ b/frontend/src/components/login/login.component.tsx
@@ -21,7 +21,11 @@ const LoginComponent = () => {
   const [loginUser] = useLoginUserMutation();
   const [googleLogin] = useGoogleLoginMutation();
 
-  const { register, handleSubmit } = useForm<Inputs>();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<Inputs>({ mode: "onChange" });
 
   const [isBusy, setIsBusy] = useState<boolean>(false);
   const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false);
@@ -147,6 +151,8 @@ const LoginComponent = () => {
               required={true}
               icon="fas fa-envelope"
               register={register}
+              validation={{ required: "Email is required" }}
+              error={errors.email}
             />
 
             <SSInput
@@ -157,6 +163,8 @@ const LoginComponent = () => {
               required={true}
               icon="fas fa-lock"
               register={register}
+              validation={{ required: "Password is required" }}
+              error={errors.password}
             />
 
             <div className="flex justify-end -mt-2">

--- a/frontend/src/components/login/login.component.tsx
+++ b/frontend/src/components/login/login.component.tsx
@@ -45,7 +45,7 @@ const LoginComponent = () => {
 
         setIsLoggedIn(true);
       }
-    } catch (err: unknown) {
+    } catch {
       toast.error(
         "Login failed. Please check your credentials."
       );
@@ -75,7 +75,7 @@ const LoginComponent = () => {
 
         setIsLoggedIn(true);
       }
-    } catch (err: unknown) {
+    } catch {
       toast.error(
         "Failed to login with Google. Please try again."
       );


### PR DESCRIPTION
Fixes #677 

## Problem
The login form was missing inline validation error messages. When a user 
submitted the form with empty fields, no error messages appeared under 
the inputs — the form silently attempted an API call instead.

## Root Cause
`useForm` was destructured without `formState: { errors }` and no 
`validation` props or `error` props were passed to the `SSInput` 
components, unlike the signup form which handled this correctly.

## Fix
- Added `formState: { errors }` to `useForm` destructuring
- Added `mode: "onChange"` for real-time validation feedback
- Added `validation` and `error` props to email and password `SSInput` 
  components, consistent with `signup.component.tsx`

## Testing
- [ ] Empty form submission shows inline errors under both fields
- [ ] Valid credentials still log in successfully
- [ ] Google login still works normally

## Type
- [x] Bug fix