### PR TITLE
Fix: Privilege Escalation / Broken Access Control in Writer Application Approval

### DIFF
--- a/backend/src/app/modules/user/user.controller.ts
+++ b/backend/src/app/modules/user/user.controller.ts
@@ -5,6 +5,7 @@ import { routeParam } from "../../../shared/route_param";
 import sendResponse from "../../../shared/send_response";
 import { getToken } from "../../middleware/token";
 import catchAsync from "../../../shared/catch_async";
+import ApiError from "../../../errors/api_error";
 
 const getAllUsers = async (req: Request, res: Response) => {
   try {
@@ -88,6 +89,15 @@ const applyForWriter = catchAsync(async (req: Request, res: Response) => {
 
 const approveWriterApplication = catchAsync(
   async (req: Request, res: Response) => {
+    // Defense-in-depth: verify caller is admin/super_admin at the controller level
+    const token = await getToken(req);
+    if (token.role !== "admin" && token.role !== "super_admin") {
+      throw new ApiError(
+        httpStatus.FORBIDDEN,
+        "Only administrators can approve writer applications!"
+      );
+    }
+
     const { email } = req.body;
 
     const result = await UserService.approveWriterApplication(email);

--- a/backend/src/app/modules/user/user.router.ts
+++ b/backend/src/app/modules/user/user.router.ts
@@ -16,7 +16,7 @@ router.get("/profile", UserController.getProfileInfo);
 // Apply for Writer
 router.get(
   "/writer-application-list",
-  auth(ENUM_USER_ROLE.ADMIN, ENUM_USER_ROLE.SUPER_ADMIN, ENUM_USER_ROLE.WRITER),
+  auth(ENUM_USER_ROLE.ADMIN, ENUM_USER_ROLE.SUPER_ADMIN),
   UserController.getAllWriterApplicationUsers
 );
 
@@ -62,7 +62,7 @@ router.post(
 // Apply for Writer
 router.post(
   "/approve-writer-application",
-  auth(ENUM_USER_ROLE.ADMIN, ENUM_USER_ROLE.SUPER_ADMIN, ENUM_USER_ROLE.WRITER),
+  auth(ENUM_USER_ROLE.ADMIN, ENUM_USER_ROLE.SUPER_ADMIN),
   UserController.approveWriterApplication
 );
 


### PR DESCRIPTION
## Description

This PR addresses a critical **Broken Access Control (BAC)** vulnerability in the writer application approval workflow (`backend/src/app/modules/user/`).

Previously, the `/approve-writer-application` endpoint included `ENUM_USER_ROLE.WRITER` in its `auth()` middleware. This meant any user who already held the `writer` role could arbitrarily approve the pending applications of other regular users — effectively granting them writer privileges without any administrator oversight. The `/writer-application-list` endpoint had the same misconfiguration, allowing writers to view all pending applications.

This is a direct violation of the **principle of least privilege** and compromises the platform's entire role-based access control system.

## Resolved Issue
Resolves #941 

## Changes Made

### `backend/src/app/modules/user/user.router.ts`
- **Removed** `ENUM_USER_ROLE.WRITER` from the `auth()` middleware on:
  - `POST /approve-writer-application`
  - `GET /writer-application-list`
- Only `ADMIN` and `SUPER_ADMIN` roles can now access these endpoints.

### `backend/src/app/modules/user/user.controller.ts`
- **Added** a defense-in-depth role check inside the `approveWriterApplication` controller handler.
- The controller independently verifies the caller's role is `admin` or `super_admin` before proceeding, returning `403 Forbidden` otherwise.
- **Added** `ApiError` import to support the new role guard.

## Security Impact

| Before | After |
|--------|-------|
| Writers could approve other users' writer applications | Only Admin / Super Admin can approve |
| Writers could view all pending writer applications | Only Admin / Super Admin can view |
| Single layer of access control (middleware only) | Two layers: middleware + controller-level verification |

## How It Was Tested

- Verified that requests from a `writer` role token to `/approve-writer-application` now return `403 Forbidden`.
- Verified that requests from a `writer` role token to `/writer-application-list` now return `403 Forbidden`.
- Verified that `admin` and `super_admin` tokens can still successfully approve applications.

## Labels

`security` `backend` `access-control` `bug-fix`