### PR TITLE
fix: add explicit auth middleware to GET /user/profile route

### DIFF
--- a/backend/src/app/modules/user/user.router.ts
+++ b/backend/src/app/modules/user/user.router.ts
@@ -11,7 +11,16 @@ const router = express.Router();
 router.get("/lists", auth(ENUM_USER_ROLE.ADMIN, ENUM_USER_ROLE.SUPER_ADMIN), UserController.getAllUsers);
 
 // Profile
-router.get("/profile", UserController.getProfileInfo);
+router.get(
+  "/profile",
+  auth(
+    ENUM_USER_ROLE.USER,
+    ENUM_USER_ROLE.WRITER,
+    ENUM_USER_ROLE.ADMIN,
+    ENUM_USER_ROLE.SUPER_ADMIN
+  ),
+  UserController.getProfileInfo,
+);
 
 // Apply for Writer
 router.get(


### PR DESCRIPTION
**Issue:** Closes #770

---

## Screenshot (when helpful)

N/A — this is a backend middleware change with no UI impact.

---

## What this PR does

The `GET /user/profile` route in `backend/src/app/modules/user/user.router.ts` was the only protected route in the user router **without** an explicit `auth(...)` middleware guard.

Every other protected route in the same file guards access at the router level:

```ts
router.get("/lists", auth(ENUM_USER_ROLE.ADMIN, ENUM_USER_ROLE.SUPER_ADMIN), UserController.getAllUsers);
router.get("/:id",  auth(ENUM_USER_ROLE.USER, ...), UserController.getUser);
router.patch("/update", auth(ENUM_USER_ROLE.USER, ...), UserController.updateUser);
```

The `/profile` route was missing this and instead relied on an implicit 401 thrown inside `getProfileInfo` when `getToken(req)` finds no token. That works today, but is fragile — any refactor of `getProfileInfo` that moves or removes the `getToken` call would silently expose the endpoint.

This PR adds the explicit `auth(...)` guard to `/profile`, making it consistent with the rest of the router. **No behaviour changes** — unauthenticated requests still get a 401, authenticated requests still get the profile. The security contract is now just visible and enforced at the right layer.

---

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Documentation update

> Technically a security-hygiene / defensive refactor. The implicit auth still worked, but this makes the protection explicit and consistent with the rest of the codebase.

---

## Related issue

Closes #770

---

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
