### PR TITLE
fix: remove redundant client-side tag filtering that conflicted with …

### DIFF
--- a/frontend/src/components/post/post.component.tsx
+++ b/frontend/src/components/post/post.component.tsx
@@ -38,16 +38,7 @@ const ExploreComponent = () => {
 
   const { data, isLoading } = useGetPostListsQuery({ ...query });
 
-  const filteredPosts =
-    selectedTags.length === 0
-      ? data?.posts || []
-      : (data?.posts || []).filter((post: Post) =>
-          selectedTags.some(
-            (selectedTag) =>
-              post.tag?.toLowerCase().trim() ===
-              selectedTag.toLowerCase().replace("#", "").trim(),
-          ),
-        );
+  const filteredPosts = data?.posts || [];
 
   const resetAllStates = () => {
     setSortBy("createdAt");


### PR DESCRIPTION
Fixes #844 

## Problem
Posts were being filtered twice — once by the API via the `genres` 
query param, and again on the client using different logic. This caused 
valid posts returned by the API to be incorrectly hidden from the user.

## Root Cause
The `filteredPosts` variable applied a second `.filter()` on top of 
already-filtered API results. The client filter compared `post.tag` 
against `selectedTag` using different string logic than the API, 
causing a mismatch.

## Fix
Removed the redundant client-side filter. `filteredPosts` now simply 
uses the API response directly since the server already handles 
genre/tag filtering correctly.

## Testing
- [ ] All posts load correctly with no filters applied
- [ ] Genre filter returns correct posts
- [ ] Tag filter returns correct posts
- [ ] Reset button restores all posts

## Type
- [x] Bug fix