### PR TITLE
fix: add accessibility labels to password toggle

### DIFF
--- a/frontend/src/components/ui-component/ss-input/ss-input.tsx
+++ b/frontend/src/components/ui-component/ss-input/ss-input.tsx
@@ -66,6 +66,8 @@ const inputType =
     type="button"
     onClick={() => setShowPassword(!showPassword)}
     className="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-500"
+    aria-label={showPassword ? "Hide password" : "Show password"}
+    title={showPassword ? "Hide password" : "Show password"}
   >
     <i className={showPassword ? "fi fi-rr-eye" : "fi fi-rr-eye-crossed"}></i>
   </button>


### PR DESCRIPTION

## What this PR does

This PR improves accessibility on the login page by adding descriptive accessibility labels to the password visibility toggle button.

Previously, the password visibility toggle relied only on icons, which could not be properly interpreted by screen readers or assistive technologies.

## Screenshot (when helpful)

N/A – This update improves accessibility for the password visibility toggle button and does not introduce major visual UI changes.

### Changes implemented

* Added dynamic `aria-label` values:

  * "Show password"
  * "Hide password"
* Added `title` attributes for improved usability and hover feedback
* Improved accessibility and screen reader compatibility for the password visibility toggle

---

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

---

## Related issue

Closes #1339

---

## More screenshots (optional)

N/A

---

## Checklist

* [x] I have added screenshots or a recording when necessary, or marked it as **N/A** with a valid reason.
* [x] I have included the related issue number.
* [x] I have tested my changes locally.
* [x] I have performed a self-review of the code.
