### PR TITLE
fix: add rate limiting to payment endpoints

### DIFF
--- a/backend/src/app/middleware/ip.rate-limiter.ts
+++ b/backend/src/app/middleware/ip.rate-limiter.ts
@@ -140,5 +140,14 @@ export const resetPasswordRateLimiter = createRateLimiter({
   actionLabel: "password reset",
 });
 
+/** Payment: 20 attempts per 15 minutes, 15-minute block */
+export const paymentRateLimiter = createRateLimiter({
+  windowMs: 15 * 60 * 1000,  // 15 minutes
+  maxRequests: 20,
+  blockTimeMs: 15 * 60 * 1000, // 15 minutes
+  keyPrefix: "payment",
+  actionLabel: "payment",
+});
+
 export default ipRateLimiter;
 

--- a/backend/src/router/payment.route.ts
+++ b/backend/src/router/payment.route.ts
@@ -2,13 +2,14 @@ import { Router } from "express";
 import { createOrder, verifyPayment } from "../controllers/payment.controller";
 import auth from "../app/middleware/auth.middleware";
 import { ENUM_USER_ROLE } from "../enums/user";
+import { paymentRateLimiter } from "../app/middleware/ip.rate-limiter";
 
 const paymentRouter = Router();
 
 // Route to create a new Razorpay order — requires a valid user session
-paymentRouter.post("/create-order", auth(ENUM_USER_ROLE.USER), createOrder);
+paymentRouter.post("/create-order", paymentRateLimiter, auth(ENUM_USER_ROLE.USER), createOrder);
 
 // Route to verify payment signature after successful payment — requires a valid user session
-paymentRouter.post("/verify", auth(ENUM_USER_ROLE.USER), verifyPayment);
+paymentRouter.post("/verify", paymentRateLimiter, auth(ENUM_USER_ROLE.USER), verifyPayment);
 
 export default paymentRouter;


### PR DESCRIPTION
## Fixes #1298

### Summary

This PR strengthens protection for the payment endpoints by adding rate limiting using the existing rate-limiting infrastructure.

### Changes

- Added a dedicated `paymentRateLimiter`
- Applied rate limiting to:
  - POST `/create-order`
  - POST `/verify`
- Preserved the existing authentication and authorization checks already present on these routes

### Validation

- Build passes
- TypeScript checks pass
- No controller changes
- No API contract changes

### Security Impact

Adds abuse protection against excessive requests to payment-related endpoints while maintaining the existing authentication flow.