### PR TITLE
fix(backend): use replyTo instead of spoofed from header in contact email

### DIFF
--- a/backend/src/utils/email.util.ts
+++ b/backend/src/utils/email.util.ts
@@ -67,7 +67,8 @@ export const sendContactEmail = async (data: {
   });
 
   const mailOptions = {
-    from: `"${data.fullname}" <${data.email}>`,
+    from: `"${data.fullname}" <${config.verify_email}>`,
+    replyTo: data.email,
     to: config.verify_email,
     subject: `Contact Form: ${data.subject}`,
     html: `


### PR DESCRIPTION
## Description

Fixes #983

Most SMTP services (especially Gmail SMTP which is configured here via `service: "gmail"`) strictly forbid spoofing the `from` header. If the `from` field contains an email address (`data.email`) that does not match the authenticated user (`config.verify_email`), the SMTP server will either:
1. Reject the request entirely with an authentication error.
2. Force-rewrite the `from` header back to the authenticated account's email, losing the sender's original display name and email.

This PR sets the `from` header to the authenticated `config.verify_email`, and properly forwards the sender's original email in the `replyTo` header so that direct replies still reach the sender.

## Checklist

- [x] I have read the `CONTRIBUTING.md` rules.
- [x] I have tested this change locally.
- [x] My commits follow the Conventional Commits format.
- [x] The code is clean and contains no extra dependencies.