### PR TITLE
fix: use standard Express parameter syntax for get-comments route

### DIFF
--- a/backend/src/app/modules/comment/comment.router.ts
+++ b/backend/src/app/modules/comment/comment.router.ts
@@ -20,7 +20,7 @@ router.post(
 );
 
 // Get comments by postId
-router.get("/get-comments/postId=:postId", CommentController.getCommentsByPostId);
+router.get("/get-comments/:postId", CommentController.getCommentsByPostId);
 
 // Toggle like on a comment
 router.patch(


### PR DESCRIPTION
Fixes #988

The GET /comments/get-comments route used a non-standard URL parameter format:

`router.get("/get-comments/postId=:postId", ...)`

This produced URLs like `/get-comments/postId=abc123` instead of the standard Express pattern. Clients using the standard REST format `/get-comments/:postId` received 404 errors.

Fixed by replacing with the standard Express parameter syntax:

`router.get("/get-comments/:postId", ...)`

One line change in `comment.router.ts`.

## Type of change
- [x] Bug fix

## Related issue
Fixes #988

## Screenshot
N/A — backend route fix, no UI change

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.