### PR TITLE
feat: add AI Story Remix Engine with 5 remix types

### DIFF
--- a/backend/src/app/modules/ai_model/ai_model.controller.ts
+++ b/backend/src/app/modules/ai_model/ai_model.controller.ts
@@ -4,6 +4,7 @@ import ApiError from "../../../errors/api_error";
 import catchAsync from "../../../shared/catch_async";
 import sendResponse from "../../../shared/send_response";
 import { AiModelService } from "./ai_model.service";
+import { IRemixPayload } from "./ai_model.interface";
 import { getToken } from "../../middleware/token";
 import { reserveGuestQuota } from "./quota.service";
 import {
@@ -103,10 +104,35 @@ const aiFreeModelAlternateEndings = catchAsync(
   }
 );
 
+const aiModelRemix = catchAsync(async (req: Request, res: Response) => {
+  const payload = req.body as IRemixPayload;
+  const token = await getToken(req);
+  const result = await AiModelService.aiModelRemix(payload, token);
+  sendResponse(res, {
+    statusCode: httpStatus.OK,
+    success: true,
+    message: "Story remixed successfully!",
+    data: result,
+  });
+});
+
+const aiFreeModelRemix = catchAsync(async (req: Request, res: Response) => {
+  const payload = req.body as IRemixPayload;
+  const result = await AiModelService.aiFreeModelRemix(payload);
+  sendResponse(res, {
+    statusCode: httpStatus.OK,
+    success: true,
+    message: "Story remixed successfully!",
+    data: result,
+  });
+});
+
 export const AiModelController = {
   aiModelGenerate,
   aiFreeModelGenerate,
   aiModelAlternateEndings,
   aiFreeModelAlternateEndings,
+  aiModelRemix,
+  aiFreeModelRemix,
 };
 

--- a/backend/src/app/modules/ai_model/ai_model.interface.ts
+++ b/backend/src/app/modules/ai_model/ai_model.interface.ts
@@ -19,6 +19,17 @@ export interface IAlternateEnding {
   fullStory: string;
 }
 
+export type RemixType = "setting" | "perspective" | "time_period" | "tone" | "gender_swap";
+
+export interface IRemixPayload {
+  title: string;
+  content: string;
+  tag: string;
+  remixType: RemixType;
+  remixOption?: string;
+  language?: string;
+}
+
 export interface IAlternateEndingPayload {
   title: string;
   content: string;

--- a/backend/src/app/modules/ai_model/ai_model.router.ts
+++ b/backend/src/app/modules/ai_model/ai_model.router.ts
@@ -35,5 +35,16 @@ router.post(
   AiModelController.aiFreeModelAlternateEndings
 );
 
+// Remix Story
+router.post(
+  "/remix",
+  checkRequestLimit(),
+  AiModelController.aiModelRemix
+);
+// Remix Story Free
+router.post(
+  "/remix-free",
+  AiModelController.aiFreeModelRemix
+);
 export const AIModelRouter = router;
 

--- a/backend/src/app/modules/ai_model/ai_model.service.ts
+++ b/backend/src/app/modules/ai_model/ai_model.service.ts
@@ -8,10 +8,12 @@ import {
 import {
   IAIModel,
   IAlternateEndingPayload,
+  IRemixPayload,
 } from "./ai_model.interface";
 import {
   generateAlternateEndingsWithGemini,
   generateWithGeminiStories,
+  generateRemixWithGemini,
 } from "./ai_model.utils";
 import { assertSuccessfulGeneration } from "./quota.lifecycle";
 
@@ -129,9 +131,37 @@ const aiFreeModelAlternateEndings = async (payload: IAlternateEndingPayload) => 
   }
 };
 
+const aiModelRemix = async (payload: IRemixPayload, _token: ITokenPayload) => {
+  const { title, content, tag, remixType, remixOption = "", language = "English" } = payload;
+  try {
+    const result = await raceGenerationWithTimeout(
+      () => generateRemixWithGemini(title, content, tag, remixType, remixOption, language),
+      AUTHENTICATED_GENERATION_TIMEOUT_MS
+    );
+    return result;
+  } catch (error) {
+    mapGenerationError(error, "Remix generation failed.");
+  }
+};
+
+const aiFreeModelRemix = async (payload: IRemixPayload) => {
+  const { title, content, tag, remixType, remixOption = "", language = "English" } = payload;
+  try {
+    const result = await raceGenerationWithTimeout(
+      () => generateRemixWithGemini(title, content, tag, remixType, remixOption, language),
+      FREE_GENERATION_TIMEOUT_MS
+    );
+    return result;
+  } catch (error) {
+    mapGenerationError(error, "Remix generation failed.");
+  }
+};
+
 export const AiModelService = {
   aiModelGenerate,
   aiFreeModelGenerate,
   aiModelAlternateEndings,
   aiFreeModelAlternateEndings,
+  aiModelRemix,
+  aiFreeModelRemix,
 };

