### PR TITLE
fix(security): Add rate limiting to unprotected authentication endpoints

### DIFF
--- a/backend/src/app/middleware/ip.rate-limiter.ts
+++ b/backend/src/app/middleware/ip.rate-limiter.ts
@@ -8,80 +8,137 @@ interface RateRecord {
   blockedUntil?: number;
 }
 
-const store = new Map<string, RateRecord>();
+interface RateLimiterOptions {
+  /** Time window in milliseconds */
+  windowMs: number;
+  /** Maximum requests allowed within the window */
+  maxRequests: number;
+  /** Duration to block the IP in milliseconds once limit is exceeded */
+  blockTimeMs: number;
+  /** Unique key prefix to isolate this limiter's store entries (e.g. "login", "register") */
+  keyPrefix: string;
+  /** Human-readable label used in error messages (e.g. "login", "password reset") */
+  actionLabel?: string;
+}
 
-// Configurable limits
-const WINDOW_MS = 60 * 60 * 1000; // 1 hour window
-const MAX_REQUESTS = 5; // max registrations per WINDOW_MS
-const BLOCK_TIME_MS = 24 * 60 * 60 * 1000; // block 24 hours when exceeded
+const store = new Map<string, RateRecord>();
 
 // Cleanup old keys periodically to prevent memory leak
 const cleanupInterval = setInterval(() => {
   const now = Date.now();
   for (const [key, rec] of store.entries()) {
-    const age = now - rec.firstRequestAt;
-    if ((rec.blockedUntil && rec.blockedUntil < now) || age > WINDOW_MS + BLOCK_TIME_MS) {
+    // Use a generous max age for cleanup — 25 hours covers the largest block time
+    const MAX_AGE = 25 * 60 * 60 * 1000;
+    if ((rec.blockedUntil && rec.blockedUntil < now) || now - rec.firstRequestAt > MAX_AGE) {
       store.delete(key);
     }
   }
 }, 60 * 60 * 1000); // every hour
 cleanupInterval.unref(); // Allow Node process to exit cleanly
 
-export const ipRateLimiter = (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const ip = req.ip;
-    
-    if (!ip) {
-      throw new ApiError(httpStatus.FORBIDDEN, "Could not determine client IP address.");
-    }
-    
-    const now = Date.now();
-    const key = `reg_${ip}`;
+/**
+ * Factory function to create a rate-limiting middleware with custom thresholds.
+ * Each call returns an independent middleware that shares the global in-memory store
+ * but uses a unique key prefix so limits are tracked separately per endpoint.
+ */
+export const createRateLimiter = (options: RateLimiterOptions) => {
+  const { windowMs, maxRequests, blockTimeMs, keyPrefix, actionLabel = "request" } = options;
 
-    let rec = store.get(key);
-    if (!rec) {
-      rec = { count: 1, firstRequestAt: now };
+  return (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const ip = req.ip;
+
+      if (!ip) {
+        throw new ApiError(httpStatus.FORBIDDEN, "Could not determine client IP address.");
+      }
+
+      const now = Date.now();
+      const key = `${keyPrefix}_${ip}`;
+
+      let rec = store.get(key);
+      if (!rec) {
+        rec = { count: 1, firstRequestAt: now };
+        store.set(key, rec);
+        return next();
+      }
+
+      // If currently blocked
+      if (rec.blockedUntil && rec.blockedUntil > now) {
+        const retryAfter = Math.ceil((rec.blockedUntil - now) / 1000);
+        res.setHeader("Retry-After", String(retryAfter));
+        throw new ApiError(
+          httpStatus.TOO_MANY_REQUESTS,
+          `Too many ${actionLabel} attempts from this IP. Try again after ${Math.ceil(retryAfter / 60)} minutes.`
+        );
+      }
+
+      // Reset window if elapsed
+      if (now - rec.firstRequestAt > windowMs) {
+        rec.count = 1;
+        rec.firstRequestAt = now;
+        rec.blockedUntil = undefined;
+        store.set(key, rec);
+        return next();
+      }
+
+      rec.count += 1;
+
+      if (rec.count > maxRequests) {
+        rec.blockedUntil = now + blockTimeMs;
+        store.set(key, rec);
+        const retryAfter = Math.ceil(blockTimeMs / 1000);
+        res.setHeader("Retry-After", String(retryAfter));
+        throw new ApiError(
+          httpStatus.TOO_MANY_REQUESTS,
+          `Too many ${actionLabel} attempts. This IP has been temporarily blocked.`
+        );
+      }
+
       store.set(key, rec);
       return next();
+    } catch (error) {
+      next(error);
     }
-
-    // If currently blocked
-    if (rec.blockedUntil && rec.blockedUntil > now) {
-      const retryAfter = Math.ceil((rec.blockedUntil - now) / 1000);
-      res.setHeader("Retry-After", String(retryAfter));
-      throw new ApiError(
-        httpStatus.TOO_MANY_REQUESTS,
-        `Too many registration attempts from this IP. Try again after ${Math.ceil(retryAfter / 60)} minutes.`
-      );
-    }
-
-    // Reset window if elapsed
-    if (now - rec.firstRequestAt > WINDOW_MS) {
-      rec.count = 1;
-      rec.firstRequestAt = now;
-      rec.blockedUntil = undefined;
-      store.set(key, rec);
-      return next();
-    }
-
-    rec.count += 1;
-
-    if (rec.count > MAX_REQUESTS) {
-      rec.blockedUntil = now + BLOCK_TIME_MS;
-      store.set(key, rec);
-      const retryAfter = Math.ceil(BLOCK_TIME_MS / 1000);
-      res.setHeader("Retry-After", String(retryAfter));
-      throw new ApiError(
-        httpStatus.TOO_MANY_REQUESTS,
-        "Too many registration attempts. This IP has been temporarily blocked from registering."
-      );
-    }
-
-    store.set(key, rec);
-    return next();
-  } catch (error) {
-    next(error);
-  }
+  };
 };
 
+// ── Pre-configured rate limiters for authentication endpoints ──
+
+/** Registration: 5 attempts per hour, 24-hour block (original behaviour) */
+export const ipRateLimiter = createRateLimiter({
+  windowMs: 60 * 60 * 1000,        // 1 hour
+  maxRequests: 5,
+  blockTimeMs: 24 * 60 * 60 * 1000, // 24 hours
+  keyPrefix: "reg",
+  actionLabel: "registration",
+});
+
+/** Login: 10 attempts per 15 minutes, 15-minute block */
+export const loginRateLimiter = createRateLimiter({
+  windowMs: 15 * 60 * 1000,  // 15 minutes
+  maxRequests: 10,
+  blockTimeMs: 15 * 60 * 1000, // 15 minutes
+  keyPrefix: "login",
+  actionLabel: "login",
+});
+
+/** Forgot Password: 3 attempts per hour, 1-hour block (prevents email spam) */
+export const forgotPasswordRateLimiter = createRateLimiter({
+  windowMs: 60 * 60 * 1000,  // 1 hour
+  maxRequests: 3,
+  blockTimeMs: 60 * 60 * 1000, // 1 hour
+  keyPrefix: "forgot_pw",
+  actionLabel: "password reset",
+});
+
+/** Reset Password: 5 attempts per hour, 1-hour block */
+export const resetPasswordRateLimiter = createRateLimiter({
+  windowMs: 60 * 60 * 1000,  // 1 hour
+  maxRequests: 5,
+  blockTimeMs: 60 * 60 * 1000, // 1 hour
+  keyPrefix: "reset_pw",
+  actionLabel: "password reset",
+});
+
 export default ipRateLimiter;
+

--- a/backend/src/app/modules/auth/auth.router.ts
+++ b/backend/src/app/modules/auth/auth.router.ts
@@ -2,18 +2,23 @@ import express from "express";
 import { AuthController } from "./auth.controller";
 import validateRequest from "../../middleware/validate.request";
 import { UserValidator } from "../user/user.validation";
-import ipRateLimiter from "../../middleware/ip.rate-limiter";
+import ipRateLimiter, {
+  loginRateLimiter,
+  forgotPasswordRateLimiter,
+  resetPasswordRateLimiter,
+} from "../../middleware/ip.rate-limiter";
 const router = express.Router();
 
 // Login API route
 router.post(
   "/login",
+  loginRateLimiter,
   validateRequest(UserValidator.login),
   AuthController.login
 );
 
 // Google Login API route
-router.post("/google-login", AuthController.googleLogin);
+router.post("/google-login", loginRateLimiter, AuthController.googleLogin);
 
 // Register API route
 router.post(
@@ -29,6 +34,7 @@ router.post("/refresh-token", AuthController.refreshToken);
 // Forgot Password API route
 router.post(
   "/forgot-password",
+  forgotPasswordRateLimiter,
   validateRequest(UserValidator.forgotPassword),
   AuthController.forgotPassword
 );
@@ -36,8 +42,10 @@ router.post(
 // Reset Password API route
 router.post(
   "/reset-password",
+  resetPasswordRateLimiter,
   validateRequest(UserValidator.resetPassword),
   AuthController.resetPassword
 );
 
 export const AuthRouter = router;
+


### PR DESCRIPTION
## Summary

Addresses the **Missing Rate Limiting on Authentication Endpoints** vulnerability. While `/register` was correctly protected by `ipRateLimiter`, critical endpoints (`/login`, `/google-login`, `/forgot-password`, `/reset-password`) had no rate limiting — leaving them wide open to brute-force attacks, credential stuffing, and email spam abuse.

## Resolved Issue
Resolves #951 

## Problem

- `/login` and `/google-login` could be hammered indefinitely to guess credentials.
- `/forgot-password` could be abused to spam password-reset emails to any user.
- `/reset-password` had no throttle on token-guessing attempts.

## Solution

### 1. Refactored `ip.rate-limiter.ts` into a factory pattern

Introduced `createRateLimiter(options)` — a configurable factory that generates rate-limiting middleware with custom thresholds. All limiters share a single in-memory store but use unique key prefixes so limits are tracked independently per endpoint.

### 2. Created endpoint-specific rate limiters

| Limiter | Endpoint(s) | Window | Max Requests | Block Duration |
|---|---|---|---|---|
| `ipRateLimiter` | `/register` | 1 hour | 5 | 24 hours |
| `loginRateLimiter` | `/login`, `/google-login` | 15 min | 10 | 15 min |
| `forgotPasswordRateLimiter` | `/forgot-password` | 1 hour | 3 | 1 hour |
| `resetPasswordRateLimiter` | `/reset-password` | 1 hour | 5 | 1 hour |

### 3. Applied limiters in `auth.router.ts`

Rate limiters are placed **before** `validateRequest()` middleware so that even malformed/spam requests count against the IP's limit.

## Files Changed

- `backend/src/app/middleware/ip.rate-limiter.ts` — Refactored to factory pattern; added pre-configured limiters.
- `backend/src/app/modules/auth/auth.router.ts` — Imported and applied endpoint-specific rate limiters.

## Backward Compatibility

The original `ipRateLimiter` named + default export is preserved with identical behavior (5 req/hr, 24hr block, `reg_` key prefix). No other consumers are affected.

## Testing

- TypeScript compilation passes with zero errors.
- Verified that each limiter uses a unique store key prefix, so hitting the login limit does not affect registration or password-reset limits.
- `Retry-After` header is correctly set on `429 Too Many Requests` responses with human-readable error messages.

## Labels

`security` `backend` `rate-limiting` `authentication` `high-priority`