### PR TITLE
fix(config): remove hardcoded MongoDB URI and require DATABASE_URL en…

### DIFF
--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -16,7 +16,7 @@ const parseCorsOrigins = (
 export default {
   env: process.env.NODE_ENV,
   port: process.env.PORT || "5000",
-  database_url: process.env.DATABASE_URL || "mongodb+srv://university_system:Y4K8t26J0a894hke@cluster0.v4fkr.mongodb.net/ai_storie_books?retryWrites=true&w=majority",
+  database_url: process.env.DATABASE_URL?.trim() || undefined,
   cors_origins: parseCorsOrigins(process.env.CORS_ORIGINS),
   bcrypt_salt_rounds: process.env.SALT_ROUNDS,
   jwt: {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -15,7 +15,13 @@ dns.setServers(["1.1.1.1", "8.8.8.8"]);
 
 async function connectDB() {
   if (mongoose.connection.readyState === 1) return;
-  await mongoose.connect(config.database_url as string);
+  const databaseUrl = config.database_url;
+  if (!databaseUrl) {
+    throw new Error(
+      "DATABASE_URL is not set. Define it in backend/.env before starting the server."
+    );
+  }
+  await mongoose.connect(databaseUrl);
 }
 
 async function main() {


### PR DESCRIPTION
## What this PR does

This PR removes the hard-coded MongoDB connection URI and enforces the use of the `DATABASE_URL` environment variable for database configuration.

### Changes made

* Removed embedded MongoDB credentials from:

  * `backend/src/config/index.ts`
* Updated configuration handling to:

  * Read only from `process.env.DATABASE_URL`
  * Trim the environment variable before use
* Added startup validation in:

  * `backend/src/server.ts`
* Server now throws a clear error when `DATABASE_URL` is missing before attempting a database connection

### Why

This improves application security and configuration reliability by:

* Eliminating credentials stored in source control
* Preventing accidental connections to production databases
* Enforcing explicit environment-based configuration
* Following secure secret-management best practices

---

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

---

## Related issue

Closes #893

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.
