### PR TITLE
fix(frontend): resolve prompt word-count validation bug

### DIFF
--- a/frontend/src/components/stories/stories.utils.ts
+++ b/frontend/src/components/stories/stories.utils.ts
@@ -96,10 +96,7 @@ export const getWordCount = (str: string) => {
   if (typeof str !== "string" || !str.trim()) {
     return 0;
   }
-  return str
-    .trim()
-    .split(/\s+/)
-    .filter((word) => /^[a-zA-Z]+$/.test(word)).length;
+  return str.trim().split(/\s+/).length;
 };
 
 export const prompts = [

--- a/frontend/src/models/post.ts
+++ b/frontend/src/models/post.ts
@@ -40,6 +40,7 @@ export interface Post {
   imageURL: string;
   topic: Topic[];
   language?: string;
+  emotions?: string[];
   author: Author;
   likesCount: number;
   commentsCount: number;


### PR DESCRIPTION
## Description
closes #861 
This PR resolves the prompt word count validation bug in the frontend. Previously, the `getWordCount` utility function filtered out any word containing punctuation or contractions (using a strict `/^[a-zA-Z]+$/` regex). This caused valid prompts containing punctuation to be under-counted and blocked users from submitting the form (failing the 10-word minimum check).

The function has been updated to count words based on whitespace separation, allowing normal sentence construction containing punctuation. Additionally, the missing `emotions` field has been added to the frontend `Post` model interface to resolve pre-existing typechecking compilation failures.

## Changes Made
* **`frontend/src/components/stories/stories.utils.ts`**: Updated `getWordCount` to count all whitespace-separated words.
* **`frontend/src/models/post.ts`**: Added `emotions?: string[]` definition to `Post` interface.

## How to Test
1. Go to the story generation form.
2. Enter the prompt: `"In a dystopian world, everyone didn't remember the past 24 hours."` (11 words containing commas and contractions).
3. The form should now successfully submit instead of failing with the "Prompt must be at least 10 words" message.

---
*GSSoC '26 Contributor*
