### PR TITLE
Fix: User Identity Spoofing in Collaboration WebSockets

### DIFF
--- a/backend/src/socket/collab.socket.ts
+++ b/backend/src/socket/collab.socket.ts
@@ -2,6 +2,8 @@ import { Server, Socket } from "socket.io";
 import logger from "../utils/logger.util";
 import { GoogleGenerativeAI } from "@google/generative-ai";
 import config from "../config";
+import { JwtHalers } from "../utils/jwt.helper";
+import { Secret } from "jsonwebtoken";
 
 const genAI = new GoogleGenerativeAI(config.gemini_api_key as string);
 
@@ -47,11 +49,30 @@ function getColorForUser(index: number): string {
 export const setupCollabSocket = (io: Server) => {
   const collabNamespace = io.of("/collab");
 
+  collabNamespace.use((socket, next) => {
+    try {
+      const token = socket.handshake.auth?.token as string | undefined;
+      if (!token) return next(new Error("Unauthorized"));
+      
+      const verifiedUser = JwtHalers.verifyToken(token, config.jwt.secret as Secret);
+      const userId = verifiedUser._id || verifiedUser.userId || verifiedUser.sub || verifiedUser.id;
+      if (!userId) return next(new Error("Unauthorized"));
+      
+      socket.data.userId = userId.toString();
+      socket.data.username = verifiedUser.name || "Unknown User";
+      next();
+    } catch (error) {
+      next(new Error("Unauthorized"));
+    }
+  });
+
   collabNamespace.on("connection", (socket: Socket) => {
     logger.debug("Collab socket connected");
 
     // Create a new room
-    socket.on("collab:create_room", ({ userId, username }) => {
+    socket.on("collab:create_room", () => {
+      const userId = socket.data.userId;
+      const username = socket.data.username;
       const roomId = generateRoomId();
       const room: IRoom = {
         roomId,
@@ -71,7 +92,9 @@ export const setupCollabSocket = (io: Server) => {
     });
 
     // Join an existing room
-    socket.on("collab:join_room", ({ roomId, userId, username }) => {
+    socket.on("collab:join_room", ({ roomId }) => {
+      const userId = socket.data.userId;
+      const username = socket.data.username;
       const room = rooms.get(roomId);
       if (!room) {
         socket.emit("collab:error", { message: "Room not found" });
@@ -92,7 +115,8 @@ export const setupCollabSocket = (io: Server) => {
     });
 
     // User adds text to story
-    socket.on("collab:add_text", ({ roomId, userId, text }) => {
+    socket.on("collab:add_text", ({ roomId, text }) => {
+      const userId = socket.data.userId;
       const room = rooms.get(roomId);
       if (!room) return;
 
@@ -149,11 +173,14 @@ export const setupCollabSocket = (io: Server) => {
     });
 
     // Typing indicator
-    socket.on("collab:typing", ({ roomId, userId, username }) => {
+    socket.on("collab:typing", ({ roomId }) => {
+      const userId = socket.data.userId;
+      const username = socket.data.username;
       socket.to(roomId).emit("collab:user_typing", { userId, username });
     });
 
-    socket.on("collab:stop_typing", ({ roomId, userId }) => {
+    socket.on("collab:stop_typing", ({ roomId }) => {
+      const userId = socket.data.userId;
       socket.to(roomId).emit("collab:user_stop_typing", { userId });
     });
 


### PR DESCRIPTION
## Description

This PR addresses a critical **User Identity Spoofing** vulnerability in the real-time collaboration WebSocket system (`backend/src/socket/collab.socket.ts`).

Previously, the WebSocket events under the `/collab` namespace (such as `collab:add_text` and `collab:create_room`) blindly trusted the `userId` and `username` parameters provided directly in the client's event payload. Because these values were never cross-referenced against the authenticated socket session, any authenticated malicious user could spoof another user's identity, act on their behalf inside collaboration rooms, and attribute story content to them. Furthermore, the `/collab` namespace itself was missing authentication middleware, meaning unauthenticated connections could potentially interact with it.

## Resolved Issue
Resolves #945 

## Changes Made

### `backend/src/socket/collab.socket.ts`
- **Added Authentication Middleware:** Implemented a new `collabNamespace.use(...)` middleware that verifies the user's JWT token during the socket handshake for the `/collab` namespace.
- **Secure Identity Storage:** The verified token payload is now used to extract the user's true `_id` and `name`, which are then safely stored server-side in `socket.data.userId` and `socket.data.username`.
- **Removed Client Trust:** Updated all relevant event listeners to stop destructuring and trusting `userId` and `username` from the client payload.
- **Enforced Server Identity:** Event listeners now strictly pull the user's identity from `socket.data.userId` and `socket.data.username`.

### Affected Events
- `collab:create_room`
- `collab:join_room`
- `collab:add_text`
- `collab:typing`
- `collab:stop_typing`

## Security Impact

| Before | After |
|--------|-------|
| `/collab` namespace accepted unauthenticated connections | `/collab` namespace strictly requires a valid JWT token |
| Server trusted client-provided `userId` and `username` | Server ignores client identity payloads |
| Malicious users could impersonate others in collaboration | Impersonation is impossible; server enforces identity via `socket.data` |

## How It Was Tested

- Verified that connecting to `/collab` without a valid token results in an `Unauthorized` connection error.
- Connected with a valid token and attempted to emit a `collab:add_text` event with a fake `userId` in the payload. Verified that the server ignored the fake ID and correctly attributed the text to the authenticated user's true ID.
- Verified that room creation, joining, and typing indicators still function perfectly with the refactored secure identities.

## Labels

`security` `backend` `websocket` `identity-spoofing` `high-priority`