### PR TITLE
fix: handle missing Gemini API key

### DIFF
--- a/backend/src/app/modules/ai_model/__tests__/ai_model.utils.test.ts
+++ b/backend/src/app/modules/ai_model/__tests__/ai_model.utils.test.ts
@@ -1,0 +1,45 @@
+import httpStatus from "http-status";
+import {
+  generateAlternateEndingsWithGemini,
+  generateWithGeminiStories,
+} from "../ai_model.utils";
+
+jest.mock("@google/generative-ai", () => ({
+  GoogleGenerativeAI: jest.fn().mockImplementation(() => ({
+    getGenerativeModel: jest.fn().mockReturnValue({
+      startChat: jest.fn(),
+    }),
+  })),
+  HarmBlockThreshold: {
+    BLOCK_LOW_AND_ABOVE: "BLOCK_LOW_AND_ABOVE",
+  },
+  HarmCategory: {
+    HARM_CATEGORY_HARASSMENT: "HARM_CATEGORY_HARASSMENT",
+    HARM_CATEGORY_HATE_SPEECH: "HARM_CATEGORY_HATE_SPEECH",
+  },
+}));
+
+jest.mock("../../../../config", () => ({
+  __esModule: true,
+  default: {
+    gemini_api_key: "",
+  },
+}));
+
+describe("ai_model.utils Gemini configuration", () => {
+  it("fails story generation when GEMINI_API_KEY is missing", async () => {
+    await expect(generateWithGeminiStories("space")).rejects.toMatchObject({
+      statusCode: httpStatus.INTERNAL_SERVER_ERROR,
+      message: expect.stringContaining("Gemini API key is not configured"),
+    });
+  });
+
+  it("fails alternate endings when GEMINI_API_KEY is missing", async () => {
+    await expect(
+      generateAlternateEndingsWithGemini("Title", "Story body", "Adventure")
+    ).rejects.toMatchObject({
+      statusCode: httpStatus.INTERNAL_SERVER_ERROR,
+      message: expect.stringContaining("Gemini API key is not configured"),
+    });
+  });
+});

--- a/backend/src/app/modules/ai_model/ai_model.utils.ts
+++ b/backend/src/app/modules/ai_model/ai_model.utils.ts
@@ -11,7 +11,10 @@ import { IAlternateEnding } from "./ai_model.interface";
 import ApiError from "../../../errors/api_error";
 import httpStatus from "http-status";
 
