### PR TITLE
fix: use Date.now function default for post publishedAt (#814)

### DIFF
--- a/backend/src/app/modules/post/post.model.ts
+++ b/backend/src/app/modules/post/post.model.ts
@@ -23,7 +23,7 @@ export const PostSchema: Schema<IPost> = new Schema<IPost, PostModel>(
     isDeleted: { type: Boolean, default: false },
     deletedAt: { type: Date, default: null },
     deletedBy: { type: Schema.Types.ObjectId, ref: "User", default: null },
-    publishedAt: { type: Date, default: new Date() },
+    publishedAt: { type: Date, default: Date.now },
     updatedBy: { type: Schema.Types.ObjectId, ref: "User", default: null },
     attachments: [{ type: String }],
     comments: [{ type: Schema.Types.ObjectId, ref: "Comment" }],


### PR DESCRIPTION
## What this PR does:

Fixes a subtle Mongoose schema bug where `publishedAt` used `default: new Date()`.
`new Date()` is evaluated **once** when the schema file is loaded, so every post created
during the same process lifetime shares the identical stale timestamp from server startup.
Changed to `default: Date.now` — a function reference that Mongoose calls per-document,
giving each post its own accurate creation-time value.
## Type of change: 
Bug fix

## Related issue: 
Closes #814
 ## Screenshots: 
N/A — backend-only one-line schema fix, no UI change
## Checklist:
 Related issue filled in
 Tested changes
 Self-reviewed code

*Contributing under GSSoC'26* 