### PR TITLE
fix: cap readingHistory to 500 entries to prevent MongoDB 16MB limit …

### DIFF
--- a/backend/src/app/modules/user/user.model.ts
+++ b/backend/src/app/modules/user/user.model.ts
@@ -98,5 +98,11 @@ UserSchema.pre("save", async function (next) {
   
   next();
 });
+UserSchema.pre("save", function (next) {
+  if (this.readingHistory && this.readingHistory.length > 500) {
+    this.readingHistory = this.readingHistory.slice(-500);
+  }
+  next();
+});
 
 export const User = model<IUser, UserModel>("User", UserSchema);


### PR DESCRIPTION
…(#1297)

## What this PR does
Fixes unbounded `readingHistory` array in `user.model.ts` that could cause MongoDB documents to exceed the 16 MB size limit. Added a Mongoose `pre("save")` middleware that caps `readingHistory` to the 500 most recent entries.

## Type of change
- [x] Bug fix

## Related issue
Fixes #1297

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.

## Screenshot
N/A — backend model change, no UI impact.