### PR TITLE
refactor: strip verificationToken from register payload before User.create

### DIFF
--- a/backend/src/app/modules/auth/auth.service.ts
+++ b/backend/src/app/modules/auth/auth.service.ts
@@ -92,7 +92,8 @@ const register = async (payload: IUser & { verificationToken?: string }) => {
     throw new ApiError(httpStatus.CONFLICT, "User already exists!");
   }
   
-  const result = await User.create(payload);
+  const { verificationToken: _, ...userPayload } = payload;
+  const result = await User.create(userPayload);
   
   // Clean up OTP record after successful registration
   await OTPModel.deleteOne({ email: userEmail });

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -5,6 +5,7 @@ import {
   useMarkNotificationReadMutation,
 } from "../redux/apis/notification.api";
 import { connectSocket, disconnectSocket, getSocketIo } from "../socket/socket.oi";
+import type { NotificationItem } from "../models/notification";
 
 /**
  * Notification bell: REST + Socket.IO real-time updates.
@@ -13,7 +14,7 @@ import { connectSocket, disconnectSocket, getSocketIo } from "../socket/socket.o
  */
 export const useNotifications = () => {
   const [isOpen, setIsOpen] = useState(false);
-  const [realtimeNotifications, setRealtimeNotifications] = useState<any[]>([]);
+  const [realtimeNotifications, setRealtimeNotifications] = useState<NotificationItem[]>([]);
   const isAuthed = isLoggedIn();
 
   const { data, isFetching, refetch } = useGetNotificationsQuery(undefined, {
@@ -26,7 +27,7 @@ export const useNotifications = () => {
     const baseNotifications = data ?? [];
     // Add real-time notifications that aren't already in the list
     const newRealtime = realtimeNotifications.filter(
-      (rt) => !baseNotifications.some((n: any) => n._id === rt._id)
+      (rt: NotificationItem) => !baseNotifications.some((n: NotificationItem) => n._id === rt._id)
     );
     return [...newRealtime, ...baseNotifications];
   }, [data, realtimeNotifications]);
@@ -60,7 +61,7 @@ export const useNotifications = () => {
       }
 
       // Listen for real-time notifications
-      const handleNewNotification = (notification: any) => {
+      const handleNewNotification = (notification: NotificationItem) => {
         console.log("[Story Spark] Received notification:", notification);
         setRealtimeNotifications((prev) => [notification, ...prev]);
         // Refetch to keep in sync with backend


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Closes #1037
- **Description:** Fill in **What this PR does** so a reviewer can understand the change without your local context.
- **Screenshots:** Add screenshots or a short recording when they help (UI changes, confusing flows, or non-code proof). If not needed, say so in the checklist.

## Screenshot (when helpful)

N/A

## What this PR does

This PR ensures that when a new user registers in `auth.service.ts`, only valid user fields belonging to the schema are passed to `User.create()`. It destructures and discards the `verificationToken` from the payload, preventing strict-mode violations or accidental leaks of validation tokens into the database or logs.

## Type of change

- [x] Code refactor

## Related issue

Closes #1037

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason (Noted N/A as this is a non-UI logic change).
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
