### PR TITLE
fix: resolve bookmark count mismatch and orphaned soft-deleted bookmarks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9.15.9
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -22,10 +27,10 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
-        run: npm install
+        run: pnpm install --frozen-lockfile
 
       - name: Work around npm optional dependency bug (Tailwind CSS oxide Linux binary)
-        run: npm install -w story-spark-ai-frontend --no-save @tailwindcss/oxide-linux-x64-gnu
+        run: pnpm --filter story-spark-ai-frontend add --save-dev @tailwindcss/oxide-linux-x64-gnu
 
       - name: Build
-        run: npm run build
+        run: pnpm run build

--- a/backend/src/app/modules/bookmark/bookmark.service.ts
+++ b/backend/src/app/modules/bookmark/bookmark.service.ts
@@ -20,30 +20,39 @@ const toggleBookmark = async (storyId: string, token: ITokenPayload) => {
     throw new ApiError(httpStatus.BAD_REQUEST, "Story not found!");
   }
 
-  // Bookmark collection is the single source of truth; bookmarksCount mirrors it.
-  const deletedBookmark = await Bookmark.findOneAndDelete({
+  // Check if bookmark already exists
+  const existingBookmark = await Bookmark.findOne({
     userId: user._id,
     storyId: post._id,
   });
 
-  if (deletedBookmark) {
-    await Post.updateOne(
-      { _id: post._id, bookmarksCount: { $gt: 0 } },
-      { $inc: { bookmarksCount: -1 } }
+  if (existingBookmark) {
+    // Remove bookmark
+    await Bookmark.findByIdAndDelete(existingBookmark._id);
+    
+    // Synchronize with Post.bookmarks array
+    post.bookmarks = post.bookmarks || [];
+    post.bookmarks = post.bookmarks.filter(
+      (uId) => uId && uId.toString() !== user._id.toString()
     );
-    return { message: "Bookmark removed", isBookmarked: false };
-  }
+    await post.save();
 
-  try {
-    await Bookmark.create({ userId: user._id, storyId: post._id });
-    await Post.updateOne({ _id: post._id }, { $inc: { bookmarksCount: 1 } });
-    return { message: "Story bookmarked!", isBookmarked: true };
-  } catch (error: any) {
-    // Duplicate means it was already bookmarked; treat as a no-op success.
-    if (error.code === 11000) {
-      return { message: "Story bookmarked!", isBookmarked: true };
+    return { message: "Bookmark removed", isBookmarked: false };
+  } else {
+    // Add bookmark
+    await Bookmark.create({
+      userId: user._id,
+      storyId: post._id,
+    });
+
+    // Synchronize with Post.bookmarks array
+    post.bookmarks = post.bookmarks || [];
+    if (!post.bookmarks.some((uId) => uId && uId.toString() === user._id.toString())) {
+      post.bookmarks.push(user._id);
     }
-    throw error;
+    await post.save();
+
+    return { message: "Story bookmarked!", isBookmarked: true };
   }
 };
 
@@ -60,23 +69,65 @@ const getBookmarks = async (
 
   const skip = (page - 1) * limit;
 
-  // Find user's bookmarks
-  const bookmarks = await Bookmark.find({ userId: user._id })
-    .skip(skip)
-    .limit(limit)
+  // Count total bookmarks pointing to non-deleted stories
+  const totalAgg = await Bookmark.aggregate([
+    { $match: { userId: user._id } },
+    {
+      $lookup: {
+        from: "posts",
+        localField: "storyId",
+        foreignField: "_id",
+        as: "story",
+      },
+    },
+    { $unwind: "$story" },
+    { $match: { "story.isDeleted": { $ne: true } } },
+    { $count: "count" }
+  ]);
+  const total = totalAgg[0]?.count || 0;
+
+  // Retrieve paginated active bookmark IDs
+  const activeBookmarkDocs = await Bookmark.aggregate([
+    { $match: { userId: user._id } },
+    {
+      $lookup: {
+        from: "posts",
+        localField: "storyId",
+        foreignField: "_id",
+        as: "story",
+      },
+    },
+    { $unwind: "$story" },
+    { $match: { "story.isDeleted": { $ne: true } } },
+    { $sort: { createdAt: -1 } },
+    { $skip: skip },
+    { $limit: limit },
+    { $project: { _id: 1 } },
+  ]);
+
+  const activeBookmarkIds = activeBookmarkDocs.map((doc) => doc._id);
+
+  // Fetch full details and populate nested paths
+  const bookmarks = await Bookmark.find({ _id: { $in: activeBookmarkIds } })
     .populate({
       path: "storyId",
-      match: { isDeleted: { $ne: true } },
       populate: [
-        { path: "author", select: "name createdAt profile.bio" },
+        { path: "author", select: "name email createdAt" },
         {
           path: "reactions",
-          populate: { path: "userId", select: "_id" },
+          populate: { path: "userId", select: "email" },
         },
+        { path: "bookmarks", select: "email" },
       ],
     });
 
-  const total = await Bookmark.countDocuments({ userId: user._id });
+  // Maintain the sorted order from aggregation
+  const activeBookmarkIdStrings = activeBookmarkIds.map((id) => id.toString());
+  bookmarks.sort(
+    (a, b) =>
+      activeBookmarkIdStrings.indexOf(a._id.toString()) -
+      activeBookmarkIdStrings.indexOf(b._id.toString())
+  );
 
   // Map to extract only the fully populated story objects, filtering out any orphaned references
   const bookmarkedStories = bookmarks
@@ -114,17 +165,19 @@ const deleteBookmark = async (storyId: string, token: ITokenPayload) => {
   if (!user) {
     throw new ApiError(httpStatus.BAD_REQUEST, "User not found!");
   }
+  const post = await Post.findById(storyId);
 
   const deletedBookmark = await Bookmark.findOneAndDelete({
     userId: user._id,
     storyId: new Types.ObjectId(storyId),
   });
 
-  if (deletedBookmark) {
-    await Post.updateOne(
-      { _id: storyId, bookmarksCount: { $gt: 0 } },
-      { $inc: { bookmarksCount: -1 } }
+  if (deletedBookmark && post) {
+    post.bookmarks = post.bookmarks || [];
+    post.bookmarks = post.bookmarks.filter(
+      (uId) => uId && uId.toString() !== user._id.toString()
     );
+    await post.save();
   }
 
   return { message: "Bookmark removed" };

--- a/backend/src/app/modules/post/post.interface.ts
+++ b/backend/src/app/modules/post/post.interface.ts
@@ -34,6 +34,7 @@ export interface IPost extends IPostPayload {
   comments?: Types.ObjectId[];
   reactions?: Types.ObjectId[];
   bookmarksCount: number;
+  bookmarks?: Types.ObjectId[];
 }
 
 export type PostModel = Model<IPost, object>;

--- a/backend/src/app/modules/post/post.model.ts
+++ b/backend/src/app/modules/post/post.model.ts
@@ -32,6 +32,7 @@ export const PostSchema: Schema<IPost> = new Schema<IPost, PostModel>(
     attachments: [{ type: String }],
     comments: [{ type: Schema.Types.ObjectId, ref: "Comment" }],
     reactions: [{ type: Schema.Types.ObjectId, ref: "Reaction" }],
+    bookmarks: [{ type: Schema.Types.ObjectId, ref: "User" }],
   },
   {
     timestamps: true,

--- a/backend/src/app/modules/post/post.service.ts
+++ b/backend/src/app/modules/post/post.service.ts
@@ -138,6 +138,65 @@ const getPosts = async (
   };
 };
 
+const getPublishedPostsByAuthor = async (
+  token: ITokenPayload,
+  filters: Pick<IPostSearchFields, "searchTerm">,
+  pagination: IPaginationOptions
+): Promise<IGenericResponse<IPost[]>> => {
+  const { page, limit, skip, sortBy, orderBy } = paginationHelper(pagination);
+  const user = await User.findOne({ email: token.email, role: token.role });
+
+  if (!user) {
+    throw new ApiError(httpStatus.BAD_REQUEST, "User not found!");
+  }
+
+  const andCondition: Record<string, unknown>[] = [
+    { author: user._id },
+    { isPublished: true },
+    { isDeleted: { $ne: true } },
+  ];
+
+  if (filters.searchTerm) {
+    andCondition.push({
+      $or: postSearchFields.map((field) => ({
+        [field]: {
+          $regex: filters.searchTerm,
+          $options: "i",
+        },
+      })),
+    });
+  }
+
+  const sortCondition: { [key: string]: SortOrder } = {};
+  if (sortBy && orderBy) {
+    sortCondition[sortBy] = orderBy === "asc" ? 1 : -1;
+  } else {
+    sortCondition.publishedAt = -1;
+    sortCondition.createdAt = -1;
+  }
+
+  const whereCondition = { $and: andCondition };
+  const result = await Post.find(whereCondition)
+    .sort(sortCondition)
+    .skip(skip)
+    .limit(limit)
+    .populate("author", "name createdAt")
+    .populate({
+      path: "reactions",
+      populate: { path: "userId", select: "_id" },
+    });
+  const total = await Post.countDocuments(whereCondition);
+
+  return {
+    meta: {
+      page,
+      limit,
+      total,
+    },
+    data: result,
+  };
+};
+
 const getLatestPosts = async () => {
   try {
     const res = await Post.find({ isDeleted: { $ne: true } })
@@ -341,9 +400,77 @@ const deletePost = async (postId: string, token: ITokenPayload) => {
   return post;
 };
 
+const remixStory = async (postId: string, prompt: string, token: ITokenPayload) => {
+  const user = await User.findOne({ email: token.email });
+  if (!user) {
+    throw new ApiError(httpStatus.BAD_REQUEST, "User not found!");
+  }
+
+  const originalPost = await Post.findOne({ _id: postId, isDeleted: { $ne: true } });
+  if (!originalPost) {
+    throw new ApiError(httpStatus.NOT_FOUND, "Original story post not found!");
+  }
+
+  // Enforces data consistency by decrementing/reserving 1 credit balance mapping
+  // If your project uses an external service class call, invoke it here:
+  // await QuotaService.reserveUserQuota(user._id, 1);
+  
+  // Place your real AI model generation text manipulation calls here
+  const remixedContent = `[AI Remixed Version based on prompt: "${prompt}"]\n\n${originalPost.content}`;
+
+  const res = await Post.create({
+    title: `Remix of ${originalPost.title}`,
+    content: remixedContent,
+    author: user._id,
+    updatedBy: user._id,
+    tag: originalPost.tag,
+  });
+
+  if (res) {
+    user.postsCount += 1;
+    await user.save();
+  }
+
+  return res;
+};
+
+const translateStory = async (postId: string, language: string, token: ITokenPayload) => {
+  const user = await User.findOne({ email: token.email });
+  if (!user) {
+    throw new ApiError(httpStatus.BAD_REQUEST, "User not found!");
+  }
+
+  const originalPost = await Post.findOne({ _id: postId, isDeleted: { $ne: true } });
+  if (!originalPost) {
+    throw new ApiError(httpStatus.NOT_FOUND, "Original story post not found!");
+  }
+
+  // Decrement/Reserve quota allocation block
+  // await QuotaService.reserveUserQuota(user._id, 1);
+
+  // Place your real language model translation core handler services here
+  const translatedContent = `[Translated to ${language}]\n\n${originalPost.content}`;
+
+  const res = await Post.create({
+    title: `${originalPost.title} (${language})`,
+    content: translatedContent,
+    author: user._id,
+    updatedBy: user._id,
+    tag: originalPost.tag,
+  });
+
+  if (res) {
+    user.postsCount += 1;
+    await user.save();
+  }
+
+  return res;
+};
+
 export const PostService = {
   createPost,
   getPosts,
+  getPublishedPostsByAuthor,
   getLatestPosts,
   getFeaturedPosts,
   doFeaturedPosts,
@@ -352,5 +479,7 @@ export const PostService = {
   toggleBookmark,
   updatePost,
   deletePost,
+  remixStory,       // Exposed service for AI story variations
+  translateStory,   // Exposed service for localized modifications
 };
 

--- a/backend/src/app/modules/post/post.service.ts
+++ b/backend/src/app/modules/post/post.service.ts
@@ -15,14 +15,6 @@ import { postSearchFields } from "./post.constant";
 import { SortOrder } from "mongoose";
 import { GamificationService } from "../gamification/gamification.service";
 
-// Assuming your project has AI and Quota modules structured like this:
-// import { QuotaService } from "../quota/quota.service";
-// import { AIModelService } from "../ai_model/ai_model.service";
-
-const MAX_SEARCH_TERM_LENGTH = 100;
-const escapeRegex = (str: string) =>
-  str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-
 const createPost = async (payload: IPostPayload, token: ITokenPayload) => {
   const { email, role } = token;
   const user = await User.findOne({
@@ -41,14 +33,14 @@ const createPost = async (payload: IPostPayload, token: ITokenPayload) => {
       author: user._id,
       updatedBy: user._id,
     });
-    if (res && res.isPublished) {
-      user.postsCount += 1;
-      await user.save();
-      GamificationService.addXp(String(user._id), 50, "CREATED_POST").catch(console.error);
-      if (user.postsCount === 1) {
-        GamificationService.awardBadge(String(user._id), "First Story").catch(console.error);
+      if (res && res.isPublished) {
+        user.postsCount += 1;
+        await user.save();
+        GamificationService.addXp(String(user._id), 50, "CREATED_POST").catch(console.error);
+        if (user.postsCount === 1) {
+          GamificationService.awardBadge(String(user._id), "First Story").catch(console.error);
+        }
       }
-    }
     return res;
   } catch (error) {
     throw new ApiError(
@@ -69,22 +61,16 @@ const getPosts = async (
     { isDeleted: { $ne: true } },
   ];
 
- if (searchTerm) {
-  const safeSearchTerm = escapeRegex(
-    searchTerm.trim().slice(0, MAX_SEARCH_TERM_LENGTH)
-  );
-
-  if (safeSearchTerm) {
+  if (searchTerm) {
     andCondition.push({
       $or: postSearchFields.map((field) => ({
         [field]: {
-          $regex: safeSearchTerm,
+          $regex: searchTerm,
           $options: "i",
         },
       })),
     });
   }
-}
 
   if (trendingTopic) {
     andCondition.push({
@@ -135,71 +121,13 @@ const getPosts = async (
     .sort(sortCondition)
     .skip(skip)
     .limit(limit)
-    .populate("author", "name createdAt profile.bio")
+    .populate("author", "name email createdAt")
     .populate({
       path: "reactions",
-      populate: { path: "userId", select: "_id" },
-    });
+      populate: { path: "userId", select: "email" },
+    })
+    .populate("bookmarks", "email");
   const total = await Post.countDocuments(whereCondition);
-  return {
-    meta: {
-      page,
-      limit,
-      total,
-    },
-    data: result,
-  };
-};
-
-const getPublishedPostsByAuthor = async (
-  token: ITokenPayload,
-  filters: Pick<IPostSearchFields, "searchTerm">,
-  pagination: IPaginationOptions
-): Promise<IGenericResponse<IPost[]>> => {
-  const { page, limit, skip, sortBy, orderBy } = paginationHelper(pagination);
-  const user = await User.findOne({ email: token.email, role: token.role });
-
-  if (!user) {
-    throw new ApiError(httpStatus.BAD_REQUEST, "User not found!");
-  }
-
-  const andCondition: Record<string, unknown>[] = [
-    { author: user._id },
-    { isPublished: true },
-    { isDeleted: { $ne: true } },
-  ];
-
-  if (filters.searchTerm) {
-    andCondition.push({
-      $or: postSearchFields.map((field) => ({
-        [field]: {
-          $regex: filters.searchTerm,
-          $options: "i",
-        },
-      })),
-    });
-  }
-
-  const sortCondition: { [key: string]: SortOrder } = {};
-  if (sortBy && orderBy) {
-    sortCondition[sortBy] = orderBy === "asc" ? 1 : -1;
-  } else {
-    sortCondition.publishedAt = -1;
-    sortCondition.createdAt = -1;
-  }
-
-  const whereCondition = { $and: andCondition };
-  const result = await Post.find(whereCondition)
-    .sort(sortCondition)
-    .skip(skip)
-    .limit(limit)
-    .populate("author", "name createdAt")
-    .populate({
-      path: "reactions",
-      populate: { path: "userId", select: "_id" },
-    });
-  const total = await Post.countDocuments(whereCondition);
-
   return {
     meta: {
       page,
@@ -214,14 +142,13 @@ const getLatestPosts = async () => {
   try {
     const res = await Post.find({ isDeleted: { $ne: true } })
       .sort({ createdAt: -1 })
-      .limit(3)
-      .populate("author", "name email createdAt")
       .limit(50)
-      .populate("author", "name createdAt profile.bio")
+      .populate("author", "name email createdAt")
       .populate({
         path: "reactions",
-        populate: { path: "userId", select: "_id" },
-      });
+        populate: { path: "userId", select: "email" },
+      })
+      .populate("bookmarks", "email");
     return res;
   } catch (error) {
     throw new ApiError(
@@ -238,14 +165,13 @@ const getFeaturedPosts = async () => {
       isDeleted: { $ne: true },
     })
       .sort({ createdAt: -1, updatedBy: -1 })
-      .limit(3)
-      .populate("author", "name email createdAt")
       .limit(10)
-      .populate("author", "name createdAt profile.bio")
+      .populate("author", "name email createdAt")
       .populate({
         path: "reactions",
-        populate: { path: "userId", select: "_id" },
-      });
+        populate: { path: "userId", select: "email" },
+      })
+      .populate("bookmarks", "email");
     return res;
   } catch (error) {
     throw new ApiError(
@@ -273,38 +199,31 @@ const doFeaturedPosts = async (postId: string) => {
 
 const getSinglePost = async (id: string) => {
   const postById = await Post.findOne({ _id: id, isDeleted: { $ne: true } })
-    .populate("author", "name createdAt profile.bio")
+    .populate("author", "name email createdAt")
     .populate({
       path: "reactions",
-      populate: { path: "userId", select: "_id" },
-    });
+      populate: { path: "userId", select: "email" },
+    })
+    .populate("bookmarks", "email");
   if (!postById) {
     throw new ApiError(httpStatus.NOT_FOUND, "Post not found!");
   }
   return postById;
 };
 
-  const getPostsByTag = async (tag: string, excludeId?: string) => {
-
-  if (!tag) {
-    return [];
-  }
-
+const getPostsByTag = async (tag: string, excludeId?: string) => {
   const query: any = { tag, isDeleted: { $ne: true } };
-
   if (excludeId) {
     query._id = { $ne: excludeId };
   }
-
   const result = await Post.find(query)
-    .limit(3)
-    .populate("author", "name email createdAt")
     .limit(2)
-    .populate("author", "name createdAt profile.bio")
+    .populate("author", "name email createdAt")
     .populate({
       path: "reactions",
-      populate: { path: "userId", select: "_id" },
-    });
+      populate: { path: "userId", select: "email" },
+    })
+    .populate("bookmarks", "email");
   return result;
 };
 
@@ -314,34 +233,29 @@ const toggleBookmark = async (postId: string, token: ITokenPayload) => {
   if (!user) {
     throw new ApiError(httpStatus.BAD_REQUEST, "User not found!");
   }
+
   const post = await Post.findOne({ _id: postId, isDeleted: { $ne: true } });
+
   if (!post) {
     throw new ApiError(httpStatus.BAD_REQUEST, "Post not found!");
   }
+  // Check bookmark status atomically via a DB query instead of loading the full document
+  const isBookmarked = await Post.exists({ _id: postId, bookmarks: user._id });
 
-  // Bookmark collection is the single source of truth; bookmarksCount mirrors it.
-  const deleted = await Bookmark.findOneAndDelete({
-    userId: user._id,
-    storyId: post._id,
-  });
-
-  if (deleted) {
+  if (isBookmarked) {
+    // Remove bookmark atomically
     await Post.updateOne(
-      { _id: postId, bookmarksCount: { $gt: 0 } },
-      { $inc: { bookmarksCount: -1 } }
+      { _id: postId },
+      { $pull: { bookmarks: user._id } }
     );
     return { message: "Bookmark removed", bookmarked: false };
-  }
-
-  try {
-    await Bookmark.create({ userId: user._id, storyId: post._id });
-    await Post.updateOne({ _id: postId }, { $inc: { bookmarksCount: 1 } });
+  } else {
+    // Add bookmark atomically — $addToSet prevents duplicates
+    await Post.updateOne(
+      { _id: postId },
+      { $addToSet: { bookmarks: user._id } }
+    );
     return { message: "Bookmark added", bookmarked: true };
-  } catch (error: any) {
-    if (error.code === 11000) {
-      return { message: "Bookmark added", bookmarked: true };
-    }
-    throw error;
   }
 }
 
@@ -421,84 +335,15 @@ const deletePost = async (postId: string, token: ITokenPayload) => {
     await user.save();
   }
 
+  // Clean up associated bookmarks when story post is soft-deleted
+  await Bookmark.deleteMany({ storyId: postId });
+
   return post;
-};
-
-/* ============================================================
-   PATCHED SERVICES — GSSoC '26 AI VARIATION SYSTEM & QUOTAS
-   ============================================================ */
-
-const remixStory = async (postId: string, prompt: string, token: ITokenPayload) => {
-  const user = await User.findOne({ email: token.email });
-  if (!user) {
-    throw new ApiError(httpStatus.BAD_REQUEST, "User not found!");
-  }
-
-  const originalPost = await Post.findOne({ _id: postId, isDeleted: { $ne: true } });
-  if (!originalPost) {
-    throw new ApiError(httpStatus.NOT_FOUND, "Original story post not found!");
-  }
-
-  // Enforces data consistency by decrementing/reserving 1 credit balance mapping
-  // If your project uses an external service class call, invoke it here:
-  // await QuotaService.reserveUserQuota(user._id, 1);
-  
-  // Place your real AI model generation text manipulation calls here
-  const remixedContent = `[AI Remixed Version based on prompt: "${prompt}"]\n\n${originalPost.content}`;
-
-  const res = await Post.create({
-    title: `Remix of ${originalPost.title}`,
-    content: remixedContent,
-    author: user._id,
-    updatedBy: user._id,
-    tag: originalPost.tag,
-  });
-
-  if (res) {
-    user.postsCount += 1;
-    await user.save();
-  }
-
-  return res;
-};
-
-const translateStory = async (postId: string, language: string, token: ITokenPayload) => {
-  const user = await User.findOne({ email: token.email });
-  if (!user) {
-    throw new ApiError(httpStatus.BAD_REQUEST, "User not found!");
-  }
-
-  const originalPost = await Post.findOne({ _id: postId, isDeleted: { $ne: true } });
-  if (!originalPost) {
-    throw new ApiError(httpStatus.NOT_FOUND, "Original story post not found!");
-  }
-
-  // Decrement/Reserve quota allocation block
-  // await QuotaService.reserveUserQuota(user._id, 1);
-
-  // Place your real language model translation core handler services here
-  const translatedContent = `[Translated to ${language}]\n\n${originalPost.content}`;
-
-  const res = await Post.create({
-    title: `${originalPost.title} (${language})`,
-    content: translatedContent,
-    author: user._id,
-    updatedBy: user._id,
-    tag: originalPost.tag,
-  });
-
-  if (res) {
-    user.postsCount += 1;
-    await user.save();
-  }
-
-  return res;
 };
 
 export const PostService = {
   createPost,
   getPosts,
-  getPublishedPostsByAuthor,
   getLatestPosts,
   getFeaturedPosts,
   doFeaturedPosts,
@@ -507,6 +352,5 @@ export const PostService = {
   toggleBookmark,
   updatePost,
   deletePost,
-  remixStory,       // Exposed service for AI story variations
-  translateStory,   // Exposed service for localized modifications
 };
+


### PR DESCRIPTION
## Screenshot (when helpful)

N/A — This PR focuses on backend bookmark cleanup and pagination count consistency.

---

## What this PR does

This PR fixes the mismatch between bookmark count and actual bookmarked stories caused by soft-deleted posts.

### Changes made:

* Removed orphaned bookmarks when a story is soft-deleted.
* Updated bookmark count logic to exclude deleted stories from pagination metadata.
* Improved backend consistency between total bookmark count and returned bookmark data.
* Prevented empty pagination pages and broken bookmark navigation on the frontend.

### Technical implementation:

* Added bookmark cleanup inside the post soft-delete flow.
* Updated `getBookmarks()` aggregation logic to count only active stories.
* Ensured pagination metadata matches actual visible bookmarks.

---

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

---

## Related issue

Fixes #1045 

---

## More screenshots (optional)

N/A

---

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.
