### PR TITLE
fix: add GET / route for admins to fetch all reports

### DIFF
--- a/backend/src/app/modules/report/report.controller.ts
+++ b/backend/src/app/modules/report/report.controller.ts
@@ -16,4 +16,13 @@ const createReport = catchAsync(async (req: Request, res: Response) => {
   });
 });
 
-export const ReportController = { createReport };
+const getAllReports = catchAsync(async (req: Request, res: Response) => {
+  const result = await ReportService.getAllReports();
+  sendResponse(res, {
+    statusCode: 200,
+    success: true,
+    message: "Reports fetched successfully",
+    data: result,
+  });
+});
+export const ReportController = { createReport, getAllReports };

--- a/backend/src/app/modules/report/report.router.ts
+++ b/backend/src/app/modules/report/report.router.ts
@@ -19,4 +19,9 @@ router.post(
   ReportController.createReport
 );
 
+router.get(
+  "/",
+  auth(ENUM_USER_ROLE.ADMIN, ENUM_USER_ROLE.SUPER_ADMIN),
+  ReportController.getAllReports
+);
 export const ReportRouter = router;


### PR DESCRIPTION
Fixes #987

`ReportService.getAllReports` was fully implemented but had no controller handler or router entry. Admins had no API endpoint to fetch submitted reports — sending `GET /api/v1/reports` returned a 404.

Added `getAllReports` controller handler in `report.controller.ts` and registered a `GET /` route in `report.router.ts` restricted to `ADMIN` and `SUPER_ADMIN` roles.

## Type of change
- [x] Bug fix

## Related issue
Fixes #987

## Screenshot
N/A — backend route fix, no UI change

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.