### PR TITLE
fix: exclude password field from getAllUsers response

### DIFF
--- a/backend/src/app/modules/user/user.service.ts
+++ b/backend/src/app/modules/user/user.service.ts
@@ -15,7 +15,7 @@ import { Report } from "../report/report.model";
 const allowedSocialFields = ["facebook", "twitter", "linkedin", "instagram"] as const;
 
 const getAllUsers = async (): Promise<IUser[]> => {
-  const result = await User.find({});
+  const result = await User.find({}).select("-password");
   return result;
 };
 


### PR DESCRIPTION
Fixes #1020 

`getAllUsers` in `user.service.ts` called `User.find({})` with no field exclusion, returning every user document including the hashed password field. Any `ADMIN` or `SUPER_ADMIN` could fetch all user password hashes via `GET /api/v1/user/lists`.

Fixed by adding `.select("-password")` — consistent with `getUser` which already correctly excludes the password field.

## Type of change
- [x] Bug fix

## Related issue
Fixes #(your issue number here)

## Screenshot
N/A — backend fix, no UI change

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.