### PR TITLE
feat: Add dropout regularization, configurable learning rate, input validation and `model_summary()` to `model.py` [ GSSOC'26 ]

### DIFF
--- a/backend/ml/model.py
+++ b/backend/ml/model.py
@@ -1,27 +1,102 @@
-from tensorflow.keras.models import Sequential
-from tensorflow.keras.layers import LSTM, Dense, RepeatVector, TimeDistributed, Input, Dropout
+"""
+model.py
+--------
+LSTM Autoencoder for writer's block detection.
+Encodes a session sequence and reconstructs it —
+high reconstruction error signals anomalous (blocked) behaviour.
 
-SEQ_LEN = 10
+Place at: backend/ml/model.py
+"""
+
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.layers import (
+    LSTM, Dense, RepeatVector,
+    TimeDistributed, Input, Dropout
+)
+from tensorflow.keras.optimizers import Adam
+
+SEQ_LEN    = 10
 N_FEATURES = 8
 
-def build_model(units=32):
+
+def build_model(
+    units: int = 32,
+    dropout: float = 0.2,
+    learning_rate: float = 0.001,
+) -> Sequential:
+    """
+    Build and compile an LSTM Autoencoder for anomaly detection.
+
+    Architecture
+    ------------
+    Encoder : LSTM(units) → compressed representation
+    Repeat  : RepeatVector repeats encoding SEQ_LEN times
+    Decoder : LSTM(units, return_sequences=True) → full sequence
+    Output  : TimeDistributed Dense → reconstructed features
+
+    Reconstruction error (MSE) is used as the anomaly score at
+    inference time — high error → writer is blocked.
+
+    Parameters
+    ----------
+    units         : LSTM hidden units (default 32)
+    dropout       : dropout rate applied after encoder and decoder (default 0.2)
+    learning_rate : Adam learning rate (default 0.001)
+
+    Returns
+    -------
+    Compiled Keras Sequential model
+    """
+    if not (0.0 <= dropout < 1.0):
+        raise ValueError(f"dropout must be in [0, 1), got {dropout}")
+    if units < 1:
+        raise ValueError(f"units must be >= 1, got {units}")
+    if learning_rate <= 0:
+        raise ValueError(f"learning_rate must be > 0, got {learning_rate}")
+
     model = Sequential([
         Input(shape=(SEQ_LEN, N_FEATURES)),
+
+        # ── Encoder ──────────────────────────────────────────────────────
         LSTM(
             units,
             activation="tanh",
             return_sequences=False,
-            name="encoder"
+            name="encoder",
         ),
+        Dropout(dropout, name="encoder_dropout"),
+
+        # ── Bridge ───────────────────────────────────────────────────────
         RepeatVector(SEQ_LEN),
+
+        # ── Decoder ──────────────────────────────────────────────────────
         LSTM(
             units,
             activation="tanh",
             return_sequences=True,
-            name="decoder"
+            name="decoder",
         ),
-        TimeDistributed(Dense(N_FEATURES, activation="linear"), name="output")
-    ])
+        Dropout(dropout, name="decoder_dropout"),
 
-    model.compile(optimizer="adam", loss="mse")
+        # ── Reconstruction ───────────────────────────────────────────────
+        TimeDistributed(
+            Dense(N_FEATURES, activation="linear"),
+            name="output",
+        ),
+    ], name="lstm_autoencoder")
+
+    model.compile(
+        optimizer=Adam(learning_rate=learning_rate),
+        loss="mse",
+    )
+
     return model
+
+
+def model_summary() -> None:
+    """Print a summary of the default model architecture."""
+    build_model().summary()
+
+
+if __name__ == "__main__":
+    model_summary()


### PR DESCRIPTION
## What this PR does

Hardens `build_model()` in `backend/ml/model.py` by adding dropout regularization, a configurable learning rate, input validation, and a `model_summary()` helper.

Previously the model had no dropout — meaning it could memorize training data and produce a meaningless anomaly threshold at inference. The `"adam"` string optimizer also gave no control over learning rate for tuning in `train.py`.

**Changes in `backend/ml/model.py`:**
- Added `dropout` parameter (default `0.2`) — `Dropout()` layers inserted after encoder and decoder LSTMs
- Added `learning_rate` parameter (default `0.001`) — replaces `"adam"` string with explicit `Adam(learning_rate=...)`
- Added input guards — `ValueError` raised for invalid `units`, `dropout`, and `learning_rate` values
- Named the model `lstm_autoencoder` for clearer logs and summaries
- Added `model_summary()` — prints architecture without training
- Added module-level docstring
- `python model.py` now prints the model summary via `if __name__ == "__main__"`

## Type of change

- [x] New feature
- [x] Code refactor

## Related issue

Closes #1066 

## Screenshot

```
Model: "lstm_autoencoder"
_________________________________________________________________
 Layer (type)            Output Shape         Param #
=================================================================
 encoder (LSTM)          (None, 32)           5248
 encoder_dropout         (None, 32)           0
 repeat_vector           (None, 10, 32)       0
 decoder (LSTM)          (None, 10, 32)       8320
 decoder_dropout         (None, 10, 32)       0
 output (TimeDistributed)(None, 10, 8)        264
=================================================================
```

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.