### PR TITLE
fix: add missing links to mobile navbar

### DIFF
--- a/frontend/src/components/hero/nav_list.component.tsx
+++ b/frontend/src/components/hero/nav_list.component.tsx
@@ -258,6 +258,18 @@ const NavListComponent: React.FC = () => {
                 </>
               )}
             </NavLink>
+
+            <NavLink to="/story-inspiration" className={({ isActive }) => getMobileLinkClass(isActive)}>
+             {({ isActive }) => (
+    <>
+               {isActive && (
+                <span className="w-2 h-2 bg-custom rounded-full mr-2.5 animate-pulse shadow-[0_0_8px_#3b82f6]" />
+           )}
+           INSPIRING STORIES
+    </>
+     )}
+</NavLink>
+
             <NavLink to="/analytics" className={({ isActive }) => getMobileLinkClass(isActive)}>
               {({ isActive }) => (
                 <>
@@ -274,6 +286,17 @@ const NavListComponent: React.FC = () => {
                 </>
               )}
             </NavLink>
+
+            <NavLink to="/contact-us" className={({ isActive }) => getMobileLinkClass(isActive)}>
+              {({ isActive }) => (
+    <>
+               {isActive && (
+                 <span className="w-2 h-2 bg-custom rounded-full mr-2.5 animate-pulse shadow-[0_0_8px_#3b82f6]" />
+               )}
+              CONTACT US
+    </>
+          )}
+</NavLink>
             <NavLink to="/community" className={({ isActive }) => getMobileLinkClass(isActive)}>
               {({ isActive }) => (
                 <>


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Fixes #745 
- **Description:** This PR adds missing mobile navbar links that were present on desktop but unavailable in the hamburger menu.
- **Screenshots:** 

- BEFORE:- 

<img width="350" height="427" alt="image" src="https://github.com/user-attachments/assets/625399ad-e603-4c31-8792-8d82dac246c7" />

- AFTER:-

<img width="362" height="365" alt="image" src="https://github.com/user-attachments/assets/21eacd16-3d39-48bb-8bd0-2fd5813b5182" />


## What this PR does
This PR improves the mobile navbar by adding the missing **Inspiring Stories** and **Contact Us** links to the hamburger menu.

These links were already available in the desktop navbar, but were missing from the mobile navigation. This made mobile navigation inconsistent with desktop navigation and reduced access to important pages on smaller screens.

## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue
None

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.