### PR TITLE
fix: hide password strength indicator on empty field

### DIFF
--- a/frontend/src/components/signup/signup.component.tsx
+++ b/frontend/src/components/signup/signup.component.tsx
@@ -327,6 +327,7 @@ const SignUpComponent = () => {
                 error={errors.password}
               />
 
+              {password?.length > 0 && (
               <div className="space-y-3 -mt-2">
                 <div
                   className="w-full h-2 bg-slate-700 rounded-full overflow-hidden"
@@ -364,6 +365,7 @@ const SignUpComponent = () => {
                   })}
                 </ul>
               </div>
+)}
 
               <SSInput
                 label="Confirm Password"


### PR DESCRIPTION
## Screenshot (when helpful)

| BEFORE | AFTER |
|------------|-----------|
| <img width="1346" height="637" alt="Image" src="https://github.com/user-attachments/assets/f198b32c-bca4-49e3-b4b6-58d5dc41b2ed" /> | <img width="1357" height="632" alt="image" src="https://github.com/user-attachments/assets/434b5c15-503b-4548-ade1-d54b6ace1607" /> |
## What this PR does
This PR fixes a UX issue in the `/signup` page where the password strength indicator was being displayed immediately on initial render, even when the password field was empty.

### Changes made:

* Added a conditional check to display the password strength indicator only when the user starts typing in the password field.
* Prevented the “Weak Password” message and validation errors from appearing on page load.
* Ensured the indicator disappears again if the password input is cleared.
* Improved the overall sign-up experience by avoiding premature validation feedback for new users.

### Result:

* **Before:** Users immediately saw red password validation errors on opening the Sign Up page without any interaction.
* **After:** Password strength feedback now appears only after user input, creating a cleaner and more intuitive UX.

## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue
Closes #704 
## More screenshots (optional)

<img width="1357" height="632" alt="image" src="https://github.com/user-attachments/assets/2c6271ff-6a78-42fd-935d-16a37847e94b" />

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
