### PR TITLE
fix(verify-email): remove duplicate credential check

### DIFF
--- a/backend/src/app/modules/verify_email/verify_email.service.ts
+++ b/backend/src/app/modules/verify_email/verify_email.service.ts
@@ -90,11 +90,7 @@ const VerifyEmail = async (payload: IEmailBody) => {
       `,
     };
     
-    if (!config.verify_email || !config.verify_password) {
-      console.log(`\n=========================================\n[DEV MODE] OTP for ${email} is: ${otp}\n=========================================\n`);
-    } else {
-      await transporter.sendMail(mailOptions);
-    }
+    await transporter.sendMail(mailOptions);
 
     return {
       expiresAt,


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Fixes #1027 
- **Description:** This PR removes the duplicate email credential check from the verify email service.
- **Screenshots:** N/A — this is a backend-only code cleanup and does not include UI changes.

## Screenshot (when helpful)

N/A — this PR only updates backend email verification logic.



## What this PR does

This PR removes the duplicate config.verify_email and config.verify_password check from backend/src/app/modules/verify_email/verify_email.service.ts.

The existing early-return check for missing email credentials is kept. After mailOptions is created, the service now directly calls transporter.sendMail(mailOptions), making the email sending flow cleaner and avoiding repeated conditional logic.


## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [x] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Documentation update

## Related issue

Closes #1027 


## More screenshots (optional)

N/A


## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.


## Testing

- Verified that only backend/src/app/modules/verify_email/verify_email.service.ts was updated.
- Ran npm run build.
   - Build failed due to an existing TypeScript syntax error in backend/src/app/modules/reaction/reaction.service.ts, which is unrelated to this PR.