### PR TITLE
fix: remove X-Forwarded-For spoofing bypass in rate limiter

### DIFF
--- a/backend/src/__tests__/rateLimitMiddleware.test.ts
+++ b/backend/src/__tests__/rateLimitMiddleware.test.ts
@@ -15,10 +15,10 @@ import {
 import type { Request, Response, NextFunction } from "express";
 
 // ── Mock factory ──────────────────────────────
-function buildMocks(ip: string, userId?: string) {
+function buildMocks(ip: string, userId?: string, headers?: Record<string, string>) {
   const req = {
     ip,
-    headers : {} as Record<string, string>,
+    headers : (headers ?? {}) as Record<string, string>,
     user    : userId ? { id: userId } : undefined,
   } as unknown as Request;
 
@@ -26,9 +26,9 @@ function buildMocks(ip: string, userId?: string) {
     statusCode : 200,
     body       : null as unknown,
     headers    : {} as Record<string, string>,
-    status(code: number) { this.statusCode = code; return this; },
-    json(body: unknown)  { this.body = body;        return this; },
-    setHeader(k: string, v: string) { this.headers[k] = v; },
+    status(code: number) { (this as any).statusCode = code; return this; },
+    json(body: unknown)  { (this as any).body = body;        return this; },
+    setHeader(k: string, v: string) { (this as any).headers[k] = v; },
   } as unknown as Response;
 
   const next: NextFunction = jest.fn();
@@ -75,6 +75,32 @@ describe("storyRateLimiter — basic behaviour", () => {
     const status = getRateLimitStatus("10.0.0.3");
     expect(status.count).toBe(2);
     expect(status.remaining).toBe(8);
+  });
+});
+
+describe("storyRateLimiter — X-Forwarded-For spoofing", () => {
+  it("ignores X-Forwarded-For and keys on req.ip", () => {
+    const { req, res, next } = buildMocks("10.0.0.1", undefined, {
+      "x-forwarded-for": "1.2.3.4",
+    });
+    for (let i = 0; i < 10; i++) storyRateLimiter(req, res, next);
+    // 11th should be blocked — same req.ip regardless of header
+    storyRateLimiter(req, res, next);
+    expect((res as any).statusCode).toBe(429);
+  });
+
+  it("does not create separate buckets per X-Forwarded-For value", () => {
+    const { req: r1, res: s1, next: n1 } = buildMocks("10.0.0.1", undefined, {
+      "x-forwarded-for": "1.1.1.1",
+    });
+    const { req: r2, res: s2, next: n2 } = buildMocks("10.0.0.1", undefined, {
+      "x-forwarded-for": "2.2.2.2",
+    });
+    // First requestor fills the bucket
+    for (let i = 0; i < 10; i++) storyRateLimiter(r1, s1, n1);
+    // Second requestor shares same req.ip → should be blocked
+    storyRateLimiter(r2, s2, n2);
+    expect((s2 as any).statusCode).toBe(429);
   });
 });
 

--- a/backend/src/middlewares/rateLimitMiddleware.ts
+++ b/backend/src/middlewares/rateLimitMiddleware.ts
@@ -30,10 +30,13 @@ export function storyRateLimiter(
   res: Response,
   next: NextFunction
 ): void {
-  // Prefer authenticated user id, fall back to IP
+  // Prefer authenticated user id, fall back to IP.
+  // NOTE: Do NOT read X-Forwarded-For directly — the client controls that
+  // header and can spoof a new IP per request to bypass the limit.
+  // Instead rely on req.ip, which Express derives from the proxy chain
+  // when trust proxy is enabled (see app.set("trust proxy", 1) in app.ts).
   const key: string =
     (req as any).user?.id ??
-    (req.headers["x-forwarded-for"] as string | undefined)?.split(",")[0].trim() ??
     req.ip ??
     "anonymous";
 


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Closes #1289
- **Description:** Fixed below.
- **Screenshots:** N/A — backend-only change, no UI impact.

## Screenshot (when helpful)

N/A

## What this PR does

The rate limiter (`backend/src/middlewares/rateLimitMiddleware.ts`) built its bucket key from the `X-Forwarded-For` header before falling back to `req.ip`. Since `X-Forwarded-For` is a client-controlled header, an attacker could send a different random value on every request and land in a fresh bucket each time — completely bypassing the 10 req/min limit for anonymous users.

**Fix:** Remove the `X-Forwarded-For` fallback so the key derives from `req.ip`, which Express derives from the proxy chain when `trust proxy` is enabled (already configured in `app.ts:14`). Also added two dedicated tests verifying the header is ignored.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #1289

## More screenshots (optional)

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.

---

### Testing & Verification

- All 7 rate limiter unit tests pass (5 existing + 2 new spoofing tests).
- No regressions in existing behavior.

### GSSoC 2026 Compliance & Transparency

- **AI Assistance Disclosure:** AI assistance was used to develop this solution. All generated logic has been audited, verified, and locally tested by me to meet project standards.
- Closes #1289