### PR TITLE
fix(collab): require JWT auth on /collab socket namespace

### DIFF
--- a/backend/src/socket/collab.socket.ts
+++ b/backend/src/socket/collab.socket.ts
@@ -1,7 +1,9 @@
 import { Server, Socket } from "socket.io";
+import { Secret } from "jsonwebtoken";
 import logger from "../utils/logger.util";
 import { GoogleGenerativeAI } from "@google/generative-ai";
 import config from "../config";
+import { JwtHalers } from "../utils/jwt.helper";
 
 const genAI = new GoogleGenerativeAI(config.gemini_api_key as string);
 
@@ -47,17 +49,56 @@ function getColorForUser(index: number): string {
 export const setupCollabSocket = (io: Server) => {
   const collabNamespace = io.of("/collab");
 
+  // Authenticate every connection to the /collab namespace using the same
+  // JWT pattern applied to the main io namespace in server.ts. Without this,
+  // any anonymous client could create rooms, join rooms, and impersonate
+  // other users by simply supplying an arbitrary userId in the payload.
+  collabNamespace.use((socket, next) => {
+    try {
+      const token = socket.handshake.auth?.token as string | undefined;
+      if (!token) {
+        return next(new Error("Unauthorized"));
+      }
+
+      const verifiedUser = JwtHalers.verifyToken(
+        token,
+        config.jwt.secret as Secret
+      );
+      const userId =
+        verifiedUser._id ||
+        verifiedUser.userId ||
+        verifiedUser.sub ||
+        verifiedUser.id;
+      if (!userId) {
+        return next(new Error("Unauthorized"));
+      }
+
+      socket.data.userId = userId.toString();
+      socket.data.username =
+        (verifiedUser.name as string | undefined) ||
+        (verifiedUser.username as string | undefined);
+      next();
+    } catch (error) {
+      logger.warn("Collab socket auth failed", error);
+      next(new Error("Unauthorized"));
+    }
+  });
+
   collabNamespace.on("connection", (socket: Socket) => {
     logger.debug("Collab socket connected");
 
+    const authUserId = socket.data.userId as string;
+    const authUsername = (socket.data.username as string | undefined) || "User";
+
     // Create a new room
-    socket.on("collab:create_room", ({ userId, username }) => {
+    socket.on("collab:create_room", (payload: { username?: string } = {}) => {
+      const username = payload.username || authUsername;
       const roomId = generateRoomId();
       const room: IRoom = {
         roomId,
-        createdBy: userId,
+        createdBy: authUserId,
         participants: [{
-          userId,
+          userId: authUserId,
           username,
           color: COLORS[0],
           socketId: socket.id,
@@ -71,19 +112,21 @@ export const setupCollabSocket = (io: Server) => {
     });
 
     // Join an existing room
-    socket.on("collab:join_room", ({ roomId, userId, username }) => {
+    socket.on("collab:join_room", ({ roomId, username }: { roomId: string; username?: string }) => {
       const room = rooms.get(roomId);
       if (!room) {
         socket.emit("collab:error", { message: "Room not found" });
         return;
       }
 
-      const existingParticipant = room.participants.find(p => p.userId === userId);
+      const resolvedUsername = username || authUsername;
+      const existingParticipant = room.participants.find(p => p.userId === authUserId);
       if (!existingParticipant) {
         const color = getColorForUser(room.participants.length);
-        room.participants.push({ userId, username, color, socketId: socket.id });
+        room.participants.push({ userId: authUserId, username: resolvedUsername, color, socketId: socket.id });
       } else {
         existingParticipant.socketId = socket.id;
+        if (resolvedUsername) existingParticipant.username = resolvedUsername;
       }
 
       socket.join(roomId);
@@ -92,15 +135,18 @@ export const setupCollabSocket = (io: Server) => {
     });
 
     // User adds text to story
-    socket.on("collab:add_text", ({ roomId, userId, text }) => {
+    socket.on("collab:add_text", ({ roomId, text }: { roomId: string; text: string }) => {
       const room = rooms.get(roomId);
       if (!room) return;
 
-      const participant = room.participants.find(p => p.userId === userId);
-      if (!participant) return;
+      const participant = room.participants.find(p => p.userId === authUserId);
+      if (!participant) {
+        socket.emit("collab:error", { message: "You are not a participant of this room" });
+        return;
+      }
 
       const chunk: IStoryChunk = {
-        authorId: userId,
+        authorId: authUserId,
         authorName: participant.username,
         color: participant.color,
         text,
@@ -113,9 +159,16 @@ export const setupCollabSocket = (io: Server) => {
     });
 
     // AI continues the story
-    socket.on("collab:ai_continue", async ({ roomId }) => {
+    socket.on("collab:ai_continue", async ({ roomId }: { roomId: string }) => {
       const room = rooms.get(roomId);
       if (!room) return;
+
+      // Only participants of a room can trigger the AI
+      const participant = room.participants.find(p => p.userId === authUserId);
+      if (!participant) {
+        socket.emit("collab:error", { message: "You are not a participant of this room" });
+        return;
+      }
 
       collabNamespace.to(roomId).emit("collab:ai_thinking", { roomId });
 
@@ -149,16 +202,19 @@ export const setupCollabSocket = (io: Server) => {
     });
 
     // Typing indicator
-    socket.on("collab:typing", ({ roomId, userId, username }) => {
-      socket.to(roomId).emit("collab:user_typing", { userId, username });
+    socket.on("collab:typing", ({ roomId, username }: { roomId: string; username?: string }) => {
+      socket.to(roomId).emit("collab:user_typing", {
+        userId: authUserId,
+        username: username || authUsername,
+      });
     });
 
-    socket.on("collab:stop_typing", ({ roomId, userId }) => {
-      socket.to(roomId).emit("collab:user_stop_typing", { userId });
+    socket.on("collab:stop_typing", ({ roomId }: { roomId: string }) => {
+      socket.to(roomId).emit("collab:user_stop_typing", { userId: authUserId });
     });
 
     // Get room info
-    socket.on("collab:get_room", ({ roomId }) => {
+    socket.on("collab:get_room", ({ roomId }: { roomId: string }) => {
       const room = rooms.get(roomId);
       if (!room) {
         socket.emit("collab:error", { message: "Room not found" });

--- a/backend/src/socket/collab.socket.ts
+++ b/backend/src/socket/collab.socket.ts
@@ -1,5 +1,5 @@
 import { Server, Socket } from "socket.io";
-import { Secret } from "jsonwebtoken";
+import type { Secret } from "jsonwebtoken";
 import logger from "../utils/logger.util";
 import { GoogleGenerativeAI } from "@google/generative-ai";
 import config from "../config";
@@ -203,6 +203,10 @@ export const setupCollabSocket = (io: Server) => {
 
     // Typing indicator
     socket.on("collab:typing", ({ roomId, username }: { roomId: string; username?: string }) => {
+      const room = rooms.get(roomId);
+      if (!room) return;
+      const isParticipant = room.participants.some(p => p.userId === authUserId);
+      if (!isParticipant) return;
       socket.to(roomId).emit("collab:user_typing", {
         userId: authUserId,
         username: username || authUsername,
@@ -210,6 +214,10 @@ export const setupCollabSocket = (io: Server) => {
     });
 
     socket.on("collab:stop_typing", ({ roomId }: { roomId: string }) => {
+      const room = rooms.get(roomId);
+      if (!room) return;
+      const isParticipant = room.participants.some(p => p.userId === authUserId);
+      if (!isParticipant) return;
       socket.to(roomId).emit("collab:user_stop_typing", { userId: authUserId });
     });
 
@@ -218,6 +226,13 @@ export const setupCollabSocket = (io: Server) => {
       const room = rooms.get(roomId);
       if (!room) {
         socket.emit("collab:error", { message: "Room not found" });
+        return;
+      }
+      // Only participants of a room can read its details to avoid leaking
+      // story content and participant identities to other authenticated users.
+      const isParticipant = room.participants.some(p => p.userId === authUserId);
+      if (!isParticipant) {
+        socket.emit("collab:error", { message: "You are not a participant of this room" });
         return;
       }
       socket.emit("collab:room_info", { room });


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Closes #769
- **Description:** Adds JWT authentication middleware to the `/collab` Socket.IO namespace and removes trust in client-supplied `userId` across all collab event handlers.
- **Screenshots:** N/A — this is a backend security fix with no UI changes.

## Screenshot (when helpful)

N/A — backend-only change. No UI is affected.

## What this PR does

The `/collab` Socket.IO namespace accepted all connections without verifying any JWT, while the main `io` namespace in `server.ts` already enforces JWT via `io.use(...)`. Every collab event handler also trusted a client-supplied `userId`, allowing anonymous clients to connect, create rooms, and impersonate any user.

This PR adds `collabNamespace.use(...)` middleware that verifies the handshake auth token using the same `JwtHalers.verifyToken` pattern used in `server.ts`, stores the verified id on `socket.data.userId`, and replaces every client-supplied `userId` in the event handlers with the server-verified one. Participant checks are also added to `collab:add_text` and `collab:ai_continue` so only room members can post or trigger AI continuations.

## Type of change

Check all that apply (if more than one, explain in "What this PR does").

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #769

## More screenshots (optional)

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
