### PR TITLE
[FEAT][GSSoC'26] StoryTranslator — Add Copy, Download & Save as Draft actionsfeat: add Copy, Download and Save as Draft actions to StoryTranslator

### DIFF
--- a/frontend/src/components/translate/StoryTranslator.tsx
+++ b/frontend/src/components/translate/StoryTranslator.tsx
@@ -1,4 +1,6 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import toast, { Toaster } from "react-hot-toast";
 import { useTranslateStoryMutation, useTranslateFreeStoryMutation } from "../../redux/apis/ai.model.api";
 import { IStories } from "../stories/stories.view.component";
 
@@ -24,12 +26,15 @@ const LANGUAGES = [
 ];
 
 export default function StoryTranslator({ story, isLogin, onClose }: Props) {
+  const navigate = useNavigate();
+
   const [selectedLanguage, setSelectedLanguage] = useState<string>("");
   const [translatedTitle, setTranslatedTitle] = useState<string>("");
   const [translatedContent, setTranslatedContent] = useState<string>("");
   const [isTranslating, setIsTranslating] = useState(false);
   const [error, setError] = useState("");
   const [isDone, setIsDone] = useState(false);
+  const [isCopied, setIsCopied] = useState(false);
 
   const [translateStory] = useTranslateStoryMutation();
   const [translateFreeStory] = useTranslateFreeStoryMutation();
@@ -63,8 +68,59 @@ export default function StoryTranslator({ story, isLogin, onClose }: Props) {
     }
   };
 
+  // ── Action 1: Copy to clipboard ──────────────────────────────────────────
+  const handleCopy = async () => {
+    const text = `${translatedTitle}\n\n${translatedContent}`;
+    try {
+      await navigator.clipboard.writeText(text);
+      setIsCopied(true);
+      toast.success("Translation copied to clipboard!");
+      setTimeout(() => setIsCopied(false), 2500);
+    } catch {
+      toast.error("Failed to copy. Please try again.");
+    }
+  };
+
+  // ── Action 2: Download as .txt ───────────────────────────────────────────
+  const handleDownload = () => {
+    const text = `${translatedTitle}\n\n${translatedContent}`;
+    const blob = new Blob([text], { type: "text/plain;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${translatedTitle || "translated-story"}.txt`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    toast.success("Story downloaded!");
+  };
+
+  // ── Action 3: Save as Draft ──────────────────────────────────────────────
+  const handleSaveAsDraft = () => {
+    const draftData = {
+      prompt: translatedContent,
+      genre: story.tag || "",
+      length: "medium",
+      language: selectedLanguage,
+    };
+    try {
+      localStorage.setItem("story_spark_draft", JSON.stringify(draftData));
+      toast.success("Saved as draft! Redirecting to story generator...");
+      setTimeout(() => {
+        onClose();
+        navigate("/stories", {
+          state: { prompt: translatedContent },
+        });
+      }, 1200);
+    } catch {
+      toast.error("Could not save draft. Storage limit may be full.");
+    }
+  };
+
   return (
     <div className="fixed inset-0 z-50 bg-black/80 backdrop-blur flex items-center justify-center p-4">
+      <Toaster position="top-center" />
       <div className="w-full max-w-4xl bg-[#0f1117] rounded-2xl border border-white/10 overflow-hidden shadow-2xl max-h-[90vh] flex flex-col">
 
         {/* Header */}
@@ -127,6 +183,7 @@ export default function StoryTranslator({ story, isLogin, onClose }: Props) {
                   Translate Again
                 </button>
               </div>
+
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 {/* Original */}
                 <div className="bg-white/5 border border-white/10 rounded-xl p-4">
@@ -142,6 +199,47 @@ export default function StoryTranslator({ story, isLogin, onClose }: Props) {
                   <p className="text-sm font-semibold text-white mb-2">{translatedTitle}</p>
                   <p className="text-xs text-white/60 leading-relaxed max-h-48 overflow-y-auto">{translatedContent}</p>
                 </div>
+              </div>
+
+              {/* ── Action Buttons ── */}
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 pt-2">
+
+                {/* Copy to Clipboard */}
+                <button
+                  onClick={handleCopy}
+                  className="flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl border border-white/10 bg-white/5 hover:bg-white/10 text-white/80 hover:text-white text-sm font-medium transition-all"
+                >
+                  {isCopied ? (
+                    <>
+                      <span>✅</span>
+                      <span>Copied!</span>
+                    </>
+                  ) : (
+                    <>
+                      <span>📋</span>
+                      <span>Copy Translation</span>
+                    </>
+                  )}
+                </button>
+
+                {/* Download as .txt */}
+                <button
+                  onClick={handleDownload}
+                  className="flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl border border-white/10 bg-white/5 hover:bg-white/10 text-white/80 hover:text-white text-sm font-medium transition-all"
+                >
+                  <span>⬇️</span>
+                  <span>Download .txt</span>
+                </button>
+
+                {/* Save as Draft */}
+                <button
+                  onClick={handleSaveAsDraft}
+                  className="flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl border border-emerald-500/30 bg-emerald-500/10 hover:bg-emerald-500/20 text-emerald-300 hover:text-emerald-200 text-sm font-medium transition-all"
+                >
+                  <span>✍️</span>
+                  <span>Save as Draft</span>
+                </button>
+
               </div>
             </div>
           )}


### PR DESCRIPTION
Closes #1089 

## Problem
When a user translates a story, the result only lived in local component state. Closing the modal permanently lost the translation with no way to recover it — even though it consumed an API call.

## Changes Made
- ✅ **Copy to Clipboard** — copies translated title + content with toast confirmation
- ✅ **Download as .txt** — downloads translation as a text file named after the translated title
- ✅ **Save as Draft** — saves translation to localStorage and redirects to `/stories` with content pre-filled in the prompt box

## Behaviour
All three action buttons render **only after a successful translation** (`isDone === true`), placed below the side-by-side comparison panel. No buttons shown during or before translation.

## Files Changed
- `frontend/src/components/translate/StoryTranslator.tsx`

## Screenshots
[paste a screenshot of the 3 buttons appearing after translation if possible]

## Checklist
- [x] No new dependencies added
- [x] Consistent with existing dark theme and emerald accent styling
- [x] Toast feedback on copy and download
- [x] Tested locally