### PR TITLE
fix(config): throw at startup when DATABASE_URL is missing (closes #768)

### DIFF
--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -17,7 +17,15 @@ export default {
   env: process.env.NODE_ENV,
   port: process.env.PORT || "5000",
   disable_logs: process.env.DISABLE_LOGS === "true" || process.env.VERCEL === "1",
-  database_url: process.env.DATABASE_URL?.trim() || undefined,
+  database_url: (() => {
+    const url = process.env.DATABASE_URL?.trim();
+    if (!url) {
+      throw new Error(
+        "DATABASE_URL environment variable is required. See backend/.env.example for setup instructions."
+      );
+    }
+    return url;
+  })(),
   cors_origins: parseCorsOrigins(process.env.CORS_ORIGINS),
   bcrypt_salt_rounds: process.env.SALT_ROUNDS,
   jwt: {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -22,13 +22,9 @@ if (config.disable_logs) {
 
 async function connectDB() {
   if (mongoose.connection.readyState === 1) return;
-  const databaseUrl = config.database_url;
-  if (!databaseUrl) {
-    throw new Error(
-      "DATABASE_URL is not set. Define it in backend/.env before starting the server."
-    );
-  }
-  await mongoose.connect(databaseUrl);
+  // config.database_url is guaranteed non-empty by config/index.ts — it throws at
+  // module load time if DATABASE_URL is missing, so no runtime guard is needed here.
+  await mongoose.connect(config.database_url);
 }
 
 async function main() {


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Closes #768
- **Description:** Replaces the silent `undefined` fallback for `DATABASE_URL` with a startup-time throw, so the server refuses to boot without a properly configured environment.
- **Screenshots:** N/A — this is a backend config hardening change with no UI surface.

## Screenshot (when helpful)

N/A — backend-only change. The behavior is observable as a startup error in the terminal when `DATABASE_URL` is unset:

```
Error: DATABASE_URL environment variable is required. See backend/.env.example for setup instructions.
```

## What this PR does

Issue #768 flagged that `backend/src/config/index.ts` historically shipped a hardcoded MongoDB Atlas URI with embedded credentials as a fallback for `DATABASE_URL`. The hardcoded URI itself was removed in an earlier change, but the fallback was replaced with `|| undefined`, which lets the process boot in a half-configured state and defers the failure to `connectDB()` at request time.

This PR implements the fix proposed directly in the issue: an IIFE that throws synchronously at module load if `DATABASE_URL` is missing or empty. With this in place:

- The server cannot start without a valid `DATABASE_URL`. There is no path back to a hardcoded fallback, by construction.
- `config.database_url` is now typed as `string` instead of `string | undefined`, so consumers (`server.ts`, `scripts/seed-admin.ts`) no longer need a cast or a runtime nullish check.
- The previously redundant guard in `server.ts`'s `connectDB()` is removed, with a brief comment explaining why the guard is no longer needed.

The error message points contributors at `backend/.env.example`, which already documents `DATABASE_URL` as a required variable, so the change is consistent with the project's existing setup guidance.

### Follow-up actions for the maintainer (cannot be done in a PR)

The code change closes the root cause but does not, on its own, fully neutralize the original credential exposure. Two out-of-band steps remain:

1. **Rotate the leaked Atlas credentials.** The original username/password are still present in the git history of cloned repos. The exposed user should be rotated or deleted on the Atlas side.
2. **(Optional) Rewrite git history** with `git filter-repo` or BFG to purge the URI from past commits, then force-push and notify forks.

These require maintainer-level access to the Atlas console and the upstream repo, so they are flagged here rather than included in the PR.

## Type of change

Check all that apply (if more than one, explain in "What this PR does").

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #768

## More screenshots (optional)

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
