### PR TITLE
fix: move matplotlib evaluation code inside __main__ guard in train_scorer.py

### DIFF
--- a/backend/ml/train_scorer.py
+++ b/backend/ml/train_scorer.py
@@ -170,33 +170,33 @@ if __name__ == "__main__":
     print(f"Saved to {SAVE_DIR}/")
     
     
-import matplotlib.pyplot as plt
-import numpy as np
+    import matplotlib.pyplot as plt
+    import numpy as np
 
-# Predictions lao
-val_size = int(0.15 * len(stories))
-val_stories = story_enc[-val_size:]
-val_prompts = prompt_enc[-val_size:]
-val_coh, val_cre, val_rel = coh[-val_size:], cre[-val_size:], rel[-val_size:]
+    # Predictions lao
+    val_size = int(0.15 * len(stories))
+    val_stories = story_enc[-val_size:]
+    val_prompts = prompt_enc[-val_size:]
+    val_coh, val_cre, val_rel = coh[-val_size:], cre[-val_size:], rel[-val_size:]
 
-pred_coh, pred_cre, pred_rel = model.predict(
-    {"story": val_stories, "prompt": val_prompts}, verbose=0
-)
+    pred_coh, pred_cre, pred_rel = model.predict(
+        {"story": val_stories, "prompt": val_prompts}, verbose=0
+    )
 
-fig, axes = plt.subplots(1, 3, figsize=(15, 5))
+    fig, axes = plt.subplots(1, 3, figsize=(15, 5))
 
-for ax, true, pred, title in zip(
-    axes,
-    [val_coh, val_cre, val_rel],
-    [pred_coh, pred_cre, pred_rel],
-    ["Coherence", "Creativity", "Relevance"]
-):
-    ax.scatter(true, pred.flatten(), alpha=0.5, s=10)
-    ax.plot([0, 1], [0, 1], 'r--')   # perfect prediction line
-    ax.set_xlabel("True")
-    ax.set_ylabel("Predicted")
-    ax.set_title(title)
+    for ax, true, pred, title in zip(
+        axes,
+        [val_coh, val_cre, val_rel],
+        [pred_coh, pred_cre, pred_rel],
+        ["Coherence", "Creativity", "Relevance"]
+    ):
+        ax.scatter(true, pred.flatten(), alpha=0.5, s=10)
+        ax.plot([0, 1], [0, 1], 'r--')   # perfect prediction line
+        ax.set_xlabel("True")
+        ax.set_ylabel("Predicted")
+        ax.set_title(title)
 
-plt.tight_layout()
-plt.savefig("scorer_eval.png")
-print("scorer_eval.png save ho gayi!")
+    plt.tight_layout()
+    plt.savefig("scorer_eval.png")
+    print("scorer_eval.png save ho gayi!")


### PR DESCRIPTION
## Screenshot (when helpful)
N/A — Python script fix, no UI involved.

## What this PR does
In `backend/ml/train_scorer.py`, the matplotlib evaluation and plotting 
code was running at module level outside the `if __name__ == "__main__":` 
block. This caused the evaluation code to execute automatically on import, 
calling `model.predict()` before the model was initialized and potentially 
crashing any module that imported from `train_scorer.py`.

This PR moves the matplotlib evaluation block inside the `if __name__ == 
"__main__":` guard so it only executes when the script is run directly.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue
Fixes #879

## More screenshots (optional)
N/A

## Checklist
- [ ] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.