### PR TITLE
fix: resolve React Hooks rule violations in stories view

### DIFF
--- a/frontend/src/components/stories/stories.view.component.tsx
+++ b/frontend/src/components/stories/stories.view.component.tsx
@@ -323,13 +323,6 @@ const StoriesViewComponent: React.FC<StoriesComponentProps> = ({
       setIsGeneratingEndings(false);
     }
   };
-  if (!stories.length) {
-  return (
-    <div className="text-center text-gray-400 py-10">
-      No stories generated yet. Start by entering a prompt ✨
-    </div>
-  );
-}
   const handleApplyEnding = (endingData: { style: string; ending: string; fullStory: string }) => {
     if (!selectedStory) return;
     const updatedStory = { ...selectedStory, content: endingData.fullStory };
@@ -580,10 +573,18 @@ const StoriesViewComponent: React.FC<StoriesComponentProps> = ({
       </div>
     );
   }
+
+  if (!stories || !stories.length) {
+    return (
+      <div className="text-center text-gray-400 py-10">
+        No stories generated yet. Start by entering a prompt ✨
+      </div>
+    );
+  }
+
   if (!selectedStory) {
     return null;
   }
-  if (!selectedStory) return null;
 
   return (
     <div className="mt-16 px-4 sm:px-6 lg:px-8 max-w-8xl mx-auto pb-10">


### PR DESCRIPTION
## Description
This PR resolves critical `react-hooks/rules-of-hooks` violations within the `stories.view.component.tsx` file that were preventing successful linting and risking severe runtime instability.

An early return condition (`if (!stories.length)`) was previously placed prematurely in the component body, causing multiple `useEffect` and `useMemo` hooks to be bypassed conditionally. Since React strictly relies on a consistent order of hook execution across renders, this behavior could trigger unpredictable UI states, stale memory leaks, or application crashes.

### Changes Made:
- **Hook Adherence**: Relocated the empty state early return safely below all React hook declarations. 
- **Unconditional Execution**: Guaranteed that state tracking hooks (`selectTopics`, `audioPlayerRef`, `narrationWordIndex`), memoizations (`sentenceSegments`), and `autoSaveStory` lifecycle hooks successfully register on every single render cycle.
- **Verification**: The file now cleanly passes ESLint checks for the Rules of Hooks.

## Resolved Issue
Resolves #1061

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code Refactor / Code Cleanup

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] The modified components compile successfully without triggering ESLint hooks warnings
- [x] The early return placement does not interfere with intended UI states or loading spinners
