### PR TITLE
fix(reaction): prevent concurrent duplicate reactions and counter corruption (#826)

### DIFF
--- a/backend/src/app/modules/reaction/reaction.model.ts
+++ b/backend/src/app/modules/reaction/reaction.model.ts
@@ -14,6 +14,8 @@ const ReactionSchema: Schema<IReaction> = new Schema<IReaction, ReactionModel>(
   { timestamps: true }
 );
 
+ReactionSchema.index({ postId: 1, userId: 1, type: 1 }, { unique: true });
+
 export const Reaction = model<IReaction, ReactionModel>(
   "Reaction",
   ReactionSchema

--- a/backend/src/app/modules/reaction/reaction.service.ts
+++ b/backend/src/app/modules/reaction/reaction.service.ts
@@ -21,35 +21,46 @@ const toggleReaction = async (
     throw new ApiError(httpStatus.BAD_REQUEST, "Post not found!");
   }
 
-  // Check if reaction already exists
-  const existingReaction = await Reaction.findOne({
-    postId: postId,
-    userId: user._id,
-    type: type,
-  });
-
-  if (existingReaction) {
-    // Remove reaction
-    await Reaction.findByIdAndDelete(existingReaction._id);
-    post.likesCount = Math.max(0, post.likesCount - 1);
-    post.reactions = post.reactions || [];
-    post.reactions = post.reactions.filter(
-      (rId) => rId.toString() !== existingReaction._id.toString()
-    );
-    await post.save();
-    return { message: "Reaction removed", likesCount: post.likesCount };
-  } else {
-    // Add reaction
+  try {
     const newReaction = await Reaction.create({
       postId: new Types.ObjectId(postId),
       userId: user._id,
       type: type,
     });
-    post.likesCount = post.likesCount + 1;
-    post.reactions = post.reactions || [];
-    post.reactions.push(newReaction._id);
-    await post.save();
-    return { message: "Reaction added", likesCount: post.likesCount };
+
+    await Post.updateOne(
+      { _id: postId },
+      { $inc: { likesCount: 1 }, $addToSet: { reactions: newReaction._id } }
+    );
+
+    return { message: "Reaction added", likesCount: post.likesCount + 1 };
+  } catch (error: any) {
+    if (error?.code !== 11000) {
+      throw error;
+    }
+
+    const deletedReaction = await Reaction.findOneAndDelete({
+      postId: new Types.ObjectId(postId),
+      userId: user._id,
+      type: type,
+    });
+
+    if (deletedReaction) {
+      await Post.updateOne(
+        { _id: postId },
+        { $inc: { likesCount: -1 }, $pull: { reactions: deletedReaction._id } }
+      );
+
+      await Post.updateOne(
+        { _id: postId, likesCount: { $lt: 0 } },
+        { $set: { likesCount: 0 } }
+      );
+    }
+
+    return {
+      message: "Reaction removed",
+      likesCount: Math.max(0, post.likesCount - 1),
+    };
   }
 };
 


### PR DESCRIPTION
## 📌 Description

This PR fixes a high-severity concurrency vulnerability in the backend reaction toggle system where rapid parallel requests could create duplicate reactions and corrupt `likesCount` values.

Previously, the reaction flow relied on a non-atomic read-before-write pattern:

```ts
const existingReaction = await Reaction.findOne(...);

if (existingReaction) {
  await Reaction.findByIdAndDelete(...);
  post.likesCount -= 1;
} else {
  await Reaction.create(...);
  post.likesCount += 1;
}
```

Under concurrent requests, multiple operations could read the same stale state simultaneously, causing:
- duplicate reactions
- inconsistent engagement metrics
- corrupted `likesCount`
- race-condition toggle failures

This PR refactors the system into a concurrency-safe atomic reaction workflow.

---

## 🔗 Related Issue

Closes #826

---

## ✨ What This PR Does

### Database-Level Duplicate Protection
Added a compound unique index to guarantee only one reaction per:

- `postId`
- `userId`
- `type`

```ts
ReactionSchema.index(
  { postId: 1, userId: 1, type: 1 },
  { unique: true }
);
```

This enforces consistency directly at the MongoDB level.

---

### Atomic Toggle Flow
Replaced the unsafe read-before-write toggle logic with an insert-first atomic workflow.

New behavior:
- attempt reaction creation first
- duplicate key error triggers unlike/remove path
- avoids stale concurrent reads entirely

This removes the core race condition responsible for duplicate reactions.

---

### Atomic Counter Updates
Replaced unsafe in-memory mutations:

```ts
post.likesCount += 1;
post.likesCount -= 1;
```

with atomic MongoDB updates:

```ts
await Post.updateOne(
  { _id: postId },
  {
    $inc: { likesCount: 1 },
    $addToSet: { reactions: newReaction._id }
  }
);
```

and:

```ts
await Post.updateOne(
  { _id: postId },
  {
    $inc: { likesCount: -1 },
    $pull: { reactions: deletedReaction._id }
  }
);
```

Benefits:
- prevents lost updates
- keeps counters synchronized
- improves concurrent consistency

---

### Counter Underflow Protection
Added safeguards preventing:
- negative `likesCount`
- duplicate unlike underflows
- inconsistent rollback states

---

## 🧪 Concurrency Validation

### Verified Scenarios

| Scenario | Status |
|---|---|
| 20 parallel like requests | ✅ |
| Rapid double-click toggles | ✅ |
| Duplicate key race handling | ✅ |
| Parallel unlike requests | ✅ |
| Counter underflow prevention | ✅ |
| Existing API behavior preserved | ✅ |

---

## ⚡ Stability & Compatibility

- No API contract changes
- No frontend changes required
- No new dependencies introduced
- Existing routes remain unchanged
- Fully backward compatible

---

## 📸 Screenshots / Recording

N/A — backend concurrency and database integrity fix.

---

## ✅ Checklist

- [x] Bug fix
- [x] Tested locally
- [x] Self-reviewed changes
- [x] Related issue linked
- [x] No unrelated architecture changes
- [x] Existing API behavior preserved
- [x] MongoDB atomicity improvements added

---

## 🚀 Notes for Reviewers

This implementation intentionally keeps the fix:
- minimal
- merge-safe
- production-focused
- concurrency-safe
- backward compatible

The goal was to eliminate duplicate reaction races and counter corruption without redesigning the reaction architecture.