### PR TITLE
fix: optimize ML inference asset loading with caching

### DIFF
--- a/backend/ml/detect.py
+++ b/backend/ml/detect.py
@@ -21,9 +21,11 @@ os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
 from tensorflow.keras.models import load_model
 from model import SEQ_LEN, N_FEATURES
 
-MODEL_PATH     = "saved/model.keras"
-SCALER_PATH    = "saved/scaler.pkl"
+MODEL_PATH = "saved/model.keras"
+SCALER_PATH = "saved/scaler.pkl"
 THRESHOLD_PATH = "saved/threshold.json"
+
+_ML_ASSETS_CACHE = None
 
 # Feature order — must match train.py exactly:
 # 0: prompt_length       words typed before submitting
@@ -45,6 +47,38 @@ FEATURE_KEYS = [
     "confidence_score",
     "blocked_word_count",
 ]
+
+
+def load_ml_assets_into_cache():
+    """
+    Load ML assets once and reuse them for all inference calls.
+
+    This prevents repeated disk reads and repeated TensorFlow/Keras model
+    loading inside detect(), reducing I/O saturation and memory growth.
+    """
+    global _ML_ASSETS_CACHE
+
+    if _ML_ASSETS_CACHE is not None:
+        return _ML_ASSETS_CACHE
+
+    for path in (MODEL_PATH, SCALER_PATH, THRESHOLD_PATH):
+        if not os.path.exists(path):
+            raise FileNotFoundError(f"{path} not found — run train.py first.")
+
+    model = load_model(MODEL_PATH)
+    scaler = joblib.load(SCALER_PATH)
+
+    with open(THRESHOLD_PATH, "r") as f:
+        threshold = json.load(f)["threshold"]
+
+    _ML_ASSETS_CACHE = {
+        "model": model,
+        "scaler": scaler,
+        "threshold": threshold,
+    }
+
+    return _ML_ASSETS_CACHE
+
 
 # ── Suggestions by anomaly type ───────────────────────────────────────────────
 
@@ -94,14 +128,13 @@ def _get_suggestion(session_raw: np.ndarray) -> str:
     """
     avg = session_raw.mean(axis=0)
 
-    # Higher = more stuck for each feature (normalized heuristics)
     scores = {
-        "prompt_length":      1 / (avg[0] + 1),         # low prompt length → stuck
-        "regeneration_count": avg[2] / 40,               # high regen → stuck
-        "backspace_ratio":    avg[4] / 100,              # high backspace → stuck
-        "pause_duration":     avg[5] / 90,               # long pauses → stuck
-        "confidence_score":   1 / (avg[6] + 1),         # low confidence → stuck
-        "blocked_word_count": avg[7] / 15,              # many blocked words → stuck
+        "prompt_length": 1 / (avg[0] + 1),
+        "regeneration_count": avg[2] / 40,
+        "backspace_ratio": avg[4] / 100,
+        "pause_duration": avg[5] / 90,
+        "confidence_score": 1 / (avg[6] + 1),
+        "blocked_word_count": avg[7] / 15,
     }
 
     worst_feature = max(scores, key=scores.get)
@@ -116,24 +149,20 @@ def detect(session: list) -> dict:
     ----------
     session : list[dict] or list[list]
         At least SEQ_LEN entries. Each entry is either:
-          - a dict with keys matching FEATURE_KEYS (from interactive mode)
-          - a list of 8 floats in FEATURE_KEYS order (from frontend tracker)
+          - a dict with keys matching FEATURE_KEYS
+          - a list of 8 floats in FEATURE_KEYS order
 
     Returns
     -------
     dict : is_stuck, confidence, anomaly_score, threshold, suggestion
     """
-    for path in (MODEL_PATH, SCALER_PATH, THRESHOLD_PATH):
-        if not os.path.exists(path):
-            raise FileNotFoundError(f"{path} not found — run train.py first.")
-
-    model     = load_model(MODEL_PATH)
-    scaler    = joblib.load(SCALER_PATH)
-    threshold = json.load(open(THRESHOLD_PATH))["threshold"]
+    assets = load_ml_assets_into_cache()
+    model = assets["model"]
+    scaler = assets["scaler"]
+    threshold = assets["threshold"]
 
     window = session[-SEQ_LEN:]
 
