### PR TITLE
fix: use env variable for Google Client ID

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -6,7 +6,7 @@
 let currentMode = 'signin';
 
 // ── Google Identity Services (GIS) Client ID ──
-const GOOGLE_CLIENT_ID = 'YOUR_GOOGLE_CLIENT_ID.apps.googleusercontent.com';
+const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID;
 
 let isSubmitting = false;
 


### PR DESCRIPTION
ISSUE NUMBER #1337 

## 🐛 Fix: Hardcoded Google Client ID

### What changed
- Replaced hardcoded Google Client ID with environment variable

### Why
- Ensures Google authentication works across local and production environments

### Testing done
- Verified Google login trigger works in UI
- Confirmed no runtime errors in frontend console

### Notes
- Requires VITE_GOOGLE_CLIENT_ID in frontend environment