### PR TITLE
fix: remove hardcoded admin credentials and add secure seed script

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,18 @@
 
    > Never commit `backend/.env` or `frontend/.env`. Only `.env.example` files belong in git.
 
-4. **Run apps**
+4. **First-Time Setup (Admin Seeding)**
+
+   Before starting the server for the first time, you must create an admin user:
+   
+   ```bash
+   cd backend
+   npx ts-node scripts/seed-admin.ts
+   ```
+   
+   Make sure `ADMIN_EMAIL` and `ADMIN_PASSWORD` are set in your `backend/.env` file.
+
+5. **Run apps**
 
    - **Both** (two terminals or one combined process):
 
@@ -86,7 +97,7 @@
    - **Backend only:** `npm run dev:backend` — API (default port **5000** if `PORT` is unset).
    - **Frontend only:** `npm run dev:frontend` — Vite dev server on **http://localhost:4001**
 
-5. **Production builds**
+6. **Production builds**
 
    ```bash
    npm run build

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,7 +13,8 @@ JWT_REFRESH_SECRET=replace_with_refresh_token_secret
 JWT_EXPIRES_IN=60d
 JWT_REFRESH_EXPIRES_IN=120d
 DEFAULT_ADMIN_PASSWORD=replace_with_default_admin_password
-
+ADMIN_EMAIL=your-admin@example.com
+ADMIN_PASSWORD=your-secure-password-here
 # AI providers
 OPEN_AI_KEY=
 GEMINI_API_KEY=

--- a/backend/scripts/seed-admin.ts
+++ b/backend/scripts/seed-admin.ts
@@ -1,0 +1,41 @@
+import bcrypt from "bcryptjs";
+import mongoose from "mongoose";
+import { User } from "../src/app/modules/user/user.model";
+import config from "../src/config";
+
+const seedAdmin = async () => {
+  const email = process.env.ADMIN_EMAIL;
+  const password = process.env.ADMIN_PASSWORD;
+
+  if (!email || !password) {
+    throw new Error("ADMIN_EMAIL and ADMIN_PASSWORD must be set in environment variables.");
+  }
+
+  // Connect to database
+  await mongoose.connect(config.database_url as string);
+
+  const existing = await User.findOne({ email });
+  if (existing) {
+    console.log("Admin user already exists. Skipping.");
+    await mongoose.disconnect();
+    return;
+  }
+
+  const hashedPassword = await bcrypt.hash(password, 12);
+  await User.create({
+    email,
+    name: "Administrator",
+    password: hashedPassword,
+    role: "admin",
+    subscriptionType: "premium",
+    status: "active",
+  });
+
+  console.log(`Admin user created: ${email}`);
+  await mongoose.disconnect();
+};
+
+seedAdmin().catch((err) => {
+  console.error(err);
+  mongoose.disconnect();
+});

--- a/backend/src/app/modules/auth/auth.service.ts
+++ b/backend/src/app/modules/auth/auth.service.ts
@@ -16,21 +16,6 @@ const googleClient = new OAuth2Client(config.google_client_id);
 
 const login = async (payload: AuthModel) => {
   const { email: userEmail, password } = payload;
-  
-  if (userEmail === "admin@gmail.com" && password === "admin@123") {
-    const adminUser = await User.findOne({ email: "admin@gmail.com" });
-    if (!adminUser) {
-      await User.create({
-        email: "admin@gmail.com",
-        name: "Administrator",
-        password: "admin@123",
-        role: "admin",
-        subscriptionType: "premium",
-        status: "active",
-      });
-    }
-  }
-
   const isExistUser = await User.findOne({ email: userEmail });
   if (!isExistUser) {
     throw new ApiError(httpStatus.NOT_FOUND, "User not found!");


### PR DESCRIPTION


N/A - Backend security fix.

## What this PR does

This PR removes a critical security backdoor where admin credentials (`admin@gmail.com` / `admin@123`) were hardcoded directly in the `login()` function in `auth.service.ts`. 

To replace this, a secure `scripts/seed-admin.ts` script has been added which reads `ADMIN_EMAIL` and `ADMIN_PASSWORD` from environment variables and safely creates the admin user with a bcrypt-hashed password before the server starts. The `.env.example` and `README.md` have been updated to reflect the new First-Time Setup instructions.

## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [x] Bug fix
- [x] New feature
- [x] Code refactor
- [x] Documentation update

## Related issue

Fixes #820  <!-- Note: Please replace <ISSUE_NUMBER> with the actual issue number on GitHub -->

## More screenshots (optional)

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason. (N/A - backend security fix)
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.