### PR TITLE
docs: add missing frontend env example

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+VITE_BASE_URL=http://localhost:5000/api/v1
+VITE_SOCKET_URL=http://localhost:5000


### PR DESCRIPTION
## Description

This PR adds the missing `frontend/.env.example` file referenced in the README setup instructions.

### Problem

The README instructs contributors to run:

```bash
cp frontend/.env.example frontend/.env
```

However, the `frontend/.env.example` file was not present in the repository, causing setup confusion and copy command failures during local development.

### Changes Made

* Added `frontend/.env.example`
* Included default frontend environment variables:

  * `VITE_BASE_URL`
  * `VITE_SOCKET_URL`

### Impact

This improves the onboarding experience for contributors and ensures the documented setup steps work correctly for local development.

Fixes setup inconsistency related to frontend environment configuration.


before
<img width="2047" height="1331" alt="Screenshot 2026-05-28 at 4 53 03 PM" src="https://github.com/user-attachments/assets/9c4f5b5e-75fa-4bfe-9dee-a8e564db1f12" />

after 
<img width="1470" height="956" alt="Screenshot 2026-05-28 at 5 12 30 PM" src="https://github.com/user-attachments/assets/0949796c-0c72-4275-a0fe-aaf222f7eee9" />
