### PR TITLE
fix: evaluate share URL and title inside handlers to use loaded post data

### DIFF
--- a/frontend/src/components/post/post.details.component.tsx
+++ b/frontend/src/components/post/post.details.component.tsx
@@ -165,35 +165,31 @@ const PostDetailsComponent = () => {
     return email === currentUser?.email;
   });
 
-  const shareUrl = window.location.href;
-
-  const shareTitle = post?.title || "Check out this story!";
-
   const handleTwitterShare = () => {
+    const currentUrl = window.location.href;
+    const currentTitle = post?.title || "Check out this story!";
     const url = `https://twitter.com/intent/tweet?url=${encodeURIComponent(
-      shareUrl
-    )}&text=${encodeURIComponent(shareTitle)}`;
-
+      currentUrl
+    )}&text=${encodeURIComponent(currentTitle)}`;
     window.open(url, "_blank", "noopener,noreferrer");
   };
 
   const handleLinkedInShare = () => {
+    const currentUrl = window.location.href;
     const url = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(
-      shareUrl
+      currentUrl
     )}`;
-
     window.open(url, "_blank", "noopener,noreferrer");
   };
 
   const handleEmailShare = () => {
-    const subject = `Story Spark AI - ${shareTitle}`;
-
-    const body = `Check out this interesting story on Story Spark AI: "${shareTitle}"\n\nRead it here: ${shareUrl}`;
-
+    const currentUrl = window.location.href;
+    const currentTitle = post?.title || "Check out this story!";
+    const subject = `Story Spark AI - ${currentTitle}`;
+    const body = `Check out this interesting story on Story Spark AI: "${currentTitle}"\n\nRead it here: ${currentUrl}`;
     const url = `mailto:?subject=${encodeURIComponent(
       subject
     )}&body=${encodeURIComponent(body)}`;
-
     window.location.href = url;
   };
 


### PR DESCRIPTION
Fixes #852 

## Problem
`shareUrl` and `shareTitle` were declared as plain `const` variables 
at component render time, before post data finished loading. This meant 
`shareTitle` always resolved to the fallback `"Check out this story!"` 
when share buttons were clicked, because `post?.title` was still 
`undefined` at initial render.

## Root Cause
```ts
// ❌ Evaluated at render before post loads
const shareUrl = window.location.href;
const shareTitle = post?.title || "Check out this story!";
```

## Fix
Moved URL and title evaluation inside each share handler so they are 
computed at click time, when post data is fully loaded.

## Testing
- [ ] Twitter share button uses correct post title
- [ ] LinkedIn share button uses correct post URL
- [ ] Email share uses correct post title in subject and body

## Type
- [x] Bug fix