### PR TITLE
fix: disable Send OTP button after successful submission to prevent spam

### DIFF
--- a/frontend/src/components/login/forgot_password.component.tsx
+++ b/frontend/src/components/login/forgot_password.component.tsx
@@ -56,6 +56,7 @@ const ForgotPasswordComponent = () => {
   const [emailAddress, setEmailAddress] = useState<string>("");
   const [verificationToken, setVerificationToken] = useState<string>("");
   const [isBusy, setIsBusy] = useState<boolean>(false);
+  const [otpSent, setOtpSent] = useState<boolean>(false);
   const [cooldown, setCooldown] = useState<number>(0);
   const [expiredAt, setExpiredAt] = useState<number>(0);
 
@@ -123,6 +124,7 @@ const ForgotPasswordComponent = () => {
         setExpiredAt(new Date(expiresAt).getTime());
         setEmailAddress(data.email);
         toast.success("OTP sent to your email successfully!");
+        setOtpSent(true);
         setCooldown(60);
         setStep(2);
       }
@@ -266,7 +268,7 @@ const ForgotPasswordComponent = () => {
                 register={register}
                 error={errors.email}
               />
-              <SSButton text="Send OTP" type="submit" isLoading={isBusy} />
+              <SSButton text="Send OTP" type="submit" isLoading={isBusy} disabled={otpSent} />
             </form>
           )}
 


### PR DESCRIPTION
## Screenshot (when helpful)
N/A - The frontend has a pre-existing duplicate import error in 
App.tsx (`createBrowserRouter` imported twice) that prevents the 
dev server from running locally. This error exists on the main 
branch and is unrelated to this fix.

## What this PR does
The "Send OTP" button on the Forgot Password page was not disabled 
after a successful OTP request. This allowed users to click it 
repeatedly, sending duplicate requests to the backend and 
potentially spamming the user's inbox.

Fix: Added a new `otpSent` boolean state that is set to `true` 
after a successful OTP request. This is passed as 
`disabled={otpSent}` to the SSButton component, which already 
handles the disabled visual state internally — no extra styling 
was needed.

## Type of change
- [x] Bug fix

## Related issue
Closes #1130

## More screenshots (optional)
N/A

## Checklist
- [x] I have added screenshots or a recording when they help explain 
      this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.