### PR TITLE
fix: add story inspiration endpoint

### DIFF
--- a/backend/src/app/modules/story_inspiration/story_inspiration.controller.ts
+++ b/backend/src/app/modules/story_inspiration/story_inspiration.controller.ts
@@ -1,0 +1,22 @@
+import { Request, Response } from "express";
+import httpStatus from "http-status";
+import catchAsync from "../../../shared/catch_async";
+import sendResponse from "../../../shared/send_response";
+import { StoryInspirationService } from "./story_inspiration.service";
+
+const createStoryInspiration = catchAsync(
+  async (req: Request, res: Response) => {
+    const result = await StoryInspirationService.createStoryInspiration(req.body);
+
+    sendResponse(res, {
+      statusCode: httpStatus.OK,
+      success: true,
+      message: "Story inspiration generated successfully",
+      data: result,
+    });
+  }
+);
+
+export const StoryInspirationController = {
+  createStoryInspiration,
+};

--- a/backend/src/app/modules/story_inspiration/story_inspiration.interface.ts
+++ b/backend/src/app/modules/story_inspiration/story_inspiration.interface.ts
@@ -1,0 +1,7 @@
+export interface IStoryInspirationRequest {
+  intro: string;
+}
+
+export interface IStoryInspirationResponse {
+  ideas: string[];
+}

--- a/backend/src/app/modules/story_inspiration/story_inspiration.router.ts
+++ b/backend/src/app/modules/story_inspiration/story_inspiration.router.ts
@@ -1,0 +1,14 @@
+import express from "express";
+import validateRequest from "../../middleware/validate.request";
+import { StoryInspirationController } from "./story_inspiration.controller";
+import { StoryInspirationValidation } from "./story_inspiration.validation";
+
+const router = express.Router();
+
+router.post(
+  "/",
+  validateRequest(StoryInspirationValidation.createStoryInspirationSchema),
+  StoryInspirationController.createStoryInspiration
+);
+
+export const StoryInspirationRouter = router;

--- a/backend/src/app/modules/story_inspiration/story_inspiration.service.ts
+++ b/backend/src/app/modules/story_inspiration/story_inspiration.service.ts
@@ -1,0 +1,29 @@
+import {
+  IStoryInspirationRequest,
+  IStoryInspirationResponse,
+} from "./story_inspiration.interface";
+
+const cleanIntro = (intro: string): string => intro.trim().replace(/\s+/g, " ");
+
+const previewIntro = (intro: string): string =>
+  intro.length > 140 ? `${intro.slice(0, 137).trim()}...` : intro;
+
+const createStoryInspiration = async (
+  payload: IStoryInspirationRequest
+): Promise<IStoryInspirationResponse> => {
+  const intro = previewIntro(cleanIntro(payload.intro));
+
+  return {
+    ideas: [
+      `Raise the stakes around "${intro}" by giving the main character one urgent choice with a clear cost.`,
+      `Turn the opening into a mystery: add one detail that does not belong and let the character investigate it.`,
+      `Introduce a rival or ally who knows more about the situation than they are willing to admit.`,
+      `Move the next scene to a more pressured setting where the character cannot easily walk away.`,
+      `Reveal that the intro is hiding a larger conflict, then end the next scene on a decision or discovery.`,
+    ],
+  };
+};
+
+export const StoryInspirationService = {
+  createStoryInspiration,
+};

--- a/backend/src/app/modules/story_inspiration/story_inspiration.validation.ts
+++ b/backend/src/app/modules/story_inspiration/story_inspiration.validation.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+const createStoryInspirationSchema = z.object({
+  body: z.object({
+    intro: z
+      .string({
+        required_error: "Story intro is required",
+      })
+      .trim()
+      .min(1, "Story intro cannot be empty")
+      .max(1000, "Story intro must be 1000 characters or less"),
+  }),
+});
+
+export const StoryInspirationValidation = {
+  createStoryInspirationSchema,
+};

--- a/backend/src/router/index.ts
+++ b/backend/src/router/index.ts
@@ -22,6 +22,7 @@ import { AnalyticsRouter } from "../app/modules/analytics/analytics.router";
 import { BugReportRouter } from "../app/modules/bug_report/bug_report.router";
 import { RecommendationRouter } from "../app/modules/recommendation/recommendation.router";
 import { WriterApplicationRoutes } from "../app/modules/writer_application/writer_application.route";
+import { StoryInspirationRouter } from "../app/modules/story_inspiration/story_inspiration.router";
 
 const router = express.Router();
 
@@ -93,6 +94,10 @@ const modules = [
   {
     path: "/story-continuation",
     router: storyRoutes,
+  },
+  {
+    path: "/story-inspiration",
+    router: StoryInspirationRouter,
   },
   {
     path: "/contact",

--- a/frontend/src/components/story-inspiration-page/StoryInspirationPage.tsx
+++ b/frontend/src/components/story-inspiration-page/StoryInspirationPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { getBaseUrl } from '../../helpers/config';
 
 const StoryInspirationPage: React.FC = () => {
   const [intro, setIntro] = useState('');
@@ -11,15 +12,14 @@ const StoryInspirationPage: React.FC = () => {
     setError('');
     setIdeas([]);
     try {
-      // Replace with your backend API endpoint
-      const response = await fetch('/api/story-inspiration', {
+      const response = await fetch(`${getBaseUrl()}/story-inspiration`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ intro }),
       });
       if (!response.ok) throw new Error('Failed to fetch ideas');
       const data = await response.json();
-      setIdeas(data.ideas || []);
+      setIdeas(data.data?.ideas || data.ideas || []);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Something went wrong");
     } finally {


### PR DESCRIPTION
## Screenshot (when helpful)

N/A - this is an API route fix. The existing submit UI now points at a real backend endpoint, but there is no visual layout change.

## What this PR does

This fixes the missing Story Inspiration API route reported in #786.

Before this change, `StoryInspirationPage.tsx` posted to a route that did not exist, so submitting the form always ended in a 404. The frontend now uses the configured API base URL and calls `/story-inspiration`, which is registered under the backend `/api/v1` router.

The backend change adds a small `story_inspiration` module with:

- a POST `/api/v1/story-inspiration` route
- request validation for the `intro` field
- a controller/service pair that returns an `ideas` array
- frontend response handling for the backend `sendResponse` wrapper shape

This PR is raised as part of GSSoC 2026.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #786

## More screenshots (optional)

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [ ] I have tested my changes.
- [x] I have done a self-review of the code.

## Local checks

- `git diff --check` passed.
- `npm run build --workspace backend` could not run because `tsc` is not installed in this checkout.
- `npm run build --workspace frontend` could not run because `tsc` is not installed in this checkout.
- `npm install` was already attempted in this workspace and failed with `ENOSPC`, so I could not install the missing toolchain locally.