### PR TITLE
fix: add missing validation rules to all SSInput fields in signup form

### DIFF
--- a/frontend/src/components/signup/signup.component.tsx
+++ b/frontend/src/components/signup/signup.component.tsx
@@ -313,6 +313,13 @@ const SignUpComponent = () => {
                 required={true}
                 icon="fas fa-envelope"
                 register={register}
+                validation={{
+                  required: "Email is required",
+                  pattern: {
+                    value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
+                    message: "Please enter a valid email address",
+                  },
+                }}
                 error={errors.email}
               />
 
@@ -324,6 +331,13 @@ const SignUpComponent = () => {
                 required={true}
                 icon="fas fa-lock"
                 register={register}
+                validation={{
+                  required: "Password is required",
+                  minLength: {
+                    value: 8,
+                    message: "Password must be at least 8 characters",
+                  },
+                }}
                 error={errors.password}
               />
 
@@ -373,6 +387,11 @@ const SignUpComponent = () => {
                 required={true}
                 icon="fas fa-eye"
                 register={register}
+                validation={{
+                  required: "Please confirm your password",
+                  validate: (value: string) =>
+                    value === password || "Passwords do not match",
+                }}
                 error={errors.confirmPassword}
               />
 
@@ -387,6 +406,22 @@ const SignUpComponent = () => {
                 required={true}
                 icon="fas fa-key"
                 register={register}
+                validation={{
+                  required: "Please enter OTP",
+                  minLength: {
+                    value: 6,
+                    message: "OTP must be 6 digits",
+                  },
+                  maxLength: {
+                    value: 6,
+                    message: "OTP must be 6 digits",
+                  },
+                  pattern: {
+                    value: /^[0-9]{6}$/,
+                    message: "OTP must contain only numbers",
+                  },
+                }}
+                error={errors.otp}
               />
 
               <SSButton


### PR DESCRIPTION
Fixes #688 

## Problem
Three form fields in the signup form had no `validation` prop passed 
to `SSInput`, meaning `errors.email`, `errors.password`, and 
`errors.confirmPassword` were always `undefined`. Inline error messages 
never appeared under these fields. The OTP field had no `validation` 
or `error` prop at all.

## Root Cause
`SSInput` components for `email`, `password`, `confirmPassword`, and 
`otp` were missing `validation` rules, unlike the `name` field which 
handled validation correctly.

## Fix
Added `validation` and `error` props to all 4 affected SSInput fields:
- `email` → required + valid email pattern
- `password` → required + minimum 8 characters
- `confirmPassword` → required + must match password
- `otp` → required + 6 digits only

## Testing
- [ ] Empty email shows "Email is required"
- [ ] Invalid email shows "Please enter a valid email address"
- [ ] Empty password shows "Password is required"
- [ ] Mismatched passwords show "Passwords do not match"
- [ ] Invalid OTP shows "OTP must contain only numbers"
- [ ] Valid inputs proceed normally

## Type
- [x] Bug fix