### PR TITLE
fix: resolve merge conflict remnant in toggleBookmark function

### DIFF
--- a/backend/src/app/modules/post/post.service.ts
+++ b/backend/src/app/modules/post/post.service.ts
@@ -232,10 +232,10 @@ const toggleBookmark = async (postId: string, token: ITokenPayload) => {
   if (!user) {
     throw new ApiError(httpStatus.BAD_REQUEST, "User not found!");
   }
- main
+ const post = await Post.findOne({ _id: postId, isDeleted: { $ne: true } });
+  if (!post) {
     throw new ApiError(httpStatus.BAD_REQUEST, "Post not found!");
   }
-
   // Check bookmark status atomically via a DB query instead of loading the full document
   const isBookmarked = await Post.exists({ _id: postId, bookmarks: user._id });
 
@@ -254,7 +254,7 @@ const toggleBookmark = async (postId: string, token: ITokenPayload) => {
     );
     return { message: "Bookmark added", bookmarked: true };
   }
-};
+}
 
 const updatePost = async (
   postId: string,


### PR DESCRIPTION
#1050 


Description:
Removed stray main merge conflict remnant in toggleBookmark function and restored the missing post lookup query in post.service.ts


## Screenshot (when helpful)

Before (Broken):
if (!user) {
    throw new ApiError(httpStatus.BAD_REQUEST, "User not found!");
  }
 main
    throw new ApiError(httpStatus.BAD_REQUEST, "Post not found!");
  }

After (Fixed):
if (!user) {
    throw new ApiError(httpStatus.BAD_REQUEST, "User not found!");
  }

  const post = await Post.findOne({ _id: postId, isDeleted: { $ne: true } });
  if (!post) {
    throw new ApiError(httpStatus.BAD_REQUEST, "Post not found!");
  }



## What this PR does

Fixes a TypeScript compilation error caused by an unresolved git merge conflict remnant in the toggleBookmark function inside post.service.ts. The stray word main was left in the code and the post lookup query was missing entirely, which prevented the backend server from starting.



## Type of change

- [ ] Bug fix

## Related issue
#1050 

## Checklist

- [ ] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [ ] I have filled in the related issue number when there is one.
- [ ] I have tested my changes.
- [ ] I have done a self-review of the code.
