### PR TITLE
fix(frontend): make writing assistant CTA button functional

### DIFF
--- a/frontend/src/components/writing-assistant/writing_assistant.component.tsx
+++ b/frontend/src/components/writing-assistant/writing_assistant.component.tsx
@@ -333,6 +333,7 @@ export default function AIWritingAssistant() {
           Join thousands of writers already using StorySpark to push past limits and find their story.
         </p>
         <button
+          onClick={() => window.location.href = "/stories"}
           style={{
             background: "linear-gradient(135deg, #7C5DFA 0%, #4F8EF7 100%)",
             border: "none",

--- a/frontend/src/models/post.ts
+++ b/frontend/src/models/post.ts
@@ -40,6 +40,7 @@ export interface Post {
   imageURL: string;
   topic: Topic[];
   language?: string;
+  emotions?: string[];
   author: Author;
   likesCount: number;
   commentsCount: number;


### PR DESCRIPTION
## Description
closes #862 
This PR resolves a non-functional call-to-action (CTA) button on the Writing Assistant landing page. 

The primary action button *"Try the Assistant — It's Free"* at the bottom of the page did not have any event handler or link, making it non-responsive when clicked. It has been updated with an `onClick` handler to redirect users to `/stories` (the workspace/dashboard). Additionally, the missing `emotions` field has been added to the frontend `Post` model interface to resolve pre-existing typechecking compilation failures.

## Changes Made
* **`frontend/src/components/writing-assistant/writing_assistant.component.tsx`**: Added click redirection to `/stories`.
* **`frontend/src/models/post.ts`**: Added `emotions?: string[]` definition to `Post` interface.

## How to Test
1. Navigate to the Writing Assistant page.
2. Scroll to the bottom and click *"Try the Assistant — It's Free"*.
3. Verify you are redirected to `/stories`.

---
*GSSoC '26 Contributor*
