### PR TITLE
fix: align Sign In form inputs with buttons on Login Page (#1228)

### DIFF
--- a/auth.css
+++ b/auth.css
@@ -18,6 +18,64 @@
     --ds-card-max-width: 420px;
 }
 
+/* ── Auth Form Card & Field Utilities ── */
+.auth-form-card {
+    width: 100%;
+    max-width: var(--ds-card-max-width);
+}
+
+.input-icon-wrapper {
+    position: relative;
+    width: 100%;
+}
+
+.input-icon-wrapper input {
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.field-label {
+    display: block;
+    font-size: 13px;
+    font-weight: 600;
+    color: rgba(225, 226, 234, 0.85);
+    margin-bottom: 6px;
+}
+
+.field-error-msg {
+    display: none;
+    margin-top: 6px;
+    font-size: 12.5px;
+    line-height: 1.35;
+    color: #ffb4ab;
+}
+
+.field-error-msg.is-visible {
+    display: block;
+}
+
+/* ── Auth Divider ("or use email") ── */
+.auth-divider {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.auth-divider-line {
+    flex: 1;
+    height: 1px;
+    background: rgba(255, 255, 255, 0.1);
+}
+
+.auth-divider-text {
+    font-size: 12px;
+    color: rgba(203, 195, 215, 0.7);
+    white-space: nowrap;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    font-weight: 600;
+}
+
 html, body {
     touch-action: pan-x pan-y;
 }
@@ -187,14 +245,12 @@ input:focus {
 /* ── Design System: Submit Buttons ── */
 .ds-btn-submit {
     height: var(--ds-btn-height);
-    max-width: var(--ds-btn-max-width);
+    width: 100%;
     font-size: 15px;
     font-weight: 700;
     display: flex;
     align-items: center;
     justify-content: center;
-    margin-left: auto;
-    margin-right: auto;
     background: linear-gradient(135deg, #7c3aed 0%, #f97316 100%);
     color: #ffffff;
     box-shadow: 0 0 32px rgba(0, 97, 182, 0.32), 0 8px 22px rgba(0, 0, 0, 0.24);
@@ -216,10 +272,8 @@ input:focus {
 /* ── Design System: Google Buttons ── */
 .ds-btn-google {
     height: 44px;
-    max-width: var(--ds-btn-max-width);
+    width: 100%;
     border-radius: 14px;
-    margin-left: auto;
-    margin-right: auto;
     background: rgba(255, 255, 255, 0.08);
     border: 1px solid rgba(255, 255, 255, 0.12);
     color: #f8fafc;

--- a/login.html
+++ b/login.html
@@ -5,15 +5,88 @@
     <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" name="viewport"/>
     <title>Login | Story Spark AI</title>
     <meta name="description" content="Sign in or create an account for Story Spark AI — turn your imagination into fully illustrated multi-variation AI stories."/>
-    
+    <!-- Tailwind CSS (w/ Form & Container plugins) -->
+    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&amp;display=swap" rel="stylesheet"/>
     <link href="https://cdn.jsdelivr.net/npm/@flaticon/flaticon-uicons/css/all/all.css" rel="stylesheet"/>
     
     <script src="https://accounts.google.com/gsi/client" async defer></script>
     
     <link href="auth.css" rel="stylesheet"/>
-    
-    <link rel="stylesheet" href="/src/index.css" />
+
+    <!-- Dynamic Tailwind config containing the app's style tokens -->
+    <script id="tailwind-config">
+        tailwind.config = {
+            darkMode: "class",
+            theme: {
+                extend: {
+                    "colors": {
+                        "on-secondary-fixed": "#36003e",
+                        "tertiary-container": "#ec6a06",
+                        "surface-dim": "#101319",
+                        "outline-variant": "#494454",
+                        "on-primary-container": "#340080",
+                        "error": "#ffb4ab",
+                        "surface-bright": "#36393f",
+                        "surface": "#101319",
+                        "on-primary-fixed-variant": "#5516be",
+                        "tertiary-fixed-dim": "#ffb690",
+                        "on-tertiary": "#552100",
+                        "on-error-container": "#ffdad6",
+                        "secondary-container": "#ae05c6",
+                        "primary-container": "#a078ff",
+                        "surface-container-lowest": "#0b0e13",
+                        "outline": "#958ea0",
+                        "surface-container-high": "#272a30",
+                        "on-secondary-fixed-variant": "#7c008e",
+                        "primary": "#d0bcff",
+                        "on-primary": "#3c0091",
+                        "on-secondary-container": "#ffd8fd",
+                        "on-tertiary-fixed": "#341100",
+                        "on-error": "#690005",
+                        "primary-fixed": "#e9ddff",
+                        "surface-variant": "#32353b",
+                        "tertiary-fixed": "#ffdbca",
+                        "on-tertiary-fixed-variant": "#783200",
+                        "on-surface-variant": "#cbc3d7",
+                        "background": "#101319",
+                        "on-secondary": "#580065",
+                        "inverse-surface": "#e1e2ea",
+                        "inverse-on-surface": "#2d3036",
+                        "on-tertiary-container": "#4a1c00",
+                        "error-container": "#93000a",
+                        "inverse-primary": "#6d3bd7",
+                        "on-background": "#e1e2ea",
+                        "surface-tint": "#d0bcff",
+                        "surface-container-highest": "#32353b",
+                        "surface-container": "#1d2025",
+                        "on-primary-fixed": "#23005c",
+                        "secondary": "#fbabff",
+                        "tertiary": "#ffb690",
+                        "surface-container-low": "#191c21",
+                        "on-surface": "#e1e2ea",
+                        "primary-fixed-dim": "#d0bcff",
+                        "secondary-fixed-dim": "#fbabff",
+                        "secondary-fixed": "#ffd6fd"
+                    },
+                    "fontFamily": {
+                        "body-md": ["Inter"],
+                        "display-lg": ["Inter"],
+                        "label-caps": ["Inter"],
+                        "headline-md": ["Inter"]
+                    },
+                    "fontSize": {
+                        "body-md": ["15px", {"lineHeight": "1.6", "fontWeight": "400"}],
+                        "display-lg": ["36px", {"lineHeight": "1.15", "letterSpacing": "-0.02em", "fontWeight": "800"}],
+                        "display-lg-mobile": ["26px", {"lineHeight": "1.2", "letterSpacing": "-0.02em", "fontWeight": "800"}],
+                        "label-caps": ["11px", {"lineHeight": "1.0", "letterSpacing": "0.08em", "fontWeight": "600"}],
+                        "headline-md": ["18px", {"lineHeight": "1.3", "letterSpacing": "-0.01em", "fontWeight": "700"}]
+                    }
+                }
+            }
+        }
+    </script>
 </head>
 <body class="bg-background text-on-surface font-body-md selection:bg-primary/30">
 <div class="min-h-screen flex items-center justify-center p-4 md:p-0">
@@ -110,7 +183,7 @@
                     <label class="field-label" for="name-field">Full Name</label>
                     <div class="input-icon-wrapper">
                         <i class="fi fi-rr-user input-icon text-[16px] absolute left-4 top-1/2 -translate-y-1/2 text-on-surface-variant/80"></i>
-                        <input class="w-full bg-surface-container-high border border-white/10 text-on-surface placeholder:text-outline focus:border-primary transition-all pl-11" placeholder="Alex Spark" type="text" id="name-field" autocomplete="name"/>
+                        <input class="w-full ds-input with-icon bg-surface-container-high border border-white/10 text-on-surface placeholder:text-outline focus:border-primary transition-all pl-11" placeholder="Alex Spark" type="text" id="name-field" autocomplete="name"/>
                     </div>
                     <span class="field-error-msg" id="name-error">Please enter your full name.</span>
                 </div>
@@ -119,7 +192,7 @@
                     <label class="field-label" for="email-field">Email Address</label>
                     <div class="input-icon-wrapper">
                         <i class="fi fi-rr-envelope input-icon text-[16px] absolute left-4 top-1/2 -translate-y-1/2 text-on-surface-variant/80"></i>
-                        <input class="w-full bg-surface-container-high border border-white/10 text-on-surface placeholder:text-outline focus:border-primary transition-all pl-11" placeholder="name@storyspark.ai" type="email" id="email-field" required autocomplete="email" value="admin@gmail.com"/>
+                        <input class="w-full ds-input with-icon bg-surface-container-high border border-white/10 text-on-surface placeholder:text-outline focus:border-primary transition-all pl-11" placeholder="name@storyspark.ai" type="email" id="email-field" required autocomplete="email" value="admin@gmail.com"/>
                     </div>
                     <span class="field-error-msg" id="email-error">Please enter a valid email address.</span>
                 </div>
@@ -131,7 +204,7 @@
                     </div>
                     <div class="input-icon-wrapper">
                         <i class="fi fi-rr-lock input-icon text-[16px] absolute left-4 top-1/2 -translate-y-1/2 text-on-surface-variant/80"></i>
-                        <input class="w-full bg-surface-container-high border border-white/10 text-on-surface placeholder:text-outline focus:border-primary transition-all pl-11 pr-11" id="password-field" placeholder="••••••••" type="password" required autocomplete="current-password" value="admin@123"/>
+                        <input class="w-full ds-input with-icon bg-surface-container-high border border-white/10 text-on-surface placeholder:text-outline focus:border-primary transition-all pl-11 pr-11" id="password-field" placeholder="••••••••" type="password" required autocomplete="current-password" value="admin@123"/>
                         <button class="absolute right-3 top-1/2 -translate-y-1/2 text-on-surface-variant hover:text-primary transition-colors p-1 rounded" onclick="togglePasswordVisibility()" type="button" aria-label="Toggle password visibility">
                             <i class="fi fi-rr-eye-crossed text-[16px]" id="eye-icon"></i>
                         </button>


### PR DESCRIPTION
## Before you open this PR

* **Issue:** Closes #1228
* **Description:** This PR fixes the misaligned sign-in form on the login page by correcting button width styling, fixing the Tailwind import, and applying the shared design-system input classes to prevent icon/text overlap.
* **Screenshots:** Added before/after screenshots to demonstrate the layout fix.

---

## Screenshot (when helpful)
<img width="1859" height="891" alt="Screenshot 2026-05-29 174657" src="https://github.com/user-attachments/assets/1eabd60b-6021-4592-94cd-ba601ea7918c" />
<img width="1723" height="902" alt="Screenshot 2026-05-29 174704" src="https://github.com/user-attachments/assets/3e39d68c-11c1-428b-9331-77c5456852bc" />


---

## What this PR does

This PR fixes the login page layout issues where the input fields extended beyond the width of the “Sign In” button and the icons/text inside the inputs overlapped.

### Changes made:

* Updated `auth.css`

  * Removed the `max-width` restriction from the submit and Google sign-in buttons.
  * Removed auto margins.
  * Set buttons to use full width for consistent alignment.

* Updated `login.html`

  * Replaced the broken local stylesheet import with the correct Tailwind CDN + config script used in `signup.html`.
  * Added the shared design-system classes:

    * `.ds-input`
    * `.with-icon`
  * These classes apply the correct left padding (`pl-11`) so icons and text no longer overlap.

The login form is now visually aligned, responsive, and consistent with the signup page styling.

---

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

---

## Related issue

Closes #1228

---

## More screenshots (optional)

N/A

---

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.
