### PR TITLE
fix: remove duplicate TermsAndConditions import in App.tsx

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -42,7 +42,7 @@ import BlogComponent from "./components/footer/blog.tsx";
 import PrivacyPolicy from "./components/footer/Privacy.tsx";
 import Terms from "./components/footer/terms.tsx";
 import GuidelinesComponent from "./components/footer/guidelines.tsx";
-import TermsAndConditions from "./components/footer/terms.tsx";
+
 import TemplatesComponent from "./components/templates/templates.component";
 import CommunityComponent from "./components/community/community.component";
 import ResourcesListComponent from "./components/community/resources_list.component";


### PR DESCRIPTION
## Screenshot 

N/A — this is a code-only change (removing a duplicate import line), no UI is affected.


## What this PR does

Removes a duplicate unused import of TermsAndConditions in frontend/src/App.tsx. The file terms.tsx was imported twice under two different names — Terms (used in the router) and TermsAndConditions (never used anywhere). The duplicate import causes ESLint unused import warnings and adds unnecessary confusion for contributors.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Fixes #680 

## More screenshots (optional)

N/A. This is a code-only change (removing a duplicate import line); no UI is affected.

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
