### PR TITLE
fix: protect POST /api/stories/branching with auth middleware

### DIFF
--- a/backend/src/routes/stories.ts
+++ b/backend/src/routes/stories.ts
@@ -2,6 +2,8 @@ import express from "express";
 import { z } from "zod";
 import validateRequest from "../app/middleware/validate.request";
 import { StoryBranchingController } from "../controllers/storyBranchingController";
+import auth from "../app/middleware/auth.middleware";
+import { ENUM_USER_ROLE } from "../enums/user";
 
 const router = express.Router();
 
@@ -15,6 +17,12 @@ const branchingStorySchema = z.object({
 
 router.post(
   "/branching",
+  auth(
+    ENUM_USER_ROLE.USER,
+    ENUM_USER_ROLE.WRITER,
+    ENUM_USER_ROLE.ADMIN,
+    ENUM_USER_ROLE.SUPER_ADMIN
+  ),
   validateRequest(branchingStorySchema),
   StoryBranchingController.createBranchingStory
 );


### PR DESCRIPTION
## What this PR does
The branching story generation endpoint `POST /api/stories/branching` in `backend/src/routes/stories.ts` had no authentication middleware, allowing any unauthenticated user to generate stories using the Gemini API and completely bypass the subscription quota system.

This PR adds `auth()` middleware to the route, consistent with how the main AI generation routes in `ai_model.router.ts` are already protected.

## Files Changed
- `backend/src/routes/stories.ts`

## Type of change
- [x] Bug fix

## Related issue
Closes #765

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.