### PR TITLE
refactor: extract buildUserInfo helper to eliminate duplicate user object construction

### DIFF
--- a/frontend/src/services/auth.service.ts
+++ b/frontend/src/services/auth.service.ts
@@ -18,6 +18,17 @@ type AuthUserInfo = {
   iat: number;
 };
 
+const buildUserInfo = (decodedData: AuthUserInfo): AuthUserInfo => ({
+  email: decodedData.email || "",
+  userId: decodedData.userId || "",
+  name: decodedData.name || "",
+  postsCount: decodedData.postsCount || 0,
+  role: decodedData.role || "guest",
+  subscriptionType: decodedData.subscriptionType || "free",
+  exp: decodedData.exp || 0,
+  iat: decodedData.iat || 0,
+});
+
 const getValidDecodedToken = () => {
   const authToken = getFromLocalStorage(AUTH_KEY);
 
@@ -31,17 +42,7 @@ const getValidDecodedToken = () => {
       removeFromLocalStorage(AUTH_KEY);
       return null;
     }
-      const userInfo = {
-        email: decodedData.email || "",
-        userId: decodedData.userId || "",
-        name: decodedData.name || "",
-        postsCount: decodedData.postsCount || 0,
-        role: decodedData.role || "guest",
-        subscriptionType: decodedData.subscriptionType || "free",
-        exp: decodedData.exp || 0,
-        iat: decodedData.iat || 0,
-      };
-      return userInfo;
+      return buildUserInfo(decodedData);
     } catch (error) {
       console.error("Invalid auth token:", error);
       removeFromLocalStorage(AUTH_KEY);
@@ -56,22 +57,7 @@ export const storeUserInfo = ({ accessToken }: AccessToken) => {
 };
 
 export const getUserInfo = (): AuthUserInfo | null => {
-  const decodedData = getValidDecodedToken();
-
-  if (!decodedData) {
-    return null;
-  }
-
-  return {
-    email: decodedData.email || "",
-    userId: decodedData.userId || "",
-    name: decodedData.name || "",
-    postsCount: decodedData.postsCount || 0,
-    role: decodedData.role || "guest",
-    subscriptionType: decodedData.subscriptionType || "free",
-    exp: decodedData.exp || 0,
-    iat: decodedData.iat || 0,
-  };
+  return getValidDecodedToken();
 };
 export const isLoggedIn = () => {
   return !!getValidDecodedToken();


### PR DESCRIPTION
Fixes #838 

## Problem
The user info object was being constructed twice in `auth.service.ts` — 
once inside `getValidDecodedToken` and again inside `getUserInfo`. 
This meant any new field added to `AuthUserInfo` had to be updated 
in two places, risking silent data mismatch bugs in production.

## Root Cause
No shared helper function existed for building the user info object, 
so both functions duplicated the same 8-field object construction.

## Fix
Extracted a `buildUserInfo` helper function that constructs the 
`AuthUserInfo` object in one place. Both `getValidDecodedToken` and 
`getUserInfo` now use this single source of truth.

## Testing
- [ ] Login works correctly
- [ ] Logout works correctly
- [ ] User info loads correctly after login
- [ ] Expired token auto logs out user

## Type
- [x] Refactor / Bug fix