### PR TITLE
fix: replace hardcoded avatar with authenticated user profile image

### DIFF
--- a/frontend/src/components/dashboard/dashboard_layout.component.tsx
+++ b/frontend/src/components/dashboard/dashboard_layout.component.tsx
@@ -175,7 +175,7 @@ import React, { useState } from "react";
 import { Link, Outlet, useLocation, useNavigate, Navigate } from "react-router-dom";
 import { MenuItem, menuItems } from "./dashboard.utils";
 import { getUserInfo } from "../../services/auth.service";
-
+import { useGetProfileInfoQuery } from "../../redux/apis/user.api";
 const DashboardLayout: React.FC = () => {
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
   const [expanded, setExpanded] = useState<{ [key: string]: boolean }>({});
@@ -187,7 +187,7 @@ const DashboardLayout: React.FC = () => {
   if (!user) {
   return <Navigate to="/login" replace />;
 }
-
+const { data } = useGetProfileInfoQuery();
   const currentPage = menuItems
     .flatMap((item) => (item.subRoutes ? [item, ...item.subRoutes] : [item]))
     .find(
@@ -241,11 +241,11 @@ const DashboardLayout: React.FC = () => {
             </span>
           </button>
 
-          <img
-            className="h-9 w-9 rounded-full"
-            src="https://avatars.githubusercontent.com/u/76697055?v=4"
-            alt="profile"
-          />
+         <img
+  className="h-9 w-9 rounded-full"
+  src={data?.profile?.avatar || "https://ui-avatars.com/api/?name=User"}
+  alt="profile"
+/>
         </div>
       </header>
 

--- a/frontend/src/components/top_header/top_header.component.tsx
+++ b/frontend/src/components/top_header/top_header.component.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
 import logo from "../../assets/logo.png";
-
-const TopHeaderComponent = () => {
+import { useGetProfileInfoQuery } from "../../redux/apis/user.api";
+function TopHeaderComponent() {
   const [, setShowNotification] = useState<boolean>(false);
+  const { data } = useGetProfileInfoQuery();
   return (
     <div className="sticky top-0 z-50">
       <div className="relative z-10 mx-auto max-w-8xl px-6 py-4 gradient-bg">
@@ -58,10 +59,10 @@ const TopHeaderComponent = () => {
                     className="!rounded-button bg-white flex text-sm rounded-full focus:outline-none"
                   >
                     <img
-                      className="h-8 w-8 rounded-full"
-                      src="https://avatars.githubusercontent.com/u/76697055?v=4"
-                      alt="profile"
-                    />
+                     className="h-8 w-8 rounded-full"
+                     src={data?.profile?.avatar || "https://ui-avatars.com/api/?name=User"}
+                     alt="profile"
+                      />
                   </button>
                 </div>
               </div>
@@ -72,6 +73,6 @@ const TopHeaderComponent = () => {
       </div>
     </div>
   );
-};
+}
 
 export default TopHeaderComponent;


### PR DESCRIPTION
## Screenshot (when helpful)

N/A - This change replaces hardcoded avatar URLs and does not introduce a visual UI redesign.

## What this PR does

- Replaces hardcoded GitHub avatar URLs in the dashboard and top header components.
- Uses authenticated user profile data via `useGetProfileInfoQuery`.
- Displays the logged-in user's avatar instead of a fixed profile image.
- Adds a fallback avatar when no profile image is available.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #1463

## More screenshots (optional)

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.