### PR TITLE
fix: prevent whitespace-only story prompts

### DIFF
--- a/frontend/src/components/stories/stories.component.tsx
+++ b/frontend/src/components/stories/stories.component.tsx
@@ -126,10 +126,11 @@ const StoriesComponent = () => {
       return;
     }
 
-    if (data.prompt === "") {
+    if (!data.prompt.trim()) {
       toast.error("Please enter a prompt to generate a story.");
       return;
     }
+
     if (getWordCount(data.prompt) < 10) {
       toast.error(
         "Please enter a prompt with at least 10 words to generate a story.",


### PR DESCRIPTION
## What this PR does

This PR fixes a validation issue in the story generation form where users could submit prompts containing only whitespace characters.

### Changes made:

* Added `.trim()` validation to prompt input
* Prevented whitespace-only submissions
* Improved frontend validation behavior and user experience

---

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

---

## Related issue

Closes #766 

---

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.