### PR TITLE
handle white space name allow problem on issue 1371

### DIFF
--- a/backend/src/app/modules/user/user.service.ts
+++ b/backend/src/app/modules/user/user.service.ts
@@ -28,7 +28,11 @@ const updateUser = async (token: ITokenPayload, payload: Partial<IUser>) => {
   const updateData: Record<string, unknown> = {};
 
   if (typeof payload.name === "string") {
-    updateData.name = payload.name;
+    const trimmedName = payload.name.trim();
+    if (!trimmedName) {
+      throw new ApiError(httpStatus.BAD_REQUEST, "Full Name cannot be empty!");
+    }
+    updateData.name = trimmedName;
   }
 
   if (payload.profile) {

--- a/backend/src/app/modules/user/user.validation.ts
+++ b/backend/src/app/modules/user/user.validation.ts
@@ -44,7 +44,7 @@ const resetPassword = z.object({
 const updateUser = z.object({
   body: z
     .object({
-      name: z.string().optional(),
+      name: z.string().trim().min(1, "Full Name cannot be empty.").optional(),
       profile: z
         .object({
           avatar: z.string().optional(),

--- a/frontend/src/components/dashboard/profile/profile.setting.component.tsx
+++ b/frontend/src/components/dashboard/profile/profile.setting.component.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, ChangeEvent, FormEvent } from "react";
 import { User } from "../../../models/user";
 
 interface ProfileSettingComponentProps {
@@ -19,9 +19,10 @@ export const ProfileSettingComponent = ({ user, onSave, loading }: ProfileSettin
       instagram: user.profile?.social?.instagram || "",
     },
   });
+  const [nameError, setNameError] = useState<string>("");
 
   const handleChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ) => {
     const { name, value } = e.target;
 
@@ -42,10 +43,18 @@ export const ProfileSettingComponent = ({ user, onSave, loading }: ProfileSettin
     }
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
+
+    const trimmedName = formData.name?.trim();
+    if (!trimmedName) {
+      setNameError("Full Name cannot be empty.");
+      return;
+    }
+
+    setNameError("");
     onSave({
-      name: formData.name,
+      name: trimmedName,
       profile: {
         bio: formData.bio,
         avatar: formData.avatar,
@@ -91,6 +100,11 @@ export const ProfileSettingComponent = ({ user, onSave, loading }: ProfileSettin
                       onChange={handleChange}
                       className={inputClassName}
                     />
+                    {nameError && (
+                      <p className="mt-2 text-sm text-rose-600 dark:text-rose-400">
+                        {nameError}
+                      </p>
+                    )}
                   </div>
 
                   <div>


### PR DESCRIPTION
## What this PR does

This PR fixes a validation issue in the Profile Settings page where users could save their profile with a Full Name containing only whitespace characters.

### Problem

Previously, the application accepted inputs such as `"   "` (spaces only) in the Full Name field and allowed the profile to be saved successfully. This could result in invalid or blank user profile information being stored in the database.

### Changes Implemented

* Added trimming of the Full Name input before validation.
* Added validation to reject inputs containing only whitespace characters.
* Prevented profile updates when the Full Name is empty after trimming.
* Added a user-friendly validation message informing users that the Full Name cannot be empty.

### Benefits

* Prevents invalid profile data from being stored.
* Improves overall data consistency and integrity.
* Enhances user experience by providing clear validation feedback.
* Ensures profile names contain meaningful content before submission.

## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

## Related issue

Fixes #1371

## More screenshots (optional)

N/A

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes by attempting to save profiles with whitespace-only names and verified that validation prevents submission.
* [x] I have done a self-review of the code.
