### PR TITLE
fix: remove duplicate imports in App.tsx (#1440)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,15 +6,6 @@ import WritingAssistantComponent from "./components/writing-assistant/writing_as
 import CollabHome from "./components/collab/CollabHome";
 import CollabRoom from "./components/collab/CollabRoom";
 import StoriesComponent from "./components/stories/stories.component";
-
-import {
-  createBrowserRouter,
-  RouterProvider,
-  Navigate,
-  Outlet,
-} from "react-router-dom";
-import ScrollToTop from "./components/ScrollToTop";
-
 import HeroSectionComponent from "./components/hero/hero_section.component";
 import HomeComponent from "./components/home/home.component";
 import LoginComponent from "./components/login/login.component";
@@ -53,7 +44,6 @@ import ContributorsComponent from "./components/footer/contributors";
 import ReportBug from "./components/report-bug/ReportBug";
 import AnalyticsPage from "./components/dashboard/analytics/analytics.page";
 import StoryWorkspace from "./components/story/StoryWorkspace";
-import StoriesComponent from "./components/stories/stories.component";
 
 type ProtectedRouteProps = {
   allowedRoles: string[];


### PR DESCRIPTION
## Screenshot (when helpful)
N/A - No UI changes, this is an import cleanup fix.

## What this PR does
App.tsx had duplicate import statements causing redundancy and lint warnings.

Duplicates removed:
- `createBrowserRouter`, `Navigate`, `Outlet`, `RouterProvider` from react-router-dom was imported twice
- `ScrollToTop` component was imported twice
- `StoriesComponent` was imported twice

Fixed by removing all duplicate import declarations and keeping one clean consolidated import per dependency.

Result: 1 file changed, 11 lines deleted.

## Type of change
- [x] Bug fix

## Related issue
Fixes #1440

## More screenshots (optional)
N/A

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.