### PR TITLE
fix: support Bearer token authorization headers

### DIFF
--- a/backend/src/app/middleware/auth.middleware.ts
+++ b/backend/src/app/middleware/auth.middleware.ts
@@ -10,6 +10,7 @@ const auth =
   async (req: Request, res: Response, next: NextFunction) => {
     try {
       const token = req.headers.authorization as string;
+
       if (!token) {
         throw new ApiError(
           httpStatus.UNAUTHORIZED,
@@ -22,13 +23,24 @@ const auth =
         token,
         config.jwt.secret as Secret
       );
-      if (requiredRole.length && !requiredRole.includes(verifiedUser.role)) {
-        throw new ApiError(httpStatus.FORBIDDEN, "Forbidden");
+
+      if (
+        requiredRole.length &&
+        !requiredRole.includes(verifiedUser.role)
+      ) {
+        throw new ApiError(
+          httpStatus.FORBIDDEN,
+          "Forbidden"
+        );
       }
+
       req.user = verifiedUser;
+
       next();
     } catch (err) {
       next(err);
+      
     }
   };
+
 export default auth;

--- a/backend/src/utils/jwt.helper.ts
+++ b/backend/src/utils/jwt.helper.ts
@@ -21,8 +21,26 @@ const createResetToken = (
   return jwt.sign(payload, secret, options);
 };
 
-const verifyToken = (token: string, secret: Secret): JwtPayload => {
-  return jwt.verify(token, secret) as JwtPayload;
+const verifyToken = (
+  token: string,
+  secret: Secret
+): JwtPayload => {
+  if (!token) {
+    throw new Error("Token missing");
+  }
+
+  const extractedToken = token.startsWith("Bearer ")
+    ? token.split(" ")[1]
+    : token;
+
+  if (!extractedToken) {
+    throw new Error("Invalid token format");
+  }
+
+  return jwt.verify(
+    extractedToken,
+    secret
+  ) as JwtPayload;
 };
 
 export const JwtHalers = {


### PR DESCRIPTION


## What this PR does

This PR fixes JWT authentication by adding support for standard Bearer token authorization headers.

Previously, the entire Authorization header was passed directly to `jwt.verify()`. When requests used the standard format:

`Authorization: Bearer <token>`

the `Bearer` prefix could cause token verification to fail.

This change extracts the JWT token from the Authorization header before verification while maintaining backward compatibility with raw token formats.

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

## Related issue

Fixes #1292 



## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.