-    # Accept both dict-style (interactive) and list-style (frontend tracker)
     if isinstance(window[0], dict):
         session_raw = np.array(
             [[s[k] for k in FEATURE_KEYS] for s in window],
@@ -148,12 +177,12 @@ def detect(session: list) -> dict:
             f"got {session_raw.shape}. Check FEATURE_KEYS order."
         )
 
-    seq_scaled    = scaler.transform(session_raw).reshape(1, SEQ_LEN, N_FEATURES)
+    seq_scaled = scaler.transform(session_raw).reshape(1, SEQ_LEN, N_FEATURES)
     reconstructed = model.predict(seq_scaled, verbose=0)
     anomaly_score = float(np.mean((seq_scaled - reconstructed) ** 2))
 
     is_stuck = anomaly_score > threshold
-    ratio    = anomaly_score / threshold
+    ratio = anomaly_score / threshold
 
     if not is_stuck:
         confidence = "N/A"
@@ -165,11 +194,11 @@ def detect(session: list) -> dict:
         confidence = "Low"
 
     return {
-        "is_stuck":      is_stuck,
-        "confidence":    confidence,
+        "is_stuck": is_stuck,
+        "confidence": confidence,
         "anomaly_score": round(anomaly_score, 6),
-        "threshold":     round(threshold, 6),
-        "suggestion":    _get_suggestion(session_raw) if is_stuck else "",
+        "threshold": round(threshold, 6),
+        "suggestion": _get_suggestion(session_raw) if is_stuck else "",
     }
 
 
@@ -184,23 +213,23 @@ def _get_int(prompt: str) -> int:
 
 
 PROMPTS = {
-    "prompt_length":      "    prompt_length       (words typed)            : ",
-    "time_to_submit":     "    time_to_submit      (seconds before submit)  : ",
+    "prompt_length": "    prompt_length       (words typed)            : ",
+    "time_to_submit": "    time_to_submit      (seconds before submit)  : ",
     "regeneration_count": "    regeneration_count  (times regenerated)      : ",
-    "session_duration":   "    session_duration    (seconds in session)     : ",
-    "backspace_ratio":    "    backspace_ratio     (0–100, % of backspaces) : ",
-    "pause_duration":     "    pause_duration      (longest pause, seconds) : ",
-    "confidence_score":   "    confidence_score    (1–10)                   : ",
+    "session_duration": "    session_duration    (seconds in session)     : ",
+    "backspace_ratio": "    backspace_ratio     (0–100, % of backspaces) : ",
+    "pause_duration": "    pause_duration      (longest pause, seconds) : ",
+    "confidence_score": "    confidence_score    (1–10)                   : ",
     "blocked_word_count": "    blocked_word_count  (frustration words seen) : ",
 }
 
 
 def _interactive():
-    print("\n" + "="*52)
+    print("\n" + "=" * 52)
     print("  Writer's Block Detector — Interactive Mode")
-    print("="*52)
+    print("=" * 52)
     print(f"\nEnter data for {SEQ_LEN} timesteps (one per writing window).")
-    print("─"*52)
+    print("─" * 52)
 
     session = []
     for i in range(1, SEQ_LEN + 1):
@@ -208,9 +237,9 @@ def _interactive():
         step = {key: _get_int(prompt) for key, prompt in PROMPTS.items()}
         session.append(step)
 
-    print("\n" + "─"*52)
+    print("\n" + "─" * 52)
     print("  Result")
-    print("─"*52)
+    print("─" * 52)
 
     result = detect(session)
 


### PR DESCRIPTION
## What this PR does

This PR optimizes the ML inference pipeline by implementing an in-memory caching mechanism for ML assets used inside `detect()`.

Previously, the Keras model, scaler, and threshold configuration were loaded from disk on every inference request, causing repeated I/O operations and unnecessary TensorFlow model reloads.

### Changes made:

* Added `load_ml_assets_into_cache()` helper
* Implemented singleton-style caching for:

  * Keras model
  * scaler
  * threshold configuration
* Removed repeated disk reads during inference
* Improved runtime performance and reduced memory overhead

## Type of change

* [x] Bug fix
* [x] Code refactor
* [ ] New feature
* [ ] Documentation update

## Related issue

Closes #632

## Screenshot

N/A — backend performance optimization without UI changes.

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.
