### PR TITLE
fix(comment): replace read-modify-write commentsCount increment with atomic $inc

### DIFF
--- a/backend/src/app/modules/comment/comment.service.ts
+++ b/backend/src/app/modules/comment/comment.service.ts
@@ -23,8 +23,11 @@ const createComment = async (
   if (!post) {
     throw new ApiError(httpStatus.BAD_REQUEST, "Post not found!");
   }
-  post.commentsCount = post.commentsCount + 1;
-  await post.save();
+  // Use an atomic $inc update instead of the read-modify-write pattern.
+  // With concurrent requests, both would read the same commentsCount value
+  // and both would write count + 1, losing one increment per race.
+  // findByIdAndUpdate with $inc is a single atomic MongoDB operation.
+  await Post.findByIdAndUpdate(post._id, { $inc: { commentsCount: 1 } });
   const commentData: Omit<IComment, "parentCommentId"> = {
     postId: new Types.ObjectId(payload.postId),
     userId: user._id,


### PR DESCRIPTION
## What happened?

Closes #1294

`createComment` in `comment.service.ts` incremented `commentsCount` using a read-modify-write pattern:

```ts
post.commentsCount = post.commentsCount + 1;
await post.save();
```

Two concurrent comment requests on the same post both read the same starting value (e.g. `5`), both compute `5 + 1 = 6`, and both save `6`. One increment is silently lost per race. Under moderate traffic the displayed comment count drifts below the actual number of comments stored in the database.

## Fix

Replace with a single atomic MongoDB update:

```ts
await Post.findByIdAndUpdate(post._id, { $inc: { commentsCount: 1 } });
```

`$inc` is a single atomic operation at the database level, eliminating the race window entirely.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `backend/src/app/modules/comment/comment.service.ts`: replaced `post.commentsCount = post.commentsCount + 1; await post.save()` with `await Post.findByIdAndUpdate(post._id, { $inc: { commentsCount: 1 } })` in `createComment`.

## Screenshots / Demo

Not applicable. This is a server-side concurrency fix with no visual change.

## Testing Done

1. Start the backend server.
2. Send 10 simultaneous `POST /comment` requests for the same post.
3. Confirm that `commentsCount` on the post equals 10 after all requests complete (no lost increments).
4. Confirm normal single-request comment creation still works.

## Checklist

- [x] I have read the CONTRIBUTING.md and followed its guidelines
- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue
- [x] I have not used any AI-generated content in this PR

## GSSoC Label Request

Could you please add the appropriate GSSoC 2026 label to this PR? It helps with tracking and scoring under GSSoC '26. Thank you!

program: gssoc