--- a/backend/src/app/modules/ai_model/ai_model.utils.ts
+++ b/backend/src/app/modules/ai_model/ai_model.utils.ts
@@ -252,3 +252,66 @@ export async function generateAlternateEndingsWithGemini(
     );
   }
 }
+
+export async function generateRemixWithGemini(
+  title: string,
+  content: string,
+  tag: string,
+  remixType: string,
+  remixOption: string,
+  language: string = "English"
+): Promise<{ title: string; content: string; tag: string }> {
+  const remixPrompts: Record<string, string> = {
+    setting: `Rewrite this story keeping the same plot and characters but change the setting to: ${remixOption}. Keep the same story structure.`,
+    perspective: `Rewrite this story from the perspective of: ${remixOption}. Keep the same events but show them from this character's point of view.`,
+    time_period: `Rewrite this story keeping the same plot but set it in: ${remixOption}. Adjust all details to fit the time period.`,
+    tone: `Rewrite this story keeping the same plot but change the tone to: ${remixOption}. Adjust the writing style accordingly.`,
+    gender_swap: `Rewrite this story with all characters gender-swapped. Keep the same plot and events.`,
+  };
+
+  const remixInstruction = remixPrompts[remixType] || remixPrompts.tone;
+
+  const prompt = `You are a creative writing assistant. Here is a story:
+
+Title: ${title}
+Content: ${content}
+Genre: ${tag}
+
+Task: ${remixInstruction}
+
+Write the remixed story in ${language}. Return a JSON object with this exact structure:
+{
+  "title": "remixed story title",
+  "content": "full remixed story content",
+  "tag": "${tag}"
+}`;
+
+  try {
+    const chatSession = model.startChat({
+      generationConfig: {
+        ...generationConfig,
+        maxOutputTokens: 4096,
+      },
+      safetySettings,
+      history: [],
+    });
+
+    const result = await chatSession.sendMessage(prompt);
+    const rawText = result.response.text();
+    const cleanText = sanitizeJsonText(rawText);
+    const parsed = JSON.parse(cleanText);
+
+    if (!parsed.title || !parsed.content) {
+      throw new ApiError(httpStatus.BAD_REQUEST, "Invalid remix response from AI.");
+    }
+
+    return parsed;
+  } catch (error: unknown) {
+    if (error instanceof ApiError) throw error;
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    throw new ApiError(
+      httpStatus.INTERNAL_SERVER_ERROR,
+      `AI remix generation failed: ${errorMsg}`
+    );
+  }
+}

