### PR TITLE
fix(api): use configured API base URL for story continuation

### DIFF
--- a/frontend/src/services/continuation.service.ts
+++ b/frontend/src/services/continuation.service.ts
@@ -1,4 +1,5 @@
-import axios from "axios";
+import { instance as apiClient } from "../helpers/axios/axionInstance";
+import { getBaseUrl } from "../helpers/config";
 import { Chapter } from "../types/story.types";
 
 export const continueStory = async (
@@ -8,23 +9,23 @@ export const continueStory = async (
     .map((chapter) => chapter.content)
     .join("\n\n");
 
-  const response = await axios.post(
-    "http://localhost:5000/api/v1/story-continuation/continue",
+  const response = await apiClient.post(
+    `${getBaseUrl()}/story-continuation/continue`,
     {
-      prompt: `
+      prompt: `                                                 
 Continue this story naturally.
 
 Rules:
-- Maintain character consistency
+- Maintain character consistency                            
 - Keep emotional tone
 - Avoid repetition
 - Continue the narrative smoothly
 
 Story:
 ${previousContent}
-      `,
+      `,                
     }
   );
 
   return response.data.text;
-};
+};                                                              

--- a/frontend/src/services/continuation.service.ts
+++ b/frontend/src/services/continuation.service.ts
@@ -12,20 +12,20 @@ export const continueStory = async (
   const response = await apiClient.post(
     `${getBaseUrl()}/story-continuation/continue`,
     {
-      prompt: `                                                 
+      prompt: `
 Continue this story naturally.
 
 Rules:
-- Maintain character consistency                            
+- Maintain character consistency
 - Keep emotional tone
 - Avoid repetition
 - Continue the narrative smoothly
 
 Story:
 ${previousContent}
-      `,                
+      `,
     }
   );
 
   return response.data.text;
-};                                                              
+};


### PR DESCRIPTION
## Description

Fixes the story continuation service using a hardcoded localhost endpoint instead of the configured API base URL.

Previously, continuation requests were sent directly to:

http://localhost:5000/api/v1/story-continuation/continue

This caused the feature to fail in deployed environments where the frontend and backend are hosted separately.

The service now uses the project's configured API base URL, ensuring compatibility across development and production deployments.

Fixes #1367 

---

## Changes Made

* Removed hardcoded localhost endpoint from the story continuation service
* Updated requests to use the configured API base URL
* Preserved existing request payload structure
* Preserved existing response handling behavior
* Followed the project's existing API configuration pattern

---

## Root Cause

The story continuation service bypassed deployment configuration and directly targeted a localhost backend endpoint.

As a result, production deployments continued attempting requests to localhost, causing story continuation requests to fail outside local development environments.

---

## Validation

* Verified the service now uses the environment-configured API URL
* Confirmed no localhost dependency remains in the continuation request
* Preserved existing API request and response flow
* Confirmed consistency with existing API configuration usage patterns

---

## Impact

* Fixes story continuation in deployed environments
* Supports separate frontend/backend hosting setups
* Improves deployment portability
* Reduces environment-specific failures

---

## Checklist

* [x] I have read the CONTRIBUTING.md guidelines
* [x] I have tested the changes locally
* [x] My changes are focused only on this issue
* [x] I have reviewed my code before submitting
* [x] My commit follows repository conventions
