### PR TITLE
fix(UI): hide navbar on signup page

### DIFF
--- a/frontend/src/components/layout/root_layout.component.tsx
+++ b/frontend/src/components/layout/root_layout.component.tsx
@@ -10,7 +10,7 @@ interface RootLayoutProps {
 
 const RootLayout: React.FC<RootLayoutProps> = ({ children }) => {
   const { pathname } = useLocation();
-  const hideHeader = pathname === "/login";
+  const hideHeader = pathname === "/login" || pathname === "/signup";
   const hideFooter = pathname === "/login" || pathname === "/signup";
 
   return (


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Navbar is visible on the Create Account page but missing on the Login page, causing inconsistent authentication page UI.

- **Description:** 
Updated the root layout so that on login and register page the navbar is hidden.
- **Screenshots:** 
 Before
<img width="1366" height="672" alt="image" src="https://github.com/user-attachments/assets/9d917e83-66e7-4e8e-a368-9c63d2f381b8" />


After
<img width="1366" height="619" alt="image" src="https://github.com/user-attachments/assets/fc9a54cf-035d-4ea5-8c9c-14f26a9185d8" />






## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Documentation update

## Related issue

Closes #712 

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
