### PR TITLE
fix(comment): replace read-modify-write like toggle with atomic $addToSet and $pull

### DIFF
--- a/backend/src/app/modules/comment/comment.service.ts
+++ b/backend/src/app/modules/comment/comment.service.ts
@@ -110,14 +110,28 @@ const toggleCommentLike = async (commentId: string, token: ITokenPayload) => {
     throw new ApiError(httpStatus.NOT_FOUND, "Post not found!");
   }
   
-  const hasLiked = comment.likes?.includes(user._id);
-  if (hasLiked) {
-    comment.likes = comment.likes?.filter((id) => id.toString() !== user._id.toString());
-  } else {
-    comment.likes?.push(user._id);
-  }
-  await comment.save();
-  return comment;
+  // Replace the read-modify-write likes toggle with atomic MongoDB operators.
+  // The original pattern read likes, checked membership with includes, mutated
+  // the array, and saved. Two concurrent toggles by the same user can both pass
+  // the includes check (both see the ID absent), both push, and both save,
+  // resulting in a duplicate like entry.
+  //
+  // $addToSet adds the user ID only if it is not already present (like).
+  // $pull removes all matching entries (unlike). Both are atomic.
+  // Checking the current state first determines which operation to perform.
+  const isCurrentlyLiked = await Comment.exists({
+    _id: comment._id,
+    likes: user._id,
+  });
+
+  const updatedComment = await Comment.findByIdAndUpdate(
+    comment._id,
+    isCurrentlyLiked
+      ? { $pull: { likes: user._id } }
+      : { $addToSet: { likes: user._id } },
+    { new: true }
+  );
+  return updatedComment;
 };
 
 export const CommentService = {


### PR DESCRIPTION
## What happened?

Closes #1295

`toggleCommentLike` in `comment.service.ts` checked whether the user had liked a comment using `comment.likes?.includes(user._id)`, then mutated the in-memory array and called `comment.save()`:

```ts
const hasLiked = comment.likes?.includes(user._id);
if (hasLiked) {
  comment.likes = comment.likes?.filter((id) => id.toString() !== user._id.toString());
} else {
  comment.likes?.push(user._id);
}
await comment.save();
```

Two concurrent toggle requests by the same user can both pass the `includes` check (both see the user ID absent in their separate reads), both call `likes.push`, and both save — leaving a duplicate ID in the `likes` array. A subsequent unlike may not remove all copies.

## Fix

Replace the read-modify-write pattern with atomic MongoDB operations:

1. `Comment.exists({ _id, likes: user._id })` to determine the current like state.
2. `findByIdAndUpdate` with `$addToSet` (like) or `$pull` (unlike).

`$addToSet` is idempotent — it never produces duplicates even under concurrent requests. `$pull` removes all matching entries atomically. Both are single MongoDB operations with no race window.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `backend/src/app/modules/comment/comment.service.ts`: replaced the in-memory read-modify-write block in `toggleCommentLike` with `Comment.exists` + `findByIdAndUpdate` using `$addToSet` / `$pull`.

## Screenshots / Demo

Not applicable. This is a server-side concurrency fix with no visual change.

## Testing Done

1. Send two simultaneous `POST /like/:commentId` requests from the same authenticated user on a comment they have not yet liked.
2. Confirm the comment's `likes` array contains the user ID exactly once (no duplicate).
3. Send two simultaneous unlike requests. Confirm the user ID is fully removed.
4. Confirm normal single-request like/unlike still toggles correctly.

## Checklist

- [x] I have read the CONTRIBUTING.md and followed its guidelines
- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue
- [x] I have not used any AI-generated content in this PR

## GSSoC Label Request

Could you please add the appropriate GSSoC 2026 label to this PR? It helps with tracking and scoring under GSSoC '26. Thank you!

program: gssoc