### PR TITLE
fix: add missing auth and ENUM_USER_ROLE imports to analytics.router.ts

### DIFF
--- a/backend/src/app/modules/analytics/analytics.router.ts
+++ b/backend/src/app/modules/analytics/analytics.router.ts
@@ -1,5 +1,7 @@
 import express from "express";
 import { AnalyticsController } from "./analytics.controller";
+import auth from "../../middleware/auth.middleware";
+import { ENUM_USER_ROLE } from "../../../enums/user";
 
 const router = express.Router();
 


### PR DESCRIPTION
## What this PR does
`backend/src/app/modules/analytics/analytics.router.ts` used `auth()` and `ENUM_USER_ROLE` on three routes (`/productive-hours`, `/emotion-distribution`, `/mood-timeline`) without importing them, causing TypeScript build failures:
-error TS2304: Cannot find name 'auth'.
-error TS2304: Cannot find name 'ENUM_USER_ROLE'.

This PR adds the two missing imports, consistent with how every other router in the codebase (e.g. `post.router.ts`, `user.router.ts`) imports them.

## Files Changed
- `backend/src/app/modules/analytics/analytics.router.ts`

## Type of change
- [x] Bug fix

## Related issue
Closes #833 

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.