### PR TITLE
fix: hide cookie consent banner on auth pages

### DIFF
--- a/frontend/src/components/layout/root_layout.component.tsx
+++ b/frontend/src/components/layout/root_layout.component.tsx
@@ -22,7 +22,7 @@ const RootLayout: React.FC<RootLayoutProps> = ({ children }) => {
   return (
     <div className={`flex flex-col min-h-screen bg-slate-50 text-slate-900 transition-colors duration-300 dark:bg-slate-950 dark:text-slate-100 ${!isAuthPage ? "pb-20 lg:pb-0" : ""}`}>
       {!hideHeader && <NavListComponent />}
-      <CookieConsentBanner />
+      {!isAuthPage && <CookieConsentBanner />}
       <div className="flex-grow min-h-0">{children}</div>
       {!hideFooter && <FooterComponent />}
 


### PR DESCRIPTION
## What this PR does

Fixes an issue where the Cookie Consent Banner was displayed on Signup and Login pages on first visit.

The banner is now hidden on authentication pages while preserving its existing behavior on all other pages.

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

## Related issue

Fixes #1390

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.
