### PR TITLE
feat: send Google credential to backend for proper token verification

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -497,23 +497,29 @@ function decodeJwt(token) {
     }
 }
 
-function handleGoogleCredentialResponse(response) {
-    const user = decodeJwt(response.credential);
-    if (user) {
-        const status = document.getElementById('google-auth-status');
-        const avatar = document.getElementById('google-user-avatar');
-        const name = document.getElementById('google-user-name');
-        const email = document.getElementById('google-user-email');
-        const googleBtnText = document.getElementById('google-btn-text');
+async function handleGoogleCredentialResponse(response) {
+    try {
+        const res = await fetch('/api/auth/google-login', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ token: response.credential }),
+        });
 
-        if (avatar) avatar.src = user.picture || '';
-        if (name) name.innerText = user.name || 'Google User';
-        if (email) email.innerText = user.email || '';
-        if (status) status.classList.remove('hidden');
+        const data = await res.json();
 
-        if (googleBtnText) {
-            googleBtnText.innerText = `Signed in as ${user.given_name || user.name}`;
+        if (!res.ok) {
+            setAlert('error', data.message || 'Google login failed. Please try again.');
+            return;
         }
+
+        localStorage.setItem('accessToken', data.data.accessToken);
+        setAlert('success', 'Signed in with Google successfully! Redirecting…');
+        setTimeout(() => {
+            window.location.href = '/dashboard';
+        }, 1000);
+
+    } catch (err) {
+        setAlert('error', 'Something went wrong with Google Sign-In. Please try again.');
     }
 }
 


### PR DESCRIPTION
## Before you open this PR
- **Issue:** Closes #865 
- **Description:** Replaces insecure client-side Google JWT decoding with a proper backend API call.
- **Screenshots:** N/A — no UI changes.

## Screenshot (when helpful)
N/A — this is a security fix with no visual changes.

## What this PR does
Previously, `handleGoogleCredentialResponse()` decoded the Google token locally 
using `decodeJwt()` with no signature verification. Anyone could craft a fake 
JWT and be treated as authenticated.

This PR fixes that by sending the token to `POST /api/auth/google-login` which 
verifies it server-side using `google-auth-library`. On success, the returned 
`accessToken` is stored in localStorage and the user is redirected to the dashboard.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue
Closes #865 

## More screenshots (optional)
N/A

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
