### PR TITLE
fix: add startup guard for RAZORPAY_KEY_SECRET and use timingSafeEqual in verifyPayment

### DIFF
--- a/backend/src/controllers/payment.controller.ts
+++ b/backend/src/controllers/payment.controller.ts
@@ -2,6 +2,17 @@ import { Request, Response } from "express";
 import crypto from "crypto";
 import razorpayInstance from "../config/razorpay";
 
+// Validate RAZORPAY_KEY_SECRET is present at startup so misconfigured
+// deployments fail loudly rather than silently passing undefined to
+// crypto.createHmac() and returning an opaque 500 during payment verification.
+const RAZORPAY_KEY_SECRET = process.env.RAZORPAY_KEY_SECRET;
+if (!RAZORPAY_KEY_SECRET) {
+  throw new Error(
+    "Missing required environment variable: RAZORPAY_KEY_SECRET. " +
+    "Payment verification cannot work without it."
+  );
+}
+
 // Creates a new Razorpay order and returns the order details to the frontend
 export const createOrder = async (req: Request, res: Response) => {
   try {
@@ -38,12 +49,18 @@ export const verifyPayment = async (req: Request, res: Response) => {
     // Razorpay signature verification: HMAC-SHA256 of "order_id|payment_id"
     const body = razorpay_order_id + "|" + razorpay_payment_id;
     const expectedSignature = crypto
-      .createHmac("sha256", process.env.RAZORPAY_KEY_SECRET as string)
+      .createHmac("sha256", RAZORPAY_KEY_SECRET)
       .update(body)
       .digest("hex");
 
-    // Compare expected signature with the one sent by Razorpay
-    if (expectedSignature !== razorpay_signature) {
+    // Use timingSafeEqual to compare signatures and prevent timing-based attacks
+    const expectedBuffer = Buffer.from(expectedSignature, "hex");
+    const receivedBuffer = Buffer.from(razorpay_signature, "hex");
+    const signaturesMatch =
+      expectedBuffer.length === receivedBuffer.length &&
+      crypto.timingSafeEqual(expectedBuffer, receivedBuffer);
+
+    if (!signaturesMatch) {
       return res.status(400).json({ success: false, message: "Invalid signature" });
     }
 


### PR DESCRIPTION
## Summary

Fixes #1042

- Validates `RAZORPAY_KEY_SECRET` at **module load time** so a missing or empty environment variable throws a clear `Error` on server startup instead of silently passing `undefined` to `crypto.createHmac()` and returning an opaque `500` during a live payment verification request.
- Replaces the `expectedSignature !== razorpay_signature` string equality check with `crypto.timingSafeEqual()` to eliminate timing side-channel leakage when comparing HMAC signatures.
- The module-level constant is reused inside `verifyPayment`, removing the redundant inline `process.env.RAZORPAY_KEY_SECRET as string` cast.

## Changes

`backend/src/controllers/payment.controller.ts`
- Added module-level `RAZORPAY_KEY_SECRET` constant with fail-fast guard
- Updated `verifyPayment` to use the constant instead of re-reading `process.env`
- Switched signature comparison to `crypto.timingSafeEqual` with a length pre-check

## Test plan

- [ ] Start the server without `RAZORPAY_KEY_SECRET` set -- process should exit immediately with a clear error message
- [ ] Start the server with `RAZORPAY_KEY_SECRET` set -- server should boot normally
- [ ] Submit a valid payment -- `POST /payment/verify` returns `200 { success: true }`
- [ ] Submit a tampered signature -- `POST /payment/verify` returns `400 { success: false, message: "Invalid signature" }`