### PR TITLE
Fix/double filter bug

### DIFF
--- a/frontend/src/components/post/post.component.tsx
+++ b/frontend/src/components/post/post.component.tsx
@@ -38,16 +38,7 @@ const ExploreComponent = () => {
 
   const { data, isLoading } = useGetPostListsQuery({ ...query });
 
-  const filteredPosts =
-    selectedTags.length === 0
-      ? data?.posts || []
-      : (data?.posts || []).filter((post: Post) =>
-          selectedTags.some(
-            (selectedTag) =>
-              post.tag?.toLowerCase().trim() ===
-              selectedTag.toLowerCase().replace("#", "").trim(),
-          ),
-        );
+  const filteredPosts = data?.posts || [];
 
   const resetAllStates = () => {
     setSortBy("createdAt");

--- a/package-lock.json
+++ b/package-lock.json
@@ -783,6 +783,7 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1227,6 +1228,7 @@
     "node_modules/@fortawesome/fontawesome-svg-core": {
       "version": "6.7.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.7.2"
       },
@@ -1974,6 +1976,7 @@
       "version": "5.0.6",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -2071,6 +2074,7 @@
     "node_modules/@types/node": {
       "version": "22.19.19",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2119,6 +2123,7 @@
       "version": "19.2.14",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2262,6 +2267,7 @@
       "version": "8.59.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
@@ -2530,6 +2536,7 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2861,6 +2868,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3026,6 +3034,7 @@
     "node_modules/chart.js": {
       "version": "4.5.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -3410,7 +3419,8 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cycle": {
       "version": "1.0.3",
@@ -3756,6 +3766,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4215,6 +4226,7 @@
       "version": "9.39.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4962,7 +4974,8 @@
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.15.0.tgz",
       "integrity": "sha512-dMW4CWBTUK1AEEDeZc1g4xpPGIrSf9fJF960qbTZmN/QwZIWY5wgliS6JWl9/25fpTGJrMRtSjGtOmPnfjZB+A==",
-      "license": "Standard 'no charge' license: https://gsap.com/standard-license."
+      "license": "Standard 'no charge' license: https://gsap.com/standard-license.",
+      "peer": true
     },
     "node_modules/has-binary-data": {
       "version": "0.1.1",
@@ -6506,6 +6519,7 @@
     "node_modules/react": {
       "version": "19.2.6",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6521,6 +6535,7 @@
     "node_modules/react-dom": {
       "version": "19.2.6",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6566,11 +6581,13 @@
     },
     "node_modules/react-is": {
       "version": "16.13.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-redux": {
       "version": "9.3.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -6706,7 +6723,8 @@
     },
     "node_modules/redux": {
       "version": "5.0.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -7406,6 +7424,7 @@
     "node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.4",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7626,6 +7645,7 @@
       "version": "5.7.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7805,6 +7825,7 @@
     "node_modules/vite": {
       "version": "6.4.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -7892,6 +7913,7 @@
     "node_modules/vite/node_modules/picomatch": {
       "version": "4.0.4",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8110,6 +8132,7 @@
     "node_modules/zod": {
       "version": "3.25.76",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Fixes #844
- **Description:** This PR removes duplicate frontend filtering logic in the Explore page to fix missing posts when selecting genres/tags.
- **Screenshots:** N/A (UI behavior fix, no visual redesign)

---

## What this PR does

This PR fixes a bug where posts were being filtered twice — once by the backend API (via genres query param) and again in the frontend using a `.filter()` operation.

This caused valid posts returned from the API to be incorrectly hidden when selecting genres or tags.

The fix removes the redundant frontend filtering and relies fully on the API response.

---

## Type of change

- [x] Bug fix

---

## Related issue

Fixes #844

---

## More screenshots (optional)

N/A

---

## Checklist

- [x] I have added screenshots or noted N/A
- [x] I have filled in the related issue number
- [x] I have tested my changes locally
- [x] I have done a self-review of the code