### PR TITLE
fix: prevent duplicate reports from same user on same content

### DIFF
--- a/backend/src/app/modules/report/report.model.ts
+++ b/backend/src/app/modules/report/report.model.ts
@@ -14,4 +14,7 @@ const reportSchema = new Schema<IReport>(
   { timestamps: true }
 );
 
+// Prevent the same user from reporting the same content more than once
+reportSchema.index({ reportedBy: 1, targetId: 1, targetType: 1 }, { unique: true });
+
 export const Report = mongoose.model<IReport>("Report", reportSchema);

--- a/backend/src/app/modules/report/report.service.ts
+++ b/backend/src/app/modules/report/report.service.ts
@@ -1,7 +1,17 @@
 import { IReport } from "./report.interface";
 import { Report } from "./report.model";
+import ApiError from "../../../errors/api_error";
+import httpStatus from "http-status";
 
 const createReport = async (payload: IReport) => {
+  const existing = await Report.findOne({
+    reportedBy: payload.reportedBy,
+    targetId: payload.targetId,
+    targetType: payload.targetType,
+  });
+  if (existing) {
+    throw new ApiError(httpStatus.CONFLICT, "You have already reported this content.");
+  }
   const result = await Report.create(payload);
   return result;
 };


### PR DESCRIPTION
## What this PR does
`createReport` in `backend/src/app/modules/report/report.service.ts` had no duplicate check — a user could call `POST /api/reports` repeatedly with the same `targetId` and `targetType`, creating multiple report documents for the same content. This inflates report counts and makes moderation unreliable.

Two fixes applied:

1. Added a `findOne` check in `createReport` — returns `409 Conflict` if the same user has already reported the same content
2. Added a compound unique index on `{ reportedBy, targetId, targetType }` in the report model as a database-level safety net

## Files Changed
- `backend/src/app/modules/report/report.service.ts`
- `backend/src/app/modules/report/report.model.ts`

## Type of change
- [x] Bug fix

## Related issue
Closes #690 

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.