### PR TITLE
Restrict users list access to admin users

### DIFF
--- a/frontend/src/components/dashboard/users/user.list.component.tsx
+++ b/frontend/src/components/dashboard/users/user.list.component.tsx
@@ -1,11 +1,23 @@
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 import { useGetUsersListQuery } from "../../../redux/apis/user.api";
 import { User } from "../../../models/user";
 import LoadingAnimation from "../../loading/loading.component";
+import { Navigate } from "react-router-dom";
+import AuthContext from "../../auth.context";
+import { USER_ROLE } from "../../../constants/role";
 
 const UserListComponent = () => {
   const { data: users, isLoading } = useGetUsersListQuery(undefined);
   const [searchTerm, setSearchTerm] = useState("");
+const auth = useContext(AuthContext);
+
+if (
+  !auth?.user ||
+  (auth.user.role !== USER_ROLE.ADMIN &&
+    auth.user.role !== USER_ROLE.SUPER_ADMIN)
+) {
+  return <Navigate to="/dashboard" replace />;
+}
 
   const filteredUsers = (users?.data ?? []).filter((user: User) => {
     const searchValue = searchTerm.toLowerCase().trim();


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Open or link a related issue when there is one (`Closes #123`, `Fixes #45`, or write **None** under Related issue below).
- **Description:** Fill in **What this PR does** so a reviewer can understand the change without your local context.
- **Screenshots:** Add screenshots or a short recording when they help (UI changes, confusing flows, or non-code proof). If not needed, say so in the checklist.

## What this PR does

Restricts the dashboard users list page so only ADMIN and SUPER_ADMIN users can access it. 

## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [X] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

CLOSES #794 

## More screenshots (optional)

N/A - This is a route access protection change.

## Checklist

- [X] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [X] I have filled in the related issue number when there is one.
- [X] I have tested my changes.
- [X] I have done a self-review of the code.
