### PR TITLE
fix: remove duplicate import declarations in analytics.router.ts

### DIFF
--- a/backend/src/app/modules/analytics/analytics.router.ts
+++ b/backend/src/app/modules/analytics/analytics.router.ts
@@ -2,18 +2,11 @@ import express from "express";
 import { AnalyticsController } from "./analytics.controller";
 import auth from "../../middleware/auth.middleware";
 import { ENUM_USER_ROLE } from "../../../enums/user";
-
-import { ENUM_USER_ROLE } from "../../../enums/user";
-import auth from "../../middleware/auth.middleware";
-
-
 const router = express.Router();
-
 router.get("/overview", AnalyticsController.getAnalyticsOverview);
 router.get("/heatmap", AnalyticsController.getHeatmap);
 router.get("/genres", AnalyticsController.getGenreDistribution);
 router.get("/wordcloud", AnalyticsController.getWordCloud);
-
 router.get(
   "/productive-hours",
   auth(
@@ -24,7 +17,6 @@ router.get(
   ),
   AnalyticsController.getProductiveHours
 );
-
 router.get(
   "/emotion-distribution",
   auth(
@@ -35,7 +27,6 @@ router.get(
   ),
   AnalyticsController.getEmotionDistribution
 );
-
 router.get(
   "/mood-timeline",
   auth(
@@ -46,5 +37,4 @@ router.get(
   ),
   AnalyticsController.getMoodTimeline
 );
-
 export const AnalyticsRouter = router;


### PR DESCRIPTION
Fixes #1002 

`backend/src/app/modules/analytics/analytics.router.ts` had duplicate import declarations for both `auth` and `ENUM_USER_ROLE`:

import { ENUM_USER_ROLE } from "../../../enums/user";
import auth from "../../middleware/auth.middleware";
import { ENUM_USER_ROLE } from "../../../enums/user";
import auth from "../../middleware/auth.middleware";

Duplicate imports are a TypeScript compilation error — `Cannot redeclare block-scoped variable`. This prevents the backend from building correctly.

Fixed by removing the duplicate import lines, keeping one of each.

## Type of change
- [x] Bug fix

## Related issue
Fixes #(your issue number here)

## Screenshot
N/A — import cleanup, no runtime behavior change

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.