### PR TITLE
fix(#1041): add auth middleware to POST /create-order and POST /verify payment routes

### DIFF
--- a/backend/src/router/payment.route.ts
+++ b/backend/src/router/payment.route.ts
@@ -1,12 +1,14 @@
 import { Router } from "express";
 import { createOrder, verifyPayment } from "../controllers/payment.controller";
+import auth from "../app/middleware/auth.middleware";
+import { ENUM_USER_ROLE } from "../enums/user";
 
 const paymentRouter = Router();
 
-// Route to create a new Razorpay order
-paymentRouter.post("/create-order", createOrder);
+// Route to create a new Razorpay order — requires a valid user session
+paymentRouter.post("/create-order", auth(ENUM_USER_ROLE.USER), createOrder);
 
-// Route to verify payment signature after successful payment
-paymentRouter.post("/verify", verifyPayment);
+// Route to verify payment signature after successful payment — requires a valid user session
+paymentRouter.post("/verify", auth(ENUM_USER_ROLE.USER), verifyPayment);
 
 export default paymentRouter;


### PR DESCRIPTION
## Summary

Fixes #1041

Both Razorpay payment endpoints were registered without any authentication guard, allowing anonymous HTTP callers to:
- Create arbitrary Razorpay orders (consuming integration quota and potentially triggering downstream billing)
- Probe the HMAC signature verification endpoint to enumerate valid order/payment ID combinations

## Change

**`backend/src/router/payment.route.ts`**
- Imported `auth` middleware and `ENUM_USER_ROLE` enum (same pattern used by story-branching, reactions, bookmarks, etc.)
- Applied `auth(ENUM_USER_ROLE.USER)` to both `POST /create-order` and `POST /verify`

## Test plan

- [ ] Unauthenticated `POST /create-order` returns 401
- [ ] Unauthenticated `POST /verify` returns 401
- [ ] Authenticated user can still create orders and verify payments
- [ ] No regressions on other routes