### PR TITLE
fix(collab): add participant checks to typing, get_room, ai_continue handlers

### DIFF
--- a/backend/src/socket/collab.socket.ts
+++ b/backend/src/socket/collab.socket.ts
@@ -3,7 +3,7 @@ import logger from "../utils/logger.util";
 import { GoogleGenerativeAI } from "@google/generative-ai";
 import config from "../config";
 import { JwtHalers } from "../utils/jwt.helper";
-import { Secret } from "jsonwebtoken";
+import type { Secret } from "jsonwebtoken";
 
 const genAI = new GoogleGenerativeAI(config.gemini_api_key as string);
 
@@ -121,7 +121,10 @@ export const setupCollabSocket = (io: Server) => {
       if (!room) return;
 
       const participant = room.participants.find(p => p.userId === userId);
-      if (!participant) return;
+      if (!participant) {
+        socket.emit("collab:error", { message: "You are not a participant of this room" });
+        return;
+      }
 
       const chunk: IStoryChunk = {
         authorId: userId,
@@ -138,8 +141,16 @@ export const setupCollabSocket = (io: Server) => {
 
     // AI continues the story
     socket.on("collab:ai_continue", async ({ roomId }) => {
+      const userId = socket.data.userId;
       const room = rooms.get(roomId);
       if (!room) return;
+
+      // Only participants can trigger AI continuation
+      const participant = room.participants.find(p => p.userId === userId);
+      if (!participant) {
+        socket.emit("collab:error", { message: "You are not a participant of this room" });
+        return;
+      }
 
       collabNamespace.to(roomId).emit("collab:ai_thinking", { roomId });
 
@@ -176,19 +187,30 @@ export const setupCollabSocket = (io: Server) => {
     socket.on("collab:typing", ({ roomId }) => {
       const userId = socket.data.userId;
       const username = socket.data.username;
+      const room = rooms.get(roomId);
+      if (!room) return;
+      if (!room.participants.some(p => p.userId === userId)) return;
       socket.to(roomId).emit("collab:user_typing", { userId, username });
     });
 
     socket.on("collab:stop_typing", ({ roomId }) => {
       const userId = socket.data.userId;
+      const room = rooms.get(roomId);
+      if (!room) return;
+      if (!room.participants.some(p => p.userId === userId)) return;
       socket.to(roomId).emit("collab:user_stop_typing", { userId });
     });
 
     // Get room info
     socket.on("collab:get_room", ({ roomId }) => {
+      const userId = socket.data.userId;
       const room = rooms.get(roomId);
       if (!room) {
         socket.emit("collab:error", { message: "Room not found" });
+        return;
+      }
+      if (!room.participants.some(p => p.userId === userId)) {
+        socket.emit("collab:error", { message: "You are not a participant of this room" });
         return;
       }
       socket.emit("collab:room_info", { room });


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Closes #769
- **Description:** Adds participant authorization checks to `collab:typing`, `collab:stop_typing`, `collab:get_room`, and `collab:ai_continue` handlers, and uses a type-only import for `Secret`.
- **Screenshots:** N/A — backend-only security hardening with no UI changes.

## Screenshot (when helpful)

N/A — backend-only change, no UI affected.

## What this PR does

PR #901 added JWT middleware to the `/collab` namespace (great!), but several event handlers still lack participant-level authorization:

- `collab:typing` / `collab:stop_typing` — any authenticated user can spam typing indicators into rooms they haven't joined.
- `collab:get_room` — any authenticated user who knows a `roomId` can read the full story content and participant list.
- `collab:ai_continue` — any authenticated user can trigger AI generation in rooms they haven't joined.
- `collab:add_text` — silently drops for non-participants but doesn't inform the client.

This PR adds `room.participants.some(...)` checks to all four handlers and returns a clear error to non-participants. It also switches `import { Secret }` to `import type { Secret }` for safer compilation under strict TS configs.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #769

## More screenshots (optional)

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
