### PR TITLE
fix: remove Community link from navbar (already in footer)

### DIFF
--- a/frontend/src/components/hero/nav_list.component.tsx
+++ b/frontend/src/components/hero/nav_list.component.tsx
@@ -23,7 +23,6 @@ const NavListComponent = () => {
           <NavLink to="/" end className={linkClass}>Home</NavLink>
           <NavLink to="/explore" className={linkClass}>Explore</NavLink>
           <NavLink to="/story-inspiration" className={linkClass}>Stories</NavLink>
-          <NavLink to="/community" className={linkClass}>Community</NavLink>
           {loggedIn && <NavLink to="/dashboard" className={linkClass}>Dashboard</NavLink>}
         </nav>
         <div className="flex items-center gap-2">
@@ -43,7 +42,6 @@ const NavListComponent = () => {
           <NavLink to="/" end className={linkClass}>Home</NavLink>
           <NavLink to="/explore" className={linkClass}>Explore</NavLink>
           <NavLink to="/story-inspiration" className={linkClass}>Stories</NavLink>
-          <NavLink to="/community" className={linkClass}>Community</NavLink>
         </div>
       )}
     </header>


### PR DESCRIPTION
## Screenshot (when helpful)
### 🌐 Live Site (Vercel — NOT updated by owner, shows old code)
The Vercel deployment is outdated. It still shows the old cluttered navbar.
<img width="1351" height="635" alt="image" src="https://github.com/user-attachments/assets/8ff528c8-8903-4860-b4e9-5d488353db2a" />

### 💻 Local (current codebase — clean navbar)
Running locally shows the navbar is already much cleaner than Vercel.
<img width="1365" height="676" alt="image" src="https://github.com/user-attachments/assets/285dd8a4-00f7-4819-9f8b-90783db2a3b4" />

### ✅ After My Fix (Community removed from navbar)
Community link removed from navbar. Still accessible in Footer → Resources.
<img width="1348" height="661" alt="image" src="https://github.com/user-attachments/assets/3381af81-f954-4088-8298-b10353a098af" />

## What this PR does

⚠️ Note for reviewer: The live Vercel site (https://storysparkai.vercel.app) 
has NOT been updated by the owner and still shows an old cluttered navbar with 
Contact Us, Community, Inspiring Stories, Analytics, Collab all crammed in.

The current codebase locally is already cleaner than Vercel. 

What I did in this PR:
- Investigated the issue thoroughly by running the project locally
- Confirmed the navbar was already partially fixed in the codebase
- Removed the remaining `Community` NavLink from the desktop navbar
- Removed the `Community` NavLink from the mobile hamburger menu

Community is already present in Footer → Resources section so users 
can still find it — just in the standard, correct place.
## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Documentation update

## Related issue

Closes #790 
## More screenshots (optional)

N/A
## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
