### PR TITLE
feat: implement access token auto-refresh on 401 response

### DIFF
--- a/frontend/src/components/auth.context.tsx
+++ b/frontend/src/components/auth.context.tsx
@@ -1,6 +1,11 @@
 import React, { createContext, useState, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
-import { getUserInfo, removeUserInfo, storeUserInfo } from "../services/auth.service";
+import {
+  getUserInfo,
+  removeUserInfo,
+  storeUserInfo,
+} from "../services/auth.service";
+import { AUTH_KEY } from "../constants/storage-key";
 
 interface User {
   id: string;
@@ -22,7 +27,7 @@ const AuthContext = createContext<AuthContextType | null>(null);
 
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const [accessToken, setAccessToken] = useState<string | null>(
-    localStorage.getItem("accessToken")
+    localStorage.getItem(AUTH_KEY),
   );
   const [user, setUser] = useState<User | null>(null);
   const navigate = useNavigate();
@@ -30,16 +35,14 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const logout = useCallback(() => {
     setAccessToken(null);
     setUser(null);
-    localStorage.removeItem("accessToken");
-    removeUserInfo();
+    removeUserInfo(); // handles localStorage removal via AUTH_KEY
     navigate("/login");
   }, [navigate]);
 
   const login = async (token: string) => {
     setAccessToken(token);
-    localStorage.setItem("accessToken", token);
-    storeUserInfo({ accessToken: token });
-    
+    storeUserInfo({ accessToken: token }); // single source of truth for token storage
+
     const userInfo = getUserInfo();
     if (userInfo) {
       setUser({
@@ -58,7 +61,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
 
     try {
       const userInfo = getUserInfo();
-      
+
       if (!userInfo || !userInfo.userId) {
         logout();
         return;

--- a/frontend/src/helpers/axios/axionInstance.ts
+++ b/frontend/src/helpers/axios/axionInstance.ts
@@ -1,7 +1,12 @@
 import axios, { AxiosResponse } from "axios";
-import { getFromLocalStorage } from "../../utils/local-storage";
+import {
+  getFromLocalStorage,
+  setToLocalStorage,
+  removeFromLocalStorage,
+} from "../../utils/local-storage";
 import { AUTH_KEY } from "../../constants/storage-key";
 import { IMeta, ResponseErrorType } from "../../types";
+import { getBaseUrl } from "../config";
 
 const instance = axios.create();
 instance.defaults.headers.post["Content-Type"] = "application/json";
@@ -23,14 +28,43 @@ instance.interceptors.request.use(
   },
   function (error) {
     return Promise.reject(error);
-  }
+  },
 );
 
 instance.interceptors.response.use(
   (response: AxiosResponse<ApiResponseData>) => {
     return response;
   },
-  function (error) {
+  async function (error) {
+    const originalRequest = error.config;
+
+    // If 401 and we haven't retried yet — attempt token refresh
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+
+      try {
+        const baseUrl = getBaseUrl();
+        const response = await axios.post(
+          `${baseUrl}/auth/refresh-token`,
+          {},
+          { withCredentials: true }, // sends the httpOnly refresh token cookie
+        );
+
+        const newAccessToken = response.data?.data?.accessToken;
+
+        if (newAccessToken) {
+          setToLocalStorage(AUTH_KEY, newAccessToken);
+          originalRequest.headers.Authorization = newAccessToken;
+          return instance(originalRequest); // retry original request
+        }
+      } catch {
+        // Refresh failed — clear session and redirect to login
+        removeFromLocalStorage(AUTH_KEY);
+        window.location.href = "/login";
+        return Promise.reject(error);
+      }
+    }
+
     let errorObject: ResponseErrorType;
     if (error.code === "ERR_NETWORK") {
       errorObject = {
@@ -62,7 +96,7 @@ instance.interceptors.response.use(
       };
     }
     return Promise.reject(errorObject);
-  }
+  },
 );
 
 export { instance };


### PR DESCRIPTION
ISSUE NUMBER: #607

Implements access token auto-refresh using the existing `POST /api/auth/refresh-token` endpoint. Previously, when the access token expired, all authenticated API calls silently failed. Now they automatically retry with a refreshed token without any interruption to the user.

---

## Changes

### `frontend/src/helpers/axios/axionInstance.ts`
- Added a 401 response interceptor that automatically calls `POST /api/auth/refresh-token` when an access token expires
- On success, stores the new token and retries the original request transparently
- On failure (refresh token also expired), clears local storage and redirects to `/login`
- Added `_retry` flag to prevent infinite retry loops
- Used `withCredentials: true` so the browser sends the `httpOnly` refresh token cookie set by the backend

### `frontend/src/components/auth.context.tsx`
- Removed duplicate `localStorage.setItem("accessToken", token)` call in the `login` function — `storeUserInfo()` is now the single source of truth for token storage
- Changed `localStorage.getItem("accessToken")` to use the `AUTH_KEY` constant to avoid hardcoded string divergence
- Simplified `logout` to use only `removeUserInfo()` instead of the redundant direct `localStorage.removeItem` call

---

## How to test

1. Login with any account
2. Open DevTools → Application → Local Storage → delete `accessToken`
3. Open Network tab → filter by Fetch/XHR
4. Trigger any authenticated action in the app
5. Observe `refresh-token` request fires automatically and the original request retries successfully
6. User stays logged in with no interruption ✅

---

## Notes

- No backend changes required — `POST /api/auth/refresh-token` was already production-ready
- Fix is localised to 2 files only