### PR TITLE
fix: resolve streamlit artifact paths

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -14,8 +14,13 @@ Place at: story-spark-ai/ml/app.py
 """
 
 import sys
-import os
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "ml"))
+from pathlib import Path
+
+APP_DIR = Path(__file__).resolve().parent
+ML_DIR = APP_DIR / "ml"
+SAVED_DIR = ML_DIR / "saved"
+
+sys.path.insert(0, str(ML_DIR))
 from ml.score_api import score_bp
 import json
 import random
@@ -120,17 +125,22 @@ st.markdown("""
 @st.cache_resource(show_spinner="Loading model…")
 def load_artifacts():
     """Returns (model, scaler, threshold) or raises if train.py hasn't been run."""
-    import os, joblib
+    import joblib
     from tensorflow.keras.models import load_model as keras_load
 
-    missing = [p for p in ("ml/saved/model.keras", "ml/saved/scaler.pkl", "ml/saved/threshold.json")
-               if not os.path.exists(p)]
+    artifact_paths = {
+        "model": SAVED_DIR / "model.keras",
+        "scaler": SAVED_DIR / "scaler.pkl",
+        "threshold": SAVED_DIR / "threshold.json",
+    }
+    missing = [str(path) for path in artifact_paths.values() if not path.exists()]
     if missing:
         raise FileNotFoundError(missing)
 
-    model     = keras_load("ml/saved/model.keras")
-    scaler    = joblib.load("ml/saved/scaler.pkl")
-    threshold = json.load(open("ml/saved/threshold.json"))["threshold"]
+    model     = keras_load(artifact_paths["model"])
+    scaler    = joblib.load(artifact_paths["scaler"])
+    with artifact_paths["threshold"].open() as fh:
+        threshold = json.load(fh)["threshold"]
     return model, scaler, threshold
 
 


### PR DESCRIPTION
@ronisarkarexe  I already completed this issue can you add gssoc tag in it

## What this PR does

Fixes the Streamlit model artifact loading path in `backend/app.py`.

Previously, `load_artifacts()` used hardcoded relative paths like `ml/saved/model.keras`, which depended on the current working directory. When the app was launched from `backend/ml`, it looked for artifacts under `backend/ml/ml/saved/...` and failed with `FileNotFoundError`.

This PR resolves artifact paths from the location of `backend/app.py` using `pathlib`, so the app consistently loads files from `backend/ml/saved` regardless of where the Streamlit command is run.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Fixes #848 

## More screenshots (optional)

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.