### PR TITLE
fix: correct default GitHub repo owner from Arpita2919 to ronisarkarexe

### DIFF
--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -44,6 +44,6 @@ export default {
   google_client_id: process.env.GOOGLE_CLIENT_ID,
   github: {
     token: process.env.GITHUB_TOKEN,
-    repo: process.env.GITHUB_REPO || "Arpita2919/story-spark-ai",
+    repo: process.env.GITHUB_REPO || "ronisarkarexe/story-spark-ai",
   },
 };


### PR DESCRIPTION
## Description

The backend configuration at `backend/src/config/index.ts` hardcoded a fallback GitHub repository owner of "Arpita2919/story-spark-ai" instead of the actual upstream repository "ronisarkarexe/story-spark-ai". This caused any GitHub API integrations that use this config value to query the wrong repository when the GITHUB_REPO environment variable was not explicitly set.

## Related Issue

Closes #1171

## Root Cause

`backend/src/config/index.ts` line 47:

```
repo: process.env.GITHUB_REPO || "Arpita2919/story-spark-ai",
```

The value "Arpita2919/story-spark-ai" references a different GitHub user fork, not the actual upstream repository (ronisarkarexe/story-spark-ai).

## Change Made

**backend/src/config/index.ts** - Line 47

Changed:

```
repo: process.env.GITHUB_REPO || "Arpita2919/story-spark-ai",
```

To:

```
repo: process.env.GITHUB_REPO || "ronisarkarexe/story-spark-ai",
```

## Impact

- GitHub contributors listing now queries the correct repository
- Any features relying on GitHub API (issue creation, bug reports, star/fork counts) will target the right repo
- The change is a single-line fix with zero risk of side effects
- When GITHUB_REPO env var is set in production, it takes precedence regardless

## Verification

| Scenario | Before | After |
|----------|--------|-------|
| GITHUB_REPO not set | Queries Arpita2919/story-spark-ai (wrong data) | Queries ronisarkarexe/story-spark-ai (correct) |
| GITHUB_REPO explicitly set | Uses env var (correct) | Uses env var (unchanged) |

## Type of Change

- [x] Bug fix - non-breaking change that fixes an issue

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] Only the required file is modified - no unrelated changes