### PR TITLE
fix: resolve status enum validation error in seed-admin script

### DIFF
--- a/backend/scripts/seed-admin.ts
+++ b/backend/scripts/seed-admin.ts
@@ -28,7 +28,7 @@ const seedAdmin = async () => {
     password: hashedPassword,
     role: "admin",
     subscriptionType: "premium",
-    status: "active",
+    status: "Active",
   });
 
   console.log(`Admin user created: ${email}`);


### PR DESCRIPTION

## Screenshot (when helpful)

N/A - This is a backend script configuration fix.

## What this PR does

This PR fixes a critical bug in the `seed-admin.ts` script that prevented developers from properly seeding the initial admin account during local development setup. 

When running `npx ts-node scripts/seed-admin.ts`, Mongoose was throwing a validation error: `` `active` is not a valid enum value for path `status` ``. This PR resolves the issue by updating the `status` payload in `User.create` from `"active"` to `"Active"`, correctly matching the expected capitalized enum defined in `enums/user_status.ts`.

*Note: I am participating in **GSSoC'26** and this is my contribution! 🚀*

## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Fixes #978 

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.

### **Additional Context** 
I am participating in **GSSoC'26** and this is my contribution for this issue! Thank you for maintaining such an awesome project! 🚀