### PR TITLE
Fix community page light theme styling

### DIFF
--- a/frontend/src/components/community/community.component.tsx
+++ b/frontend/src/components/community/community.component.tsx
@@ -27,11 +27,11 @@ export default function CommunityCardsPreview() {
   ];
 
   return (
-    <div className="min-h-screen bg-[#081120] text-white px-6 py-20">
+    <div className="min-h-screen bg-white text-slate-900 px-6 py-20 transition-colors duration-300 dark:bg-[#081120] dark:text-white">
       <div className="max-w-7xl mx-auto">
         <div className="flex flex-col md:flex-row md:items-end justify-between mb-16 gap-6">
           <div className="max-w-2xl">
-            <div className="inline-flex items-center px-4 py-1.5 rounded-full border border-blue-500/20 bg-blue-500/5 text-blue-400 text-xs font-semibold tracking-[0.2em] uppercase mb-6">
+            <div className="inline-flex items-center px-4 py-1.5 rounded-full border border-blue-500/20 bg-blue-500/10 text-blue-600 text-xs font-semibold tracking-[0.2em] uppercase mb-6 dark:bg-blue-500/5 dark:text-blue-400">
               Explore Communities
             </div>
 
@@ -39,12 +39,12 @@ export default function CommunityCardsPreview() {
               Discover Your Writing Universe
             </h2>
 
-            <p className="text-lg leading-relaxed text-gray-400">
+            <p className="text-lg leading-relaxed text-slate-600 dark:text-gray-400">
               Find your niche and connect with specialists in your favorite storytelling styles.
             </p>
           </div>
 
-          <button className="text-blue-400 font-semibold hover:translate-x-1 transition-transform">
+          <button className="text-blue-600 font-semibold hover:translate-x-1 transition-transform dark:text-blue-400">
             VIEW ALL GENRES →
           </button>
         </div>
@@ -53,7 +53,7 @@ export default function CommunityCardsPreview() {
           {genres.map((genre, index) => (
             <div
               key={index}
-              className="group relative overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-br from-[#0f172a] to-[#111827] p-8 transition-all duration-300 hover:-translate-y-2 hover:border-blue-500/30 hover:shadow-2xl hover:shadow-blue-500/10"
+              className="group relative overflow-hidden rounded-3xl border border-slate-200 bg-white p-8 shadow-lg shadow-slate-200/60 transition-all duration-300 hover:-translate-y-2 hover:border-blue-500/30 hover:shadow-2xl hover:shadow-blue-500/10 dark:border-white/10 dark:bg-gradient-to-br dark:from-[#0f172a] dark:to-[#111827] dark:shadow-none"
             >
               <div className="absolute -top-24 right-0 w-40 h-40 bg-blue-500/10 blur-3xl rounded-full opacity-0 group-hover:opacity-100 transition-opacity duration-500"></div>
 
@@ -65,20 +65,20 @@ export default function CommunityCardsPreview() {
                 {genre.category}
               </div>
 
-              <h3 className="text-3xl font-bold mb-4 group-hover:text-blue-400 transition-colors">
+              <h3 className="text-3xl font-bold mb-4 group-hover:text-blue-600 transition-colors dark:group-hover:text-blue-400">
                 {genre.title}
               </h3>
 
-              <p className="text-gray-400 leading-relaxed line-clamp-3 mb-10">
+              <p className="text-slate-600 leading-relaxed line-clamp-3 mb-10 dark:text-gray-400">
                 {genre.description}
               </p>
 
-              <div className="flex items-center justify-between pt-6 border-t border-white/10">
-                <div className="flex items-center text-sm font-medium text-gray-400">
+              <div className="flex items-center justify-between pt-6 border-t border-slate-200 dark:border-white/10">
+                <div className="flex items-center text-sm font-medium text-slate-500 dark:text-gray-400">
                   👥 {genre.writers} Writers
                 </div>
 
-                <button className="inline-flex items-center text-blue-400 font-semibold hover:translate-x-1 transition-transform">
+                <button className="inline-flex items-center text-blue-600 font-semibold hover:translate-x-1 transition-transform dark:text-blue-400">
                   Enter Hub →
                 </button>
               </div>


### PR DESCRIPTION
@ronisarkarexe Please add Gssoc tag in it

## What this PR does

Fixes the Community page not respecting the active Light Mode theme.

The page previously hardcoded a dark navy background, white text, dark cards, and dark-mode borders even when Light Mode was selected. This PR updates the Community page Tailwind classes so light mode uses white/slate surfaces, readable slate text, light borders, and blue accents, while preserving the existing navy styling behind `dark:` classes.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Fixes #1477 

## More screenshots (optional)

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.