### PR TITLE
fix: return not found for missing user delete

### DIFF
--- a/backend/src/app/modules/user/user.controller.ts
+++ b/backend/src/app/modules/user/user.controller.ts
@@ -61,23 +61,17 @@ const updateUser = async (req: Request, res: Response) => {
   }
 };
 
-const deleteUser = async (req: Request, res: Response) => {
-  try {
-    const id = routeParam(req.params.id);
+const deleteUser = catchAsync(async (req: Request, res: Response) => {
+  const id = routeParam(req.params.id);
 
-    await UserService.deleteUser(id);
+  await UserService.deleteUser(id);
 
-    sendResponse(res, {
-      statusCode: httpStatus.OK,
-      success: true,
-      message: "User deleted successfully!",
-    });
-  } catch (error) {
-    res.status(httpStatus.BAD_REQUEST).json({
-      message: "Fail to get users!",
-    });
-  }
-};
+  sendResponse(res, {
+    statusCode: httpStatus.OK,
+    success: true,
+    message: "User deleted successfully!",
+  });
+});
 
 const applyForWriter = catchAsync(async (req: Request, res: Response) => {
   const token = await getToken(req);

--- a/backend/src/app/modules/user/user.service.ts
+++ b/backend/src/app/modules/user/user.service.ts
@@ -71,6 +71,12 @@ const updateUser = async (token: ITokenPayload, payload: Partial<IUser>) => {
 };
 
 const deleteUser = async (id: string): Promise<void> => {
+  const userExists = await User.exists({ _id: id });
+
+  if (!userExists) {
+    throw new ApiError(httpStatus.NOT_FOUND, "User not found!");
+  }
+
   // Get all posts authored by this user
   const userPosts = await Post.find({ author: id }).select("_id").lean();
   const postIds = userPosts.map((p) => p._id);
@@ -112,7 +118,11 @@ const deleteUser = async (id: string): Promise<void> => {
   await Post.deleteMany({ author: id });
 
   // Finally delete the user
-  await User.deleteOne({ _id: id });
+  const result = await User.deleteOne({ _id: id });
+
+  if (result.deletedCount === 0) {
+    throw new ApiError(httpStatus.NOT_FOUND, "User not found!");
+  }
 };
 
 const applyForWriter = async (token: ITokenPayload) => {


### PR DESCRIPTION
## Screenshot (when helpful)

N/A - this is a backend API error-handling fix and does not change the UI.

## What this PR does

This fixes the user deletion path reported in #812.

Before this change, `deleteUser` called `User.deleteOne({ _id: id })` and returned successfully without checking whether MongoDB deleted a document. A delete request for a valid-looking but nonexistent user id could therefore be reported as successful.

With this change:

- `deleteUser` checks the `deleteOne` result
- `deletedCount === 0` now throws `ApiError(httpStatus.NOT_FOUND, "User not found!")`
- the delete controller uses `catchAsync`, so the not-found error reaches the global error handler instead of being converted into a generic 400 response

This PR is raised as part of GSSoC 2026.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #812

## More screenshots (optional)

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [ ] I have tested my changes.
- [x] I have done a self-review of the code.

## Local checks

- `git diff --check` passed.
- `npm run build --workspace backend` could not run because `tsc` is not installed in this checkout.
- `npm install` was already attempted in this workspace and failed with `ENOSPC`, so I could not install the missing backend toolchain locally.