### PR TITLE
fixed the confirm password match or not match indication

### DIFF
--- a/auth.css
+++ b/auth.css
@@ -271,6 +271,40 @@ input:focus {
     display: block;
 }
 
+/* ── Password Match Feedback ── */
+.ds-feedback {
+    margin-top: 8px;
+    font-size: 12.5px;
+    line-height: 1.35;
+    display: none;
+    align-items: center;
+    gap: 6px;
+}
+
+.ds-feedback.is-visible {
+    display: flex;
+}
+
+.ds-feedback.match {
+    color: #6ee7b7;
+}
+
+.ds-feedback.match::before {
+    content: "✓";
+    font-weight: bold;
+    font-size: 14px;
+}
+
+.ds-feedback.mismatch {
+    color: #ffb4ab;
+}
+
+.ds-feedback.mismatch::before {
+    content: "✕";
+    font-weight: bold;
+    font-size: 14px;
+}
+
 .ds-alert {
     margin-bottom: 14px;
     padding: 12px 12px;

--- a/auth.js
+++ b/auth.js
@@ -42,6 +42,7 @@ function initInlineValidation() {
     const nameField = document.getElementById('name-field');
     const emailField = document.getElementById('email-field');
     const passwordField = document.getElementById('password-field');
+    const confirmPasswordField = document.getElementById('confirm-password-field');
 
     if (nameField) {
         nameField.addEventListener('blur', () => validateName(true));
@@ -62,8 +63,18 @@ function initInlineValidation() {
         passwordField.addEventListener('input', () => {
             updatePasswordStrengthUI(passwordField.value || '');
             if (passwordField.getAttribute('aria-invalid') === 'true') validatePassword(true);
+            if (confirmPasswordField && confirmPasswordField.value) {
+                validateConfirmPassword(false);
+            }
         });
         updatePasswordStrengthUI(passwordField.value || '');
+    }
+
+    if (confirmPasswordField) {
+        confirmPasswordField.addEventListener('blur', () => validateConfirmPassword(true));
+        confirmPasswordField.addEventListener('input', () => {
+            validateConfirmPassword(false);
+        });
     }
 }
 
@@ -176,6 +187,45 @@ function validatePassword(showInline) {
     return !message;
 }
 
+function validateConfirmPassword(showInline) {
+    const passwordField = document.getElementById('password-field');
+    const confirmPasswordField = document.getElementById('confirm-password-field');
+    if (!confirmPasswordField || currentMode !== 'signup') return true;
+
+    const password = (passwordField && passwordField.value) || '';
+    const confirmPassword = confirmPasswordField.value || '';
+    const feedbackEl = document.getElementById('confirm-password-feedback');
+    let message = '';
+    let isMatch = false;
+
+    if (!confirmPassword) {
+        message = '';
+    } else if (password !== confirmPassword) {
+        message = 'Passwords do not match';
+    } else {
+        message = 'Passwords match';
+        isMatch = true;
+    }
+
+    if (feedbackEl) {
+        if (!message) {
+            feedbackEl.classList.remove('is-visible', 'match', 'mismatch');
+            feedbackEl.textContent = '';
+        } else {
+            feedbackEl.classList.add('is-visible');
+            feedbackEl.textContent = message;
+            feedbackEl.classList.remove('match', 'mismatch');
+            feedbackEl.classList.add(isMatch ? 'match' : 'mismatch');
+        }
+    }
+
+    if (showInline) {
+        setFieldError('confirm-password-field', 'confirm-password-error', isMatch ? '' : message);
+    }
+
+    return isMatch || !confirmPassword;
+}
+
 function setSubmitting(submitting) {
     isSubmitting = submitting;
     const submitBtn = document.getElementById('submit-btn');
@@ -183,12 +233,14 @@ function setSubmitting(submitting) {
     const emailField = document.getElementById('email-field');
     const nameField = document.getElementById('name-field');
     const passwordField = document.getElementById('password-field');
+    const confirmPasswordField = document.getElementById('confirm-password-field');
 
     if (submitBtn) submitBtn.disabled = submitting;
     if (spinner) spinner.classList.toggle('hidden', !submitting);
     if (emailField) emailField.disabled = submitting;
     if (nameField) nameField.disabled = submitting;
     if (passwordField) passwordField.disabled = submitting;
+    if (confirmPasswordField) confirmPasswordField.disabled = submitting;
 }
 
 /* ── Advanced Particle System (Canvas + Mouse Interactions) ── */
@@ -357,6 +409,12 @@ function toggleAuthMode(mode) {
         setFieldError('name-field', 'name-error', '');
         setFieldError('email-field', 'email-error', '');
         setFieldError('password-field', 'password-error', '');
+        setFieldError('confirm-password-field', 'confirm-password-error', '');
+        const feedbackEl = document.getElementById('confirm-password-feedback');
+        if (feedbackEl) {
+            feedbackEl.classList.remove('is-visible', 'match', 'mismatch');
+            feedbackEl.textContent = '';
+        }
         setSubmitting(false);
 
         form.classList.remove('form-transitioning');
@@ -419,6 +477,20 @@ function togglePasswordVisibility() {
     }
 }
 
+function toggleConfirmPasswordVisibility() {
+    const field = document.getElementById('confirm-password-field');
+    const icon = document.getElementById('confirm-eye-icon');
+    if (!field || !icon) return;
+
+    if (field.type === 'password') {
+        field.type = 'text';
+        icon.className = 'fi fi-rr-eye text-[16px]';
+    } else {
+        field.type = 'password';
+        icon.className = 'fi fi-rr-eye-crossed text-[16px]';
+    }
+}
+
 /* ── Form Submission handling ── */
 function handleFormSubmit(e) {
     e.preventDefault();
@@ -427,6 +499,7 @@ function handleFormSubmit(e) {
     const emailField = document.getElementById('email-field');
     const nameField = document.getElementById('name-field');
     const passwordField = document.getElementById('password-field');
+    const confirmPasswordField = document.getElementById('confirm-password-field');
     if (!emailField) return;
 
     setAlert('', '');
@@ -434,8 +507,9 @@ function handleFormSubmit(e) {
     const okName = validateName(true);
     const okEmail = validateEmail(true);
     const okPassword = validatePassword(true);
+    const okConfirmPassword = currentMode === 'signup' ? validateConfirmPassword(true) : true;
 
-    const isValid = currentMode === 'signup' ? (okName && okEmail && okPassword) : (okEmail && okPassword);
+    const isValid = currentMode === 'signup' ? (okName && okEmail && okPassword && okConfirmPassword) : (okEmail && okPassword);
     if (!isValid) {
         setAlert('error', 'Please fix the highlighted fields and try again.');
         const firstInvalid =

--- a/backend/src/app/modules/auth/auth.service.ts
+++ b/backend/src/app/modules/auth/auth.service.ts
@@ -51,7 +51,7 @@ const login = async (payload: AuthModel) => {
   };
 };
 
-const register = async (payload: IUser & { verificationToken?: string }) => {
+const register = async (payload: IUser & { verificationToken?: string; confirmPassword?: string }) => {
   const { email: userEmail, verificationToken } = payload;
   
   // FIX #4: Verify that email was verified via OTP before allowing registration

--- a/backend/src/app/modules/user/user.validation.ts
+++ b/backend/src/app/modules/user/user.validation.ts
@@ -13,9 +13,13 @@ const register = z.object({
     email: z.string({ required_error: "Email is required" }),
     name: z.string({ required_error: "Name is required" }),
     password: passwordSchema,
+    confirmPassword: z.string({ required_error: "Confirm password is required" }),
     verificationToken: z
       .string({ required_error: "Verification token is required" })
       .min(1, "Verification token is required"),
+  }).refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
   }),
 });
 

--- a/signup.html
+++ b/signup.html
@@ -206,6 +206,19 @@
                     <p class="ds-help" id="password-strength"></p>
                     <p class="ds-error" id="password-error" role="alert" aria-live="polite"></p>
                 </div>
+                <div class="ds-field">
+                    <label class="block text-label-caps text-on-surface-variant mb-2" for="confirm-password-field">CONFIRM PASSWORD</label>
+                    <div class="ds-input-group has-action">
+                        <i class="fi fi-rr-lock ds-input-icon text-[16px] absolute left-4 top-1/2 -translate-y-1/2 text-on-surface-variant/80"></i>
+                        <input class="w-full ds-input with-icon pl-11 pr-11" id="confirm-password-field" name="confirmPassword" autocomplete="new-password" placeholder="Re-enter your password" type="password" required aria-describedby="confirm-password-help confirm-password-error confirm-password-feedback" aria-invalid="false"/>
+                        <button class="ds-input-action flex items-center justify-center" onclick="toggleConfirmPasswordVisibility()" type="button" aria-label="Toggle confirm password visibility">
+                            <i class="fi fi-rr-eye-crossed text-[16px]" id="confirm-eye-icon"></i>
+                        </button>
+                    </div>
+                    <p class="ds-help" id="confirm-password-help">Passwords must match to create your account.</p>
+                    <p class="ds-feedback password-match-feedback" id="confirm-password-feedback" role="status" aria-live="polite"></p>
+                    <p class="ds-error" id="confirm-password-error" role="alert" aria-live="polite"></p>
+                </div>
                 <div class="flex items-center gap-2">
                     <input class="w-4 h-4 rounded border-white/10 bg-surface-container-high text-primary focus:ring-primary ring-offset-surface" id="remember" type="checkbox"/>
                     <label class="text-[13px] text-on-surface-variant" for="remember">Remember me for 30 days</label>


### PR DESCRIPTION
##Before
There was no realtime feedback in sign up part for whether the password matches or not .

## What this PR does
Adds confirm password field with real-time validation feedback on signup.

## Changes
- Frontend: confirm password field, eye toggle, green/red match indicators
- Backend: Zod validation to confirm passwords match server-side

Fixes #<725>