### PR TITLE
fix: Add _id field to WebSocket JWT verification to match auth service payload structure

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -59,7 +59,7 @@ async function main() {
           token,
           config.jwt.secret as Secret
         );
-        const userId = verifiedUser.userId || verifiedUser.sub || verifiedUser.id;
+        const userId = verifiedUser._id || verifiedUser.userId || verifiedUser.sub || verifiedUser.id;
         if (!userId) {
           return next(new Error("Unauthorized"));
         }


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Open or link a related issue when there is one (`Closes #123`, `Fixes #45`, or write **None** under Related issue below).
- **Description:** Fill in **What this PR does** so a reviewer can understand the change without your local context.
- **Screenshots:** Add screenshots or a short recording when they help (UI changes, confusing flows, or non-code proof). If not needed, say so in the checklist.

## Screenshot (when helpful)

N/A - This is a backend logic fix, not a UI change.

## What this PR does

This PR fixes a JWT user identifier mismatch in the WebSocket authentication middleware. The access token generated during login stores the user identifier as `_id`, but the WebSocket authentication flow only attempted to read `userId`, `sub`, or `id`. This mismatch caused authenticated users to fail WebSocket authentication even with a valid access token.

The fix adds `_id` to the identifier check in `backend/src/server.ts` line 62, ensuring the WebSocket authentication middleware correctly resolves the user identifier from the JWT payload structure already used by the authentication service.

## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #1300

## More screenshots (optional)

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.

### Description

This PR fixes a JWT user identifier mismatch in the WebSocket authentication middleware. The access token generated during login stores the user identifier as `_id`, but the WebSocket authentication flow only attempted to read `userId`, `sub`, or `id`. This mismatch caused authenticated users to fail WebSocket authentication even with a valid access token.

The fix adds `_id` to the identifier check in `backend/src/server.ts` line 62, ensuring the WebSocket authentication middleware correctly resolves the user identifier from the JWT payload structure already used by the authentication service.

### Testing & Verification

- Local test suite passed (pre-existing test failures unrelated to this change).
- No UI changes made, so visual verification not required.

### GSSoC 2026 Compliance & Transparency

- **AI Assistance Disclosure:** AI assistance was used to develop this solution. All generated logic has been audited, verified, and locally tested by me to meet project standards.
- Closes #1300