### PR TITLE
fix: improve help center light mode contrast

### DIFF
--- a/frontend/src/components/help_center/faq_accordion/faq_accordion.component.tsx
+++ b/frontend/src/components/help_center/faq_accordion/faq_accordion.component.tsx
@@ -27,8 +27,8 @@ const FAQAccordion: FC<FAQAccordionProps> = ({ items }) => {
   if (items.length === 0) {
     return (
       <section id="faq" className="scroll-mt-24">
-        <div className="text-center py-12 bg-blue-500/5 rounded-xl border border-white/5">
-          <p className="text-gray-400">No FAQ items match your search.</p>
+        <div className="text-center py-12 bg-white rounded-xl border border-slate-200 dark:bg-blue-500/5 dark:border-white/5">
+          <p className="text-slate-600 dark:text-gray-400">No FAQ items match your search.</p>
         </div>
       </section>
     );
@@ -45,10 +45,10 @@ const FAQAccordion: FC<FAQAccordionProps> = ({ items }) => {
       aria-labelledby="faq-heading"
     >
       <div className="text-center mb-10">
-        <h2 id="faq-heading" className="text-3xl font-bold text-gray-300">
+        <h2 id="faq-heading" className="text-3xl font-bold text-slate-900 dark:text-gray-300">
           Frequently Asked Questions
         </h2>
-        <p className="mt-3 text-gray-400 max-w-2xl mx-auto">
+        <p className="mt-3 text-slate-600 dark:text-gray-400 max-w-2xl mx-auto">
           Quick answers to the most common StorySparkAI questions.
         </p>
       </div>
@@ -63,7 +63,7 @@ const FAQAccordion: FC<FAQAccordionProps> = ({ items }) => {
             <article
               key={item.id}
               role="listitem"
-              className="bg-blue-500/10 border border-white/5 rounded-xl overflow-hidden transition-colors hover:border-indigo-500/20"
+              className="bg-white border border-slate-200 rounded-xl overflow-hidden transition-colors hover:border-indigo-300 dark:bg-blue-500/10 dark:border-white/5 dark:hover:border-indigo-500/20"
             >
               <h3>
                 <button
@@ -75,11 +75,11 @@ const FAQAccordion: FC<FAQAccordionProps> = ({ items }) => {
                   onClick={() => toggleItem(item.id)}
                   onKeyDown={(e) => handleKeyDown(e, item.id)}
                 >
-                  <span className="text-gray-300 font-medium pr-4">
+                  <span className="text-slate-900 font-medium pr-4 dark:text-gray-300">
                     {item.question}
                   </span>
                   <span
-                    className={`flex-shrink-0 w-8 h-8 rounded-full bg-indigo-500/20 flex items-center justify-center text-indigo-400 transition-transform duration-300 ${
+                    className={`flex-shrink-0 w-8 h-8 rounded-full bg-indigo-100 flex items-center justify-center text-indigo-700 transition-transform duration-300 dark:bg-indigo-500/20 dark:text-indigo-400 ${
                       isOpen ? "rotate-180" : ""
                     }`}
                     aria-hidden="true"
@@ -98,7 +98,7 @@ const FAQAccordion: FC<FAQAccordionProps> = ({ items }) => {
                   isOpen ? "pb-5 max-h-96 opacity-100" : "max-h-0 opacity-0"
                 }`}
               >
-                <p className="text-gray-400 leading-relaxed border-t border-white/5 pt-4">
+                <p className="text-slate-600 leading-relaxed border-t border-slate-200 pt-4 dark:text-gray-400 dark:border-white/5">
                   {item.answer}
                 </p>
               </div>

--- a/frontend/src/components/help_center/help_categories/help_categories.component.tsx
+++ b/frontend/src/components/help_center/help_categories/help_categories.component.tsx
@@ -23,11 +23,11 @@ const HelpCategories: FC<HelpCategoriesProps> = ({ categories }) => {
       <div className="text-center mb-10">
         <h2
           id="categories-heading"
-          className="text-3xl font-bold text-gray-300"
+          className="text-3xl font-bold text-slate-900 dark:text-gray-300"
         >
           Quick Help Categories
         </h2>
-        <p className="mt-3 text-gray-400 max-w-2xl mx-auto">
+        <p className="mt-3 text-slate-600 dark:text-gray-400 max-w-2xl mx-auto">
           Jump into the topic you need — from your first story to contributing code.
         </p>
       </div>

--- a/frontend/src/components/help_center/help_category_card/help_category_card.component.tsx
+++ b/frontend/src/components/help_center/help_category_card/help_category_card.component.tsx
@@ -14,16 +14,16 @@ const HelpCategoryCard: FC<HelpCategoryCardProps> = ({ category }) => {
     <button
       type="button"
       onClick={handleClick}
-      className="group text-left w-full bg-blue-500/10 hover:bg-blue-500/20 border border-white/5 hover:border-indigo-500/30 p-6 rounded-xl shadow-sm transform transition-all duration-300 hover:scale-[1.02] focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+      className="group text-left w-full bg-white hover:bg-indigo-50/80 border border-slate-200 hover:border-indigo-300 p-6 rounded-xl shadow-sm transform transition-all duration-300 hover:scale-[1.02] focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:bg-blue-500/10 dark:hover:bg-blue-500/20 dark:border-white/5 dark:hover:border-indigo-500/30"
     >
-      <div className="text-3xl mb-4 text-indigo-400 group-hover:text-indigo-300 transition-colors">
+      <div className="text-3xl mb-4 text-indigo-600 group-hover:text-indigo-700 transition-colors dark:text-indigo-400 dark:group-hover:text-indigo-300">
         <i className={category.icon} aria-hidden="true"></i>
       </div>
-      <h3 className="text-lg font-semibold mb-2 text-gray-300 group-hover:text-white transition-colors">
+      <h3 className="text-lg font-semibold mb-2 text-slate-900 group-hover:text-indigo-950 transition-colors dark:text-gray-300 dark:group-hover:text-white">
         {category.title}
       </h3>
-      <p className="text-gray-500 text-sm leading-relaxed">{category.description}</p>
-      <span className="inline-flex items-center gap-1 mt-4 text-sm text-indigo-400 group-hover:text-indigo-300 font-medium">
+      <p className="text-slate-600 text-sm leading-relaxed dark:text-gray-500">{category.description}</p>
+      <span className="inline-flex items-center gap-1 mt-4 text-sm text-indigo-700 group-hover:text-indigo-800 font-medium dark:text-indigo-400 dark:group-hover:text-indigo-300">
         Learn more
         <i
           className="fas fa-arrow-right text-xs transition-transform group-hover:translate-x-1"

--- a/frontend/src/components/help_center/help_hero/help_hero.component.tsx
+++ b/frontend/src/components/help_center/help_hero/help_hero.component.tsx
@@ -17,7 +17,7 @@ const HelpHero: FC<HelpHeroProps> = ({
   return (
     <section
       id="help-hero"
-      className="relative overflow-hidden border-b border-white/10"
+      className="relative overflow-hidden border-b border-slate-200 dark:border-white/10"
       aria-labelledby="help-center-title"
     >
       {/* Animated background glow */}
@@ -36,7 +36,7 @@ const HelpHero: FC<HelpHeroProps> = ({
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <Link to="/" className="inline-block mb-8">
-          <div className="bg-gradient-to-r from-white/20 to-white/10 hover:from-white/30 hover:to-white/20 text-gray-300 px-3 py-2 flex items-center gap-2 transition-all duration-300 rounded-lg border border-white/10">
+          <div className="bg-white hover:bg-slate-50 text-slate-700 px-3 py-2 flex items-center gap-2 transition-all duration-300 rounded-lg border border-slate-200 shadow-sm dark:bg-gradient-to-r dark:from-white/20 dark:to-white/10 dark:hover:from-white/30 dark:hover:to-white/20 dark:text-gray-300 dark:border-white/10">
             <i className="fa-solid fa-left-long" aria-hidden="true"></i>
             BACK
           </div>
@@ -48,7 +48,7 @@ const HelpHero: FC<HelpHeroProps> = ({
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
         >
-          <div className="inline-flex items-center justify-center mx-auto px-4 py-1.5 mb-6 rounded-full border border-white/20 bg-blue-500/20 text-white">
+          <div className="inline-flex items-center justify-center mx-auto px-4 py-1.5 mb-6 rounded-full border border-indigo-200 bg-indigo-50 text-indigo-700 dark:border-white/20 dark:bg-blue-500/20 dark:text-white">
             <span className="text-sm font-medium">SUPPORT &amp; GUIDANCE</span>
             <span className="ml-2 text-sm">
               <i className="fa-solid fa-circle-question" aria-hidden="true"></i>
@@ -57,12 +57,12 @@ const HelpHero: FC<HelpHeroProps> = ({
 
           <h1
             id="help-center-title"
-            className="text-4xl sm:text-5xl lg:text-6xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-gray-200 via-blue-400 to-indigo-400 mb-6 tracking-tight"
+            className="text-4xl sm:text-5xl lg:text-6xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-slate-950 via-blue-700 to-indigo-700 mb-6 tracking-tight dark:from-gray-200 dark:via-blue-400 dark:to-indigo-400"
           >
             Help Center
           </h1>
 
-          <p className="text-lg text-gray-400 mb-10 max-w-2xl mx-auto leading-relaxed">
+          <p className="text-lg text-slate-600 mb-10 max-w-2xl mx-auto leading-relaxed dark:text-gray-400">
             Find answers, troubleshoot issues, and get started with StorySparkAI.
             Search our guides or browse topics below.
           </p>

--- a/frontend/src/components/help_center/help_sidebar/help_sidebar.component.tsx
+++ b/frontend/src/components/help_center/help_sidebar/help_sidebar.component.tsx
@@ -34,7 +34,7 @@ const HelpSidebar: FC = () => {
         aria-label="Help center sections"
       >
         <div className="sticky top-24 space-y-1">
-          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-4 px-3">
+          <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-4 px-3 dark:text-gray-500">
             On this page
           </p>
           {HELP_SECTIONS.map((section) => (
@@ -44,8 +44,8 @@ const HelpSidebar: FC = () => {
               onClick={() => scrollToSection(section.id)}
               className={`w-full text-left px-3 py-2 rounded-lg text-sm transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${
                 activeSection === section.id
-                  ? "bg-indigo-500/20 text-indigo-300 border-l-2 border-indigo-500"
-                  : "text-gray-400 hover:text-gray-200 hover:bg-white/5"
+                  ? "bg-indigo-50 text-indigo-700 border-l-2 border-indigo-600 dark:bg-indigo-500/20 dark:text-indigo-300 dark:border-indigo-500"
+                  : "text-slate-600 hover:text-slate-950 hover:bg-slate-100 dark:text-gray-400 dark:hover:text-gray-200 dark:hover:bg-white/5"
               }`}
               aria-current={activeSection === section.id ? "true" : undefined}
             >
@@ -57,7 +57,7 @@ const HelpSidebar: FC = () => {
 
       {/* Mobile horizontal scroll nav */}
       <nav
-        className="lg:hidden sticky top-0 z-20 -mx-4 px-4 py-3 bg-slate-900/90 backdrop-blur-sm border-b border-white/10 mb-8"
+        className="lg:hidden sticky top-0 z-20 -mx-4 px-4 py-3 bg-white/95 backdrop-blur-sm border-b border-slate-200 mb-8 dark:bg-slate-900/90 dark:border-white/10"
         aria-label="Help center sections"
       >
         <div className="flex gap-2 overflow-x-auto pb-1 scrollbar-thin">
@@ -68,8 +68,8 @@ const HelpSidebar: FC = () => {
               onClick={() => scrollToSection(section.id)}
               className={`flex-shrink-0 px-4 py-2 rounded-full text-sm transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${
                 activeSection === section.id
-                  ? "bg-indigo-500/30 text-indigo-200 border border-indigo-500/40"
-                  : "bg-white/5 text-gray-400 border border-white/10 hover:bg-white/10"
+                  ? "bg-indigo-100 text-indigo-700 border border-indigo-300 dark:bg-indigo-500/30 dark:text-indigo-200 dark:border-indigo-500/40"
+                  : "bg-white text-slate-600 border border-slate-200 hover:bg-slate-100 dark:bg-white/5 dark:text-gray-400 dark:border-white/10 dark:hover:bg-white/10"
               }`}
               aria-current={activeSection === section.id ? "true" : undefined}
             >

--- a/frontend/src/components/help_center/support_links/support_links.component.tsx
+++ b/frontend/src/components/help_center/support_links/support_links.component.tsx
@@ -18,10 +18,10 @@ const SupportLinks: FC<SupportLinksProps> = ({ links }) => {
       aria-labelledby="support-heading"
     >
       <div className="text-center mb-10">
-        <h2 id="support-heading" className="text-3xl font-bold text-gray-300">
+        <h2 id="support-heading" className="text-3xl font-bold text-slate-900 dark:text-gray-300">
           Support &amp; Community
         </h2>
-        <p className="mt-3 text-gray-400 max-w-2xl mx-auto">
+        <p className="mt-3 text-slate-600 dark:text-gray-400 max-w-2xl mx-auto">
           Need more help? Connect with the StorySparkAI open-source community.
         </p>
       </div>
@@ -33,22 +33,22 @@ const SupportLinks: FC<SupportLinksProps> = ({ links }) => {
             href={link.href}
             target={link.external ? "_blank" : undefined}
             rel={link.external ? "noopener noreferrer" : undefined}
-            className="group flex items-start gap-5 bg-blue-500/10 hover:bg-blue-500/20 border border-white/5 hover:border-indigo-500/30 p-6 rounded-xl transition-all duration-300 hover:scale-[1.02] focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+            className="group flex items-start gap-5 bg-white hover:bg-indigo-50/80 border border-slate-200 hover:border-indigo-300 p-6 rounded-xl transition-all duration-300 hover:scale-[1.02] focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:bg-blue-500/10 dark:hover:bg-blue-500/20 dark:border-white/5 dark:hover:border-indigo-500/30"
           >
-            <div className="flex-shrink-0 w-12 h-12 rounded-lg bg-indigo-500/20 flex items-center justify-center text-indigo-400 group-hover:text-indigo-300 transition-colors">
+            <div className="flex-shrink-0 w-12 h-12 rounded-lg bg-indigo-100 flex items-center justify-center text-indigo-700 group-hover:text-indigo-800 transition-colors dark:bg-indigo-500/20 dark:text-indigo-400 dark:group-hover:text-indigo-300">
               <i className={`${link.icon} text-xl`} aria-hidden="true"></i>
             </div>
             <div className="flex-1 min-w-0">
-              <h3 className="text-lg font-semibold text-gray-300 group-hover:text-white transition-colors flex items-center gap-2">
+              <h3 className="text-lg font-semibold text-slate-900 group-hover:text-indigo-950 transition-colors flex items-center gap-2 dark:text-gray-300 dark:group-hover:text-white">
                 {link.title}
                 {link.external && (
                   <i
-                    className="fas fa-external-link-alt text-xs text-gray-500 group-hover:text-indigo-400"
+                    className="fas fa-external-link-alt text-xs text-slate-500 group-hover:text-indigo-600 dark:text-gray-500 dark:group-hover:text-indigo-400"
                     aria-hidden="true"
                   ></i>
                 )}
               </h3>
-              <p className="text-gray-500 text-sm mt-1 leading-relaxed">
+              <p className="text-slate-600 text-sm mt-1 leading-relaxed dark:text-gray-500">
                 {link.description}
               </p>
             </div>

--- a/frontend/src/components/help_center/troubleshoot/troubleshoot.component.tsx
+++ b/frontend/src/components/help_center/troubleshoot/troubleshoot.component.tsx
@@ -23,11 +23,11 @@ const Troubleshoot: FC<TroubleshootProps> = ({ items }) => {
       <div className="text-center mb-10">
         <h2
           id="troubleshooting-heading"
-          className="text-3xl font-bold text-gray-300"
+          className="text-3xl font-bold text-slate-900 dark:text-gray-300"
         >
           Troubleshooting
         </h2>
-        <p className="mt-3 text-gray-400 max-w-2xl mx-auto">
+        <p className="mt-3 text-slate-600 dark:text-gray-400 max-w-2xl mx-auto">
           Diagnose and fix common setup and runtime issues.
         </p>
       </div>

--- a/frontend/src/components/help_center/troubleshoot_card/troubleshoot_card.component.tsx
+++ b/frontend/src/components/help_center/troubleshoot_card/troubleshoot_card.component.tsx
@@ -7,30 +7,30 @@ interface TroubleshootCardProps {
 
 const TroubleshootCard: FC<TroubleshootCardProps> = ({ item }) => {
   return (
-    <article className="bg-blue-500/10 border border-white/5 hover:border-red-500/20 p-6 rounded-xl transition-all duration-300 hover:scale-[1.01]">
+    <article className="bg-white border border-slate-200 hover:border-red-300 p-6 rounded-xl transition-all duration-300 hover:scale-[1.01] dark:bg-blue-500/10 dark:border-white/5 dark:hover:border-red-500/20">
       <div className="flex items-start gap-4">
         <div
-          className="flex-shrink-0 w-12 h-12 rounded-lg bg-red-500/10 flex items-center justify-center text-red-400"
+          className="flex-shrink-0 w-12 h-12 rounded-lg bg-red-50 flex items-center justify-center text-red-600 dark:bg-red-500/10 dark:text-red-400"
           aria-hidden="true"
         >
           <i className={`${item.icon} text-xl`}></i>
         </div>
         <div className="flex-1 min-w-0">
-          <h3 className="text-lg font-semibold text-gray-300 mb-2">
+          <h3 className="text-lg font-semibold text-slate-900 mb-2 dark:text-gray-300">
             {item.title}
           </h3>
           <div className="space-y-3 text-sm">
             <div>
-              <span className="text-red-400/80 font-medium uppercase tracking-wide text-xs">
+              <span className="text-red-700 font-medium uppercase tracking-wide text-xs dark:text-red-400/80">
                 Symptoms
               </span>
-              <p className="text-gray-500 mt-1">{item.symptoms}</p>
+              <p className="text-slate-600 mt-1 dark:text-gray-500">{item.symptoms}</p>
             </div>
             <div>
-              <span className="text-emerald-400/80 font-medium uppercase tracking-wide text-xs">
+              <span className="text-emerald-700 font-medium uppercase tracking-wide text-xs dark:text-emerald-400/80">
                 Solution
               </span>
-              <p className="text-gray-400 mt-1 leading-relaxed">{item.solution}</p>
+              <p className="text-slate-600 mt-1 leading-relaxed dark:text-gray-400">{item.solution}</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
@ronisarkarexe  please add gssoc tag in it i solved it for you and also starred the repo
## What this PR does

Fixes the Help Center light mode contrast issues.

Previously, several Help Center sections used dark-theme styling as the default, which made light mode difficult to read. Cards, FAQ accordion items, sidebar navigation, buttons, icons, and support/troubleshooting sections had low-contrast colors or blended into the page background.

This PR updates the Help Center light-mode styles to use clearer white card backgrounds, slate text, visible borders, and stronger indigo/red/emerald accents while preserving the existing dark-mode styling with `dark:` variants.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Fixes #840

## More screenshots (optional)

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.