### PR TITLE
fix : Throw ApiError on JSON parsing failure for branching story

### DIFF
--- a/backend/src/services/storyBranchingService.ts
+++ b/backend/src/services/storyBranchingService.ts
@@ -1,5 +1,7 @@
 import { GoogleGenerativeAI } from "@google/generative-ai";
 import config from "../config";
+import ApiError from "../errors/api_error";
+import httpStatus from "http-status";
 
 export interface IBranchingStoryRequest {
   storyContext: string;
@@ -13,13 +15,6 @@ export interface IBranchingStoryResponse {
   segmentIndex: number;
 }
 
-const FALLBACK_SEGMENT =
-  "The path ahead remains uncertain, but the story presses forward through the mist.";
-const FALLBACK_CHOICES = [
-  "Move forward carefully",
-  "Look for another path",
-  "Pause and reconsider",
-];
 
 const genAI = new GoogleGenerativeAI(config.gemini_api_key as string);
 
@@ -32,23 +27,26 @@ const stripCodeFences = (text: string): string =>
 
 const parsePayload = (text: string): { storySegment: string; choices: string[] } => {
   const cleaned = stripCodeFences(text);
-  const parsed = JSON.parse(cleaned) as {
-    storySegment?: unknown;
-    choices?: unknown;
-  };
+  let parsed: any;
+  
+  try {
+    parsed = JSON.parse(cleaned);
+  } catch (error) {
+    throw new ApiError(httpStatus.INTERNAL_SERVER_ERROR, "Failed to parse AI response as JSON");
+  }
 
   if (
     typeof parsed.storySegment !== "string" ||
     !Array.isArray(parsed.choices) ||
     parsed.choices.length !== 3 ||
-    parsed.choices.some((choice) => typeof choice !== "string" || !choice.trim())
+    parsed.choices.some((choice: any) => typeof choice !== "string" || !choice.trim())
   ) {
-    throw new Error("Invalid branching story payload");
+    throw new ApiError(httpStatus.BAD_REQUEST, "Invalid branching story payload");
   }
 
   return {
     storySegment: parsed.storySegment.trim(),
-    choices: parsed.choices.map((choice) => choice.trim()),
+    choices: parsed.choices.map((choice: string) => choice.trim()),
   };
 };
 
@@ -90,11 +88,6 @@ const getSegmentIndex = (storyContext: string): number => {
   return completedChoices + 1;
 };
 
-const createFallbackResponse = (storyContext: string): IBranchingStoryResponse => ({
-  storySegment: FALLBACK_SEGMENT,
-  choices: [...FALLBACK_CHOICES],
-  segmentIndex: getSegmentIndex(storyContext),
-});
 
 const createBranchingStory = async (
   payload: IBranchingStoryRequest
@@ -118,7 +111,10 @@ const createBranchingStory = async (
     };
   } catch (error) {
     console.error("Branching story generation failed:", error);
-    return createFallbackResponse(storyContext);
+    if (error instanceof ApiError) {
+      throw error;
+    }
+    throw new ApiError(httpStatus.INTERNAL_SERVER_ERROR, "Branching story generation failed");
   }
 };
 


### PR DESCRIPTION
This pull request refactors error handling in the `storyBranchingService.ts` to use a consistent API error response model instead of returning fallback story content. The changes improve error reporting and ensure that invalid AI responses or internal errors are surfaced as proper HTTP errors.

**Error handling improvements:**

* Replaced generic `Error` throws with `ApiError` instances, providing specific HTTP status codes for JSON parsing failures and invalid AI payloads.
* Updated the main `createBranchingStory` function to throw `ApiError` on failures instead of returning a fallback response, ensuring errors are handled consistently.
* Removed the fallback story segment and choices, as well as the `createFallbackResponse` function, so the service no longer returns generic story content on failure.

**Dependency and type updates:**

* Added imports for `ApiError` and `httpStatus` to support the new error handling approach.
* Added explicit type annotations for variables and function parameters to improve type safety and clarity.


Closes #846 