--- a/frontend/src/components/remix/StoryRemix.tsx
+++ b/frontend/src/components/remix/StoryRemix.tsx
@@ -1,0 +1,170 @@
+import { useState } from "react";
+import { useRemixStoryMutation, useRemixFreeStoryMutation } from "../../redux/apis/ai.model.api";
+import { IStories } from "../stories/stories.view.component";
+
+interface Props {
+  story: IStories;
+  isLogin: boolean;
+  onRemixComplete: (remixedStory: IStories) => void;
+  onClose: () => void;
+}
+
+const REMIX_OPTIONS = [
+  {
+    type: "setting",
+    label: "🌍 Change Setting",
+    description: "Same plot, different world",
+    options: ["Space Station", "Medieval Fantasy", "Cyberpunk City", "Wild West", "Underwater Kingdom", "Post-Apocalyptic Earth"],
+  },
+  {
+    type: "perspective",
+    label: "👁️ Perspective Shift",
+    description: "Retell from a different viewpoint",
+    options: ["The Villain", "A Side Character", "An Animal", "An Omniscient Narrator", "A Child"],
+  },
+  {
+    type: "time_period",
+    label: "⏰ Time Period",
+    description: "Same story, different era",
+    options: ["Ancient Rome", "Victorian England", "1920s Jazz Era", "Far Future 2500", "Renaissance Italy", "1980s America"],
+  },
+  {
+    type: "tone",
+    label: "🎭 Tone Shift",
+    description: "Change the emotional feel",
+    options: ["Comedy", "Dark Thriller", "Romance", "Horror", "Inspirational", "Satirical"],
+  },
+  {
+    type: "gender_swap",
+    label: "🔄 Gender Swap",
+    description: "All characters gender-swapped",
+    options: ["Gender Swap"],
+  },
+];
+
+export default function StoryRemix({ story, isLogin, onRemixComplete, onClose }: Props) {
+  const [selectedType, setSelectedType] = useState<string | null>(null);
+  const [selectedOption, setSelectedOption] = useState<string | null>(null);
+  const [isRemixing, setIsRemixing] = useState(false);
+  const [error, setError] = useState("");
+
+  const [remixStory] = useRemixStoryMutation();
+  const [remixFreeStory] = useRemixFreeStoryMutation();
+
+  const selectedRemix = REMIX_OPTIONS.find(r => r.type === selectedType);
+
+  const handleRemix = async () => {
+    if (!selectedType || !selectedOption) return;
+    setIsRemixing(true);
+    setError("");
+
+    try {
+      const payload = {
+        title: story.title,
+        content: story.content,
+        tag: story.tag,
+        remixType: selectedType,
+        remixOption: selectedOption,
+      };
+
+      const result = isLogin
+        ? await remixStory(payload).unwrap()
+        : await remixFreeStory(payload).unwrap();
+
+      if (result?.data) {
+        const remixedStory: IStories = {
+          uuid: `remix-${Date.now()}`,
+          title: result.data.title,
+          content: result.data.content,
+          tag: result.data.tag,
+          imageURL: story.imageURL,
+        };
+        onRemixComplete(remixedStory);
+      }
+    } catch {
+      setError("Remix failed. Please try again.");
+    } finally {
+      setIsRemixing(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/80 backdrop-blur flex items-center justify-center p-4">
+      <div className="w-full max-w-2xl bg-[#0f1117] rounded-2xl border border-white/10 overflow-hidden shadow-2xl">
+
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-white/10">
+          <div>
+            <h2 className="text-xl font-bold text-purple-400">🔀 Remix This Story</h2>
+            <p className="text-xs text-white/40 mt-0.5 truncate max-w-xs">{story.title}</p>
+          </div>
+          <button onClick={onClose} className="text-white/40 hover:text-white transition text-xl">✕</button>
+        </div>
+
+        <div className="px-6 py-5">
+          {/* Step 1: Choose remix type */}
+          <p className="text-sm text-white/60 mb-3 font-medium">Step 1 — Choose how to remix:</p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-6">
+            {REMIX_OPTIONS.map((remix) => (
+              <button
+                key={remix.type}
+                onClick={() => { setSelectedType(remix.type); setSelectedOption(null); }}
+                className={`text-left p-4 rounded-xl border transition-all ${
+                  selectedType === remix.type
+                    ? "border-purple-500 bg-purple-500/15"
+                    : "border-white/10 bg-white/3 hover:border-white/20 hover:bg-white/5"
+                }`}
+              >
+                <div className="font-semibold text-white text-sm">{remix.label}</div>
+                <div className="text-xs text-white/40 mt-0.5">{remix.description}</div>
+              </button>
+            ))}
+          </div>
+
+          {/* Step 2: Choose option */}
+          {selectedRemix && selectedRemix.type !== "gender_swap" && (
+            <div className="mb-6">
+              <p className="text-sm text-white/60 mb-3 font-medium">Step 2 — Choose an option:</p>
+              <div className="flex flex-wrap gap-2">
+                {selectedRemix.options.map((option) => (
+                  <button
+                    key={option}
+                    onClick={() => setSelectedOption(option)}
+                    className={`px-4 py-2 rounded-full text-sm font-medium border transition-all ${
+                      selectedOption === option
+                        ? "border-purple-500 bg-purple-500/20 text-purple-300"
+                        : "border-white/10 bg-white/5 text-white/60 hover:border-white/20"
+                    }`}
+                  >
+                    {option}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {selectedRemix?.type === "gender_swap" && !selectedOption && setSelectedOption("Gender Swap") && null}
+
+          {error && (
+            <p className="text-red-400 text-sm mb-4">{error}</p>
+          )}
+
+          {/* Remix Button */}
+          <button
+            onClick={handleRemix}
+            disabled={!selectedType || (!selectedOption && selectedType !== "gender_swap") || isRemixing}
+            className="w-full py-3 rounded-xl bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-700 hover:to-indigo-700 disabled:opacity-40 disabled:cursor-not-allowed text-white font-bold text-lg transition-all"
+          >
+            {isRemixing ? (
+              <span className="flex items-center justify-center gap-2">
+                <span className="animate-spin">⟳</span> Remixing...
+              </span>
+            ) : (
+              "🔀 Generate Remix"
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/stories/stories.view.component.tsx
+++ b/frontend/src/components/stories/stories.view.component.tsx
@@ -5,6 +5,7 @@ import { useCreatePostMutation, useDeletePostMutation } from "../../redux/apis/p
 import { useGetProfileInfoQuery } from "../../redux/apis/user.api";
 import jsPDF from "jspdf";
 import StoryWorldMap from "../story-map/StoryWorldMap";
+import StoryRemix from "../remix/StoryRemix";
 import BookmarkButton from "../BookmarkButton";
 import logo from "../../assets/logoNew.png";
 import StoryGeneratingAnimation from "../loading/story-generating-animation.component";
@@ -94,6 +95,7 @@ const StoriesViewComponent: React.FC<StoriesComponentProps> = ({
   const [loading, setLoading] = useState<boolean>(false);
   const [isCopied, setIsCopied] = useState<boolean>(false);
   const [showWorldMap, setShowWorldMap] = useState<boolean>(false);
+  const [showRemix, setShowRemix] = useState<boolean>(false);
   const [createPost] = useCreatePostMutation();
   const [deletePost] = useDeletePostMutation();
   const { data: profile } = useGetProfileInfoQuery(undefined, { skip: !isLogin });
@@ -762,6 +764,14 @@ if (isLoading) {
                 </button>
                 <button
                   type="button"
+                  className="rounded-lg px-4 py-2 bg-fuchsia-700 text-slate-200 font-semibold cursor-pointer hover:bg-fuchsia-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  onClick={() => setShowRemix(true)}
+                  disabled={!selectedStory}
+                >
+                  🔀 Remix
+                </button>
+                <button
+                  type="button"
                   id="publish-story-btn"
                   className={`rounded-lg px-5 py-2 font-semibold flex items-center space-x-2 cursor-pointer bg-blue-600 text-white transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed ${
                     loading ? "" : "hover:bg-blue-500 hover:shadow-lg active:scale-95"
@@ -1059,6 +1069,18 @@ if (isLoading) {
           </div>
         </div>
       </div>
+      {showRemix && selectedStory && (
+        <StoryRemix
+          story={selectedStory}
+          isLogin={isLogin}
+          onRemixComplete={(remixedStory) => {
+            setStories([remixedStory, ...stories]);
+            setSelectedStory(remixedStory);
+            setShowRemix(false);
+          }}
+          onClose={() => setShowRemix(false)}
+        />
+      )}
       {showWorldMap && selectedStory && (
         <StoryWorldMap
           story={selectedStory.content}

--- a/frontend/src/redux/apis/ai.model.api.ts
+++ b/frontend/src/redux/apis/ai.model.api.ts
@@ -49,6 +49,28 @@ const aiModelApi = baseApi.injectEndpoints({
       },
       invalidatesTags: [tagTypes.model, tagTypes.user],
     }),
+    remixStory: build.mutation({
+      query: (data) => ({
+        url: `/${AI_MODEL_URL}/remix`,
+        method: "POST",
+        data: data,
+      }),
+      transformResponse: (response: { data: { title: string; content: string; tag: string }; message: string }) => {
+        return { data: response.data, message: response.message };
+      },
+      invalidatesTags: [tagTypes.model, tagTypes.user],
+    }),
+    remixFreeStory: build.mutation({
+      query: (data) => ({
+        url: `/${AI_MODEL_URL}/remix-free`,
+        method: "POST",
+        data: data,
+      }),
+      transformResponse: (response: { data: { title: string; content: string; tag: string }; message: string }) => {
+        return { data: response.data, message: response.message };
+      },
+      invalidatesTags: [tagTypes.model],
+    }),
   }),
 });
 
@@ -57,5 +79,7 @@ export const {
   useGenerateFreeModelMutation,
   useGenerateAlternateEndingsMutation,
   useGenerateFreeAlternateEndingsMutation,
+  useRemixStoryMutation,
+  useRemixFreeStoryMutation,
 } = aiModelApi;
 


### PR DESCRIPTION
## Before you open this PR
- **Issue:** Closes #630 
- **Description:** Adds an AI-powered Story Remix Engine with 5 remix types

## Screenshot
<img width="933" height="647" alt="image" src="https://github.com/user-attachments/assets/f2fe8fa5-3583-467f-ade2-0c69afd744f4" />


## What this PR does
Adds a "🔀 Remix" button to every generated story that lets users instantly generate creative variations using AI. Users can choose from 5 remix types: Change Setting, Perspective Shift, Time Period, Tone Shift, and Gender Swap. Each remix type has multiple options to choose from. The remixed story replaces the current story view.

New files:
- frontend/src/components/remix/StoryRemix.tsx - Remix UI component
- backend/src/app/modules/ai_model additions - remix service, controller, routes

Modified files:
- backend/src/app/modules/ai_model/ai_model.interface.ts - added IRemixPayload
- backend/src/app/modules/ai_model/ai_model.utils.ts - added generateRemixWithGemini
- backend/src/app/modules/ai_model/ai_model.service.ts - added remix service functions
- backend/src/app/modules/ai_model/ai_model.controller.ts - added remix controllers
- backend/src/app/modules/ai_model/ai_model.router.ts - added /remix and /remix-free routes
- frontend/src/redux/apis/ai.model.api.ts - added remix mutations
- frontend/src/components/stories/stories.view.component.tsx - added Remix button

## Type of change
- [x] New feature

## Related issue
Closes #630 

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.