### PR TITLE
docs : add .editorconfig for consistent editor settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
## Screenshot (when helpful)
N/A

## What this PR does

Adds a `.editorconfig` file at the project root to enforce consistent 
editor settings across all contributors and IDEs automatically.

This ensures all editors use the same indentation style, tab size, 
line endings, and charset — preventing noisy diffs in PRs caused by 
different local editor configurations.

## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [x] Documentation update

## Related issue

Closes #868 

## More screenshots (optional)

N/A — this is a non-UI configuration file addition

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
