### PR TITLE
fix: update broken deployment links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,8 @@
 
 *Generate, explore, and share multiple story variations powered by OpenAI & Gemini.*
 
-<br/>
-[![Live Demo](https://img.shields.io/badge/🌐_Live_Demo-storysparkai.vercel.app-6c3ff7?style=for-the-badge&logoColor=white)](https://storysparkai.vercel.app/)
-&nbsp;
+[![Live Demo](https://img.shields.io/badge/🌐_Live_Demo-storyspark.ai-6c3ff7?style=for-the-badge&logoColor=white)](https://storyspark.ai/)
+
 [![License: MIT](https://img.shields.io/github/license/ronisarkarexe/story-spark-ai?style=for-the-badge&color=22c55e)](https://github.com/ronisarkarexe/story-spark-ai/blob/master/LICENSE)
 &nbsp;
 [![Forks](https://img.shields.io/github/forks/ronisarkarexe/story-spark-ai?style=for-the-badge&color=3b82f6)](https://github.com/ronisarkarexe/story-spark-ai/fork)
@@ -76,7 +75,9 @@
 
 Whether you're a writer battling creative block, an educator exploring narrative structure, or simply someone who loves stories — StorySpark AI is your intelligent storytelling companion.
 
-> 🌐 **Live at:** [storysparkai.vercel.app](https://storysparkai.vercel.app/)
+> 🌐 **Live at:** [storyspark.ai](https://storyspark.ai/)
+
+
 
 ---
 
@@ -276,9 +277,8 @@ This monorepo deploys as **two separate Vercel projects**:
 
 | Project | Root Directory | Example Domain |
 |---|---|---|
-| 🖥️ Frontend | `frontend` | `storysparkai.vercel.app` |
-| ⚙️ Backend API | `backend` | `apistorysparkai.vercel.app` |
-
+| 🖥️ Frontend | `frontend` | `storyspark.ai` |
+| ⚙️ Backend API | `backend` | `api.storyspark.ai` |
 **Frontend environment variables** *(set in Vercel dashboard → redeploy after changes)*:
 
 ```env


### PR DESCRIPTION
fix: update broken deployment links in README

## What this PR does
This PR updates the outdated Vercel deployment URLs in the project's documentation (`README.md`) to the new custom domains. 
- Frontend URL changed from `storysparkai.vercel.app` to `storyspark.ai`
- Backend URL changed from `apistorysparkai.vercel.app` to `api.storyspark.ai`

Additionally, removed a few redundant markdown spacing tags (`<br />` and `&nbsp;`) to clean up the layout.

## Type of change
- [x] Documentation update

## Related issue
Fixes #966

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason. (N/A - Documentation text update only)
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.