-const genAI = new GoogleGenerativeAI(config.gemini_api_key as string);
+const geminiApiKey = config.gemini_api_key?.trim() ?? "";
+const genAI = new GoogleGenerativeAI(geminiApiKey);
+const MISSING_GEMINI_API_KEY_MESSAGE =
+  "Gemini API key is not configured. Set GEMINI_API_KEY before using Gemini generation features.";
 
 const model = genAI.getGenerativeModel({
   model: "gemini-2.5-flash",
@@ -35,6 +38,15 @@ const safetySettings = [
     threshold: HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
   },
 ];
+
+const assertGeminiApiKeyConfigured = (): void => {
+  if (!geminiApiKey) {
+    throw new ApiError(
+      httpStatus.INTERNAL_SERVER_ERROR,
+      MISSING_GEMINI_API_KEY_MESSAGE
+    );
+  }
+};
 
 interface Story {
   uuid?: string;
@@ -72,24 +84,7 @@ export async function generateWithGeminiStories(
 ): Promise<Story[]> {
   throwIfAborted(signal);
 
-  if (!config.gemini_api_key) {
-    return [
-      {
-        uuid: uuidv4(),
-        title: "The Silent Watcher of the Reef",
-        content: "Deep below the surface of the cyan lagoon, a creature of ancient wisdom watched the shifts in the tides. It was a bioluminescent manta ray, carrying patterns on its back that mirrored the constellations above. For generations, the fishermen had told stories of the guide that saved lost ships, but none had seen it up close until today. A young diver, searching for lost artifacts, found herself caught in a strong undertow. As her air began to run low, a gentle warmth illuminated the dark water. The ray appeared, gliding effortlessly through the current, creating a path of calm water that allowed her to ascend safely back to the boat.",
-        tag: "Adventure",
-        imageURL: "https://images.unsplash.com/photo-1469854523086-cc02fe5d8800?q=80&w=600&auto=format&fit=crop",
-      },
-      {
-        uuid: uuidv4(),
-        title: "Lost Echoes of the Iron Citadel",
-        content: "The ruins of the Iron Citadel rose like rusted fingers from the salt flats of Arrakis-9. Major Vance adjusted his environmental suit as the twin suns began their descent. His sensors had picked up a rhythmic pulse originating from deep within the central chamber. It sounded like an old distress beacon, but this sector had been abandoned since the wars. Pushing past the heavy collapsed blast doors, Vance shone his light into the dark abyss. On the floor lay a deactivated service android, its power core long dead, yet its internal memory bank was warm to the touch. The story of what happened during the final siege was recorded here, waiting to be retrieved.",
-        tag: "Sci-Fi",
-        imageURL: "https://images.unsplash.com/photo-1451187580459-43490279c0fa?q=80&w=600&auto=format&fit=crop",
-      }
-    ];
-  }
+  assertGeminiApiKeyConfigured();
 
   try {
     const chatSession = model.startChat({
@@ -148,35 +143,7 @@ export async function generateAlternateEndingsWithGemini(
   tag: string,
   language: string = "English"
 ): Promise<IAlternateEnding[]> {
-  if (!config.gemini_api_key) {
-    return [
-      {
-        style: "Happy Ending",
-        ending: "The diver reached the surface safely and the ray disappeared into the deep, leaving behind a glowing seashell that she kept as a token of the encounter.",
-        fullStory: "Deep below the surface of the cyan lagoon, a creature of ancient wisdom watched the shifts in the tides. It was a bioluminescent manta ray, carrying patterns on its back that mirrored the constellations above. For generations, the fishermen had told stories of the guide that saved lost ships, but none had seen it up close until today. A young diver, searching for lost artifacts, found herself caught in a strong undertow. As her air began to run low, a gentle warmth illuminated the dark water. The ray appeared, gliding effortlessly through the current, creating a path of calm water that allowed her to ascend safely back to the boat. The diver reached the surface safely and the ray disappeared into the deep, leaving behind a glowing seashell that she kept as a token of the encounter.",
-      },
-      {
-        style: "Dark Ending",
-        ending: "But the warmth was an illusion; the ray was merely drawing her deeper into the abyssal trenches where the light of the sun could never reach.",
-        fullStory: "Deep below the surface of the cyan lagoon, a creature of ancient wisdom watched the shifts in the tides. It was a bioluminescent manta ray, carrying patterns on its back that mirrored the constellations above. For generations, the fishermen had told stories of the guide that saved lost ships, but none had seen it up close until today. A young diver, searching for lost artifacts, found herself caught in a strong undertow. As her air began to run low, a gentle warmth illuminated the dark water. The ray appeared, gliding effortlessly through the current, creating a path of calm water. But the warmth was an illusion; the ray was merely drawing her deeper into the abyssal trenches where the light of the sun could never reach.",
-      },
-      {
-        style: "Plot Twist Ending",
-        ending: "When she looked at the ray's patterns, she realized they were not stars, but coordinate maps of the underwater ruins she was searching for.",
-        fullStory: "Deep below the surface of the cyan lagoon, a creature of ancient wisdom watched the shifts in the tides. It was a bioluminescent manta ray, carrying patterns on its back that mirrored the constellations above. For generations, the fishermen had told stories of the guide that saved lost ships, but none had seen it up close until today. A young diver, searching for lost artifacts, found herself caught in a strong undertow. As her air began to run low, a gentle warmth illuminated the dark water. The ray appeared, gliding effortlessly through the current, creating a path of calm water that allowed her to ascend safely back to the boat. When she looked at the ray's patterns, she realized they were not stars, but coordinate maps of the underwater ruins she was searching for.",
-      },
-      {
-        style: "Open Ending",
-        ending: "She blinked, finding herself on the beach, the sun high in the sky. She wasn't sure if it was a dream or if she had actually met the guardian.",
-        fullStory: "Deep below the surface of the cyan lagoon, a creature of ancient wisdom watched the shifts in the tides. It was a bioluminescent manta ray, carrying patterns on its back that mirrored the constellations above. For generations, the fishermen had told stories of the guide that saved lost ships, but none had seen it up close until today. A young diver, searching for lost artifacts, found herself caught in a strong undertow. As her air began to run low, a gentle warmth illuminated the dark water. The ray appeared, gliding effortlessly through the current. She blinked, finding herself on the beach, the sun high in the sky. She wasn't sure if it was a dream or if she had actually met the guardian.",
-      },
-      {
-        style: "Cliffhanger Ending",
-        ending: "As she climbed onto the boat, she heard a voice inside her mind whisper: 'We will meet again, Vance.'",
-        fullStory: "Deep below the surface of the cyan lagoon, a creature of ancient wisdom watched the shifts in the tides. It was a bioluminescent manta ray, carrying patterns on its back that mirrored the constellations above. For generations, the fishermen had told stories of the guide that saved lost ships, but none had seen it up close until today. A young diver, searching for lost artifacts, found herself caught in a strong undertow. As her air began to run low, a gentle warmth illuminated the dark water. The ray appeared, gliding effortlessly through the current, creating a path of calm water that allowed her to ascend safely back to the boat. As she climbed onto the boat, she heard a voice inside her mind whisper: 'We will meet again, Vance.'"
-      }
-    ];
-  }
+  assertGeminiApiKeyConfigured();
 
   try {
     const chatSession = model.startChat({


### PR DESCRIPTION
## Screenshot (when helpful)

N/A - this is a backend error-handling fix and does not change the UI.

## What this PR does

This fixes the missing `GEMINI_API_KEY` path in the Gemini generation utility.

Before this change, the backend returned hard-coded story and alternate-ending data when the key was not configured. That made a broken local/staging/production config look like a successful generation response.

With this change:

- the configured Gemini key is trimmed once before use
- story generation fails with a clear `500` `ApiError` when `GEMINI_API_KEY` is missing
- alternate-ending generation uses the same missing-key guard
- the hard-coded fake story and alternate-ending fallback payloads are removed
- a regression test covers both missing-key paths

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #785

## More screenshots (optional)

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [ ] I have tested my changes.
- [x] I have done a self-review of the code.

## Local checks

- `git diff --check` passed.
- `npm run build --workspace backend` could not run because `tsc` is not installed in this checkout.
- `npm run test --workspace backend -- ai_model.utils.test.ts` could not run because `jest` is not installed in this checkout.
- I tried `npm install`, but the workspace filesystem is full (`ENOSPC`), so I could not install the missing backend toolchain locally.