### PR TITLE
fix: add IP rate limiting to free AI generation endpoints to prevent …

### DIFF
--- a/backend/src/app/middleware/free-ai.rate-limiter.ts
+++ b/backend/src/app/middleware/free-ai.rate-limiter.ts
@@ -1,0 +1,87 @@
+import { Request, Response, NextFunction } from "express";
+import ApiError from "../../errors/api_error";
+import httpStatus from "http-status";
+
+interface RateRecord {
+  count: number;
+  firstRequestAt: number;
+  blockedUntil?: number;
+}
+
+const store = new Map<string, RateRecord>();
+
+// Configurable limits
+const WINDOW_MS = 24 * 60 * 60 * 1000; // 24 hours window
+const MAX_REQUESTS = 5; // max free generations per WINDOW_MS
+const BLOCK_TIME_MS = 24 * 60 * 60 * 1000; // block 24 hours when exceeded
+
+// Cleanup old keys periodically to prevent memory leak
+const cleanupInterval = setInterval(() => {
+  const now = Date.now();
+  for (const [key, rec] of store.entries()) {
+    const age = now - rec.firstRequestAt;
+    if ((rec.blockedUntil && rec.blockedUntil < now) || age > WINDOW_MS + BLOCK_TIME_MS) {
+      store.delete(key);
+    }
+  }
+}, 60 * 60 * 1000); // every hour
+cleanupInterval.unref(); // Allow Node process to exit cleanly
+
+export const freeAiRateLimiter = (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const ip = req.ip;
+    
+    if (!ip) {
+      throw new ApiError(httpStatus.FORBIDDEN, "Could not determine client IP address.");
+    }
+    
+    const now = Date.now();
+    const key = `free_ai_${ip}`;
+
+    let rec = store.get(key);
+    if (!rec) {
+      rec = { count: 1, firstRequestAt: now };
+      store.set(key, rec);
+      return next();
+    }
+
+    // If currently blocked
+    if (rec.blockedUntil && rec.blockedUntil > now) {
+      const retryAfter = Math.ceil((rec.blockedUntil - now) / 1000);
+      res.setHeader("Retry-After", String(retryAfter));
+      throw new ApiError(
+        httpStatus.TOO_MANY_REQUESTS,
+        `Daily limit for free generations reached. Try again after ${Math.ceil(retryAfter / 3600)} hours or sign in to use your monthly quota.`
+      );
+    }
+
+    // Reset window if elapsed
+    if (now - rec.firstRequestAt > WINDOW_MS) {
+      rec.count = 1;
+      rec.firstRequestAt = now;
+      rec.blockedUntil = undefined;
+      store.set(key, rec);
+      return next();
+    }
+
+    rec.count += 1;
+
+    if (rec.count > MAX_REQUESTS) {
+      rec.blockedUntil = now + BLOCK_TIME_MS;
+      store.set(key, rec);
+      const retryAfter = Math.ceil(BLOCK_TIME_MS / 1000);
+      res.setHeader("Retry-After", String(retryAfter));
+      throw new ApiError(
+        httpStatus.TOO_MANY_REQUESTS,
+        "Daily limit for free generations reached. Please sign in to continue generating stories."
+      );
+    }
+
+    store.set(key, rec);
+    return next();
+  } catch (error) {
+    next(error);
+  }
+};
+
+export default freeAiRateLimiter;

--- a/backend/src/app/modules/ai_model/ai_model.router.ts
+++ b/backend/src/app/modules/ai_model/ai_model.router.ts
@@ -3,6 +3,7 @@ import { AiModelController } from "./ai_model.controller";
 import validateRequest from "../../middleware/validate.request";
 import { AIModelValidator } from "./ai_model.validation";
 import checkRequestLimit from "../../middleware/check.request.limit";
+import freeAiRateLimiter from "../../middleware/free-ai.rate-limiter";
 const router = express.Router();
 
 // Generate Model
@@ -17,6 +18,7 @@ router.post(
 router.post(
   "/generate-free-model",
   validateRequest(AIModelValidator.aiModel),
+  freeAiRateLimiter,
   AiModelController.aiFreeModelGenerate
 );
 
@@ -32,6 +34,7 @@ router.post(
 router.post(
   "/generate-free-alternate-endings",
   validateRequest(AIModelValidator.aiAlternateEndings),
+  freeAiRateLimiter,
   AiModelController.aiFreeModelAlternateEndings
 );
 
@@ -44,6 +47,7 @@ router.post(
 // Remix Story Free
 router.post(
   "/remix-free",
+  freeAiRateLimiter,
   AiModelController.aiFreeModelRemix
 );
 // Translate Story
@@ -55,7 +59,7 @@ router.post(
 // Translate Story Free
 router.post(
   "/translate-free",
+  freeAiRateLimiter,
   AiModelController.aiFreeModelTranslate
 );
 export const AIModelRouter = router;
-


### PR DESCRIPTION
## Screenshot 
N/A  This is a purely backend logic change (Express middleware) and does not affect the user interface.


## What this PR does

**This pull request is part of my contribution to GirlScript Summer of Code (GSSoC '26).** 🌟 

Currently, the free AI generation endpoints (`/generate-free-model`, `/generate-free-alternate-endings`, `/remix-free`, and `/translate-free`) lack rate-limiting, making them highly vulnerable to bot spam and potentially exhausting the project's paid AI API quotas (OpenAI/Gemini). 

This PR introduces an IP-based rate limiter specifically designed for these endpoints:
1. Created `free-ai.rate-limiter.ts` middleware.
2. Capped the free generation endpoints to a maximum of 5 requests per IP every 24 hours.
3. Once the limit is hit, it returns a clear `429 Too Many Requests` error prompting users to sign in if they want to continue generating.

## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [x] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #964 
## More screenshots (optional)
N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
