### PR TITLE
feat: Replace per-story scoring loop with single-pass `batch_score()` in `/score` endpoint [ GSSOC'26 ]

### DIFF
--- a/backend/ml/score_api.py
+++ b/backend/ml/score_api.py
@@ -9,7 +9,8 @@ Place at: backend/ml/score_api.py
 
 import logging
 from flask import Blueprint, request, jsonify
-from scorer import score as score_story
+from scorer import batch_score
+
 
 score_bp = Blueprint("score", __name__)
 logger = logging.getLogger(__name__)
@@ -83,27 +84,38 @@ def score_route():
     if len(stories) > MAX_STORIES:
         return jsonify({"error": f"Too many stories. Maximum allowed is {MAX_STORIES}"}), 413
 
-    results = []
+    # ── pre-validate each story before hitting the model ─────────────────
+    pre_errors = {}
+    valid_stories = []
 
     for story in stories:
         uuid = story.get("uuid", "unknown")
-
-        # Validate story fields before scoring
         error_msg = _validate_story(story)
         if error_msg:
             logger.warning("Validation failed for uuid=%s: %s", uuid, error_msg)
-            results.append({"uuid": uuid, "error": error_msg})
-            continue
+            pre_errors[uuid] = error_msg
+        else:
+            valid_stories.append(story)
 
+    # ── run batch scoring in one forward pass ─────────────────────────────
+    scored = []
+    if valid_stories:
         try:
-            scores = score_story(story["content"], prompt)
-            results.append({"uuid": uuid, **scores})
+            scored = batch_score(valid_stories, prompt)
         except FileNotFoundError as e:
-            logger.error("Scorer model missing for uuid=%s: %s", uuid, e)
-            results.append({"uuid": uuid, "error": "Scorer model unavailable", "error_code": "MODEL_UNAVAILABLE"})
+            logger.error("Scorer model missing: %s", e)
+            return jsonify({
+                "error": "Scorer model unavailable",
+                "error_code": "MODEL_UNAVAILABLE"
+            }), 503
         except Exception as e:
-            logger.exception("Unexpected scoring error for uuid=%s", uuid)
-            results.append({"uuid": uuid, "error": str(e)})
+            logger.exception("Unexpected error during batch scoring")
+            return jsonify({"error": str(e)}), 500
+
+    # ── merge validation errors back into results ─────────────────────────
+    results = scored + [
+        {"uuid": uuid, "error": msg} for uuid, msg in pre_errors.items()
+    ]
 
     return jsonify({
         "scores": results,

--- a/backend/ml/scorer.py
+++ b/backend/ml/scorer.py
@@ -133,3 +133,79 @@ def score(story_text: str, prompt_text: str) -> dict:
         "relevance": round(relevance, 3),
         "overall": round((coherence + creativity + relevance) / 3, 3),
     }
+    
+def batch_score(stories: list[dict], prompt_text: str) -> list[dict]:
+    """
+    Score multiple stories in a single model forward pass.
+    Much faster than calling score() in a loop for large batches.
+
+    Args:
+        stories   : list of { "uuid": str, "content": str }
+        prompt_text: the shared prompt string
+
+    Returns:
+        list of { uuid, coherence, creativity, relevance, overall }
+
+    Raises:
+        ValueError        : if prompt_text is empty or stories is empty
+        FileNotFoundError : if model artifacts are missing
+    """
+    if not isinstance(prompt_text, str) or not prompt_text.strip():
+        raise ValueError("prompt_text must be a non-empty string")
+
+    if not stories:
+        raise ValueError("stories list must not be empty")
+
+    _load_artifacts()  # load once for the whole batch
+
+    valid   = []
+    skipped = []
+
+    for s in stories:
+        content = s.get("content", "")
+        if not isinstance(content, str) or not content.strip():
+            skipped.append({"uuid": s.get("uuid", "unknown"),
+                            "error": "Empty or missing content"})
+        else:
+            valid.append(s)
+
+    results = list(skipped)  # start with pre-filled errors
+
+    if not valid:
+        return results
+
+    # ── encode all valid stories in one shot ──────────────────────────────
+    story_seqs = _tokenizer.texts_to_sequences(
+        [s["content"] for s in valid]
+    )
+    story_pad = pad_sequences(
+        story_seqs, maxlen=MAX_LEN, padding="post", truncating="post"
+    )
+
+    # prompt is the same for every story — tile it to match batch size
+    prompt_seq = _tokenizer.texts_to_sequences([prompt_text])
+    prompt_pad = pad_sequences(
+        prompt_seq, maxlen=MAX_LEN, padding="post", truncating="post"
+    )
+    prompt_tiled = np.tile(prompt_pad, (len(valid), 1))
+
+    # ── single forward pass ───────────────────────────────────────────────
+    coh_arr, cre_arr, rel_arr = _model.predict(
+        {"story": story_pad, "prompt": prompt_tiled},
+        verbose=0,
+        batch_size=32,
+    )
+
+    for i, story in enumerate(valid):
+        coh = float(coh_arr[i][0])
+        cre = float(cre_arr[i][0])
+        rel = float(rel_arr[i][0])
+        results.append({
+            "uuid":       story["uuid"],
+            "coherence":  round(coh, 3),
+            "creativity": round(cre, 3),
+            "relevance":  round(rel, 3),
+            "overall":    round((coh + cre + rel) / 3, 3),
+        })
+
+    return results


### PR DESCRIPTION
## What this PR does

Replaces the per-story `score()` loop in `/score` with a single `batch_score()` call that runs one `model.predict()` for the entire batch.

Previously, scoring 10 stories meant 10 separate BiLSTM forward passes. Now all valid stories are encoded in one vectorized `texts_to_sequences` call, the prompt is tiled with `np.tile`, and the model runs once with `batch_size=32`.

**Changes in `backend/ml/scorer.py`:**
- Added `batch_score(stories, prompt_text)` — encodes all stories at once and runs a single `model.predict()` call
- Invalid/empty stories are filtered before the model call and returned with per-story errors

**Changes in `backend/ml/score_api.py`:**
- Replaced `from scorer import score as score_story` with `from scorer import batch_score`
- Replaced the `for` loop with a pre-validation pass + single `batch_score()` call
- `FileNotFoundError` now returns HTTP 503 at route level since it affects the whole batch

## Type of change

- [x] New feature
- [x] Code refactor

## Related issue

Closes #797 

## Screenshot

Before — N model calls for N stories:
```
batch of 5 stories → model.predict() × 5
```
After — always one model call:
```
batch of 5 stories → model.predict() × 1  (batch_size=32)
```

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.