### PR TITLE
Add multilingual read aloud voice controls

### DIFF
--- a/frontend/src/components/AudioPlayer.tsx
+++ b/frontend/src/components/AudioPlayer.tsx
@@ -39,6 +39,10 @@ const AudioPlayer = forwardRef<AudioPlayerHandle, AudioPlayerProps>(
   ({ text, title = "Story narration", onWordIndexChange, onPlaybackStateChange }, ref) => {
     const speech = useSpeechSynthesis(text);
     const speedSelectId = useId();
+    const languageSelectId = useId();
+    const voiceSelectId = useId();
+    const filteredVoices = speech.voices.filter((voice) => voice.lang === speech.selectedLanguage);
+    const voiceOptions = filteredVoices.length > 0 ? filteredVoices : speech.voices;
 
     useImperativeHandle(
       ref,
@@ -183,7 +187,7 @@ const AudioPlayer = forwardRef<AudioPlayerHandle, AudioPlayerProps>(
               </button>
             </div>
 
-            <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_180px] md:items-end">
+            <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(150px,190px)_minmax(180px,1fr)_minmax(180px,1fr)] lg:items-end">
               <div className="space-y-2">
                 <div className="flex items-center justify-between text-sm text-slate-600 dark:text-slate-400">
                   <span>Progress</span>
@@ -225,6 +229,56 @@ const AudioPlayer = forwardRef<AudioPlayerHandle, AudioPlayerProps>(
                     {SPEED_OPTIONS.map((option) => (
                       <option key={option} value={option}>
                         {option.toFixed(2).replace(/\.00$/, "")}&times;
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <label
+                  htmlFor={languageSelectId}
+                  className="text-sm font-medium text-slate-700 dark:text-slate-300"
+                >
+                  Narration language
+                </label>
+                <div className="relative">
+                  <select
+                    id={languageSelectId}
+                    aria-label="Narration language"
+                    role="combobox"
+                    value={speech.selectedLanguage}
+                    onChange={(event) => speech.setSelectedLanguage(event.target.value)}
+                    className="w-full rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm text-slate-900 shadow-sm outline-none transition-colors focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:focus:border-indigo-400 dark:focus:ring-indigo-500/20"
+                  >
+                    {speech.languageOptions.map((option) => (
+                      <option key={option.lang} value={option.lang}>
+                        {option.label} ({option.voiceCount})
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <label
+                  htmlFor={voiceSelectId}
+                  className="text-sm font-medium text-slate-700 dark:text-slate-300"
+                >
+                  Voice
+                </label>
+                <div className="relative">
+                  <select
+                    id={voiceSelectId}
+                    aria-label="Narration voice"
+                    role="combobox"
+                    value={speech.selectedVoiceId}
+                    onChange={(event) => speech.setSelectedVoiceId(event.target.value)}
+                    className="w-full rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm text-slate-900 shadow-sm outline-none transition-colors focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:focus:border-indigo-400 dark:focus:ring-indigo-500/20"
+                  >
+                    {voiceOptions.map((voice) => (
+                      <option key={voice.id} value={voice.id}>
+                        {voice.label}
                       </option>
                     ))}
                   </select>

--- a/frontend/src/components/post/post.details.component.tsx
+++ b/frontend/src/components/post/post.details.component.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import {
   useDeletePostMutation,
@@ -16,6 +16,7 @@ import PostCommentComponent from "./post.comment.component";
 import LoadingAnimation from "../loading/loading.component";
 import SSProfile from "../ui-component/ss-profile/ss-profile";
 import BookmarkButton from "../BookmarkButton";
+import AudioPlayer from "../AudioPlayer";
 
 import { formatDateShort } from "../../utils/time-formate";
 import { getUserInfo } from "../../services/auth.service";
@@ -193,75 +194,6 @@ const PostDetailsComponent = () => {
     window.location.href = url;
   };
 
-  const [isPlayingAudio, setIsPlayingAudio] = useState(false);
-  const [isPausedAudio, setIsPausedAudio] = useState(false);
-
-  const handleTextToSpeech = () => {
-    if (!post?.content) return;
-
-    if (!("speechSynthesis" in window)) {
-      toast.error("Text-to-speech is not supported in this browser.");
-      return;
-    }
-
-    if (isPlayingAudio) {
-      if (isPausedAudio) {
-        window.speechSynthesis.resume();
-        setIsPausedAudio(false);
-        toast.success("Resumed reading story");
-      } else {
-        window.speechSynthesis.pause();
-        setIsPausedAudio(true);
-        toast.success("Paused reading story");
-      }
-    } else {
-      window.speechSynthesis.cancel();
-      const cleanContent = post.content.replace(/<[^>]*>/g, "");
-      const utterance = new SpeechSynthesisUtterance(cleanContent);
-      
-      utterance.onend = () => {
-        setIsPlayingAudio(false);
-        setIsPausedAudio(false);
-      };
-
-      utterance.onerror = (e) => {
-        console.error("SpeechSynthesis error:", e);
-        setIsPlayingAudio(false);
-        setIsPausedAudio(false);
-      };
-
-      const voices = window.speechSynthesis.getVoices();
-      const englishVoice = voices.find(
-        (v) => v.lang.startsWith("en-") && v.name.includes("Google")
-      ) || voices.find((v) => v.lang.startsWith("en-"));
-      if (englishVoice) {
-        utterance.voice = englishVoice;
-      }
-
-      window.speechSynthesis.speak(utterance);
-      setIsPlayingAudio(true);
-      setIsPausedAudio(false);
-      toast.success("Playing story audio");
-    }
-  };
-
-  const handleStopAudio = () => {
-    if ("speechSynthesis" in window) {
-      window.speechSynthesis.cancel();
-    }
-    setIsPlayingAudio(false);
-    setIsPausedAudio(false);
-    toast.success("Stopped audio playback");
-  };
-
-  useEffect(() => {
-    return () => {
-      if ("speechSynthesis" in window) {
-        window.speechSynthesis.cancel();
-      }
-    };
-  }, []);
-
   const handleDelete = async () => {
     if (
       !id ||
@@ -427,6 +359,12 @@ const PostDetailsComponent = () => {
                 <div className="prose max-w-none mb-12 text-slate-700 dark:text-gray-300 whitespace-pre-wrap leading-relaxed text-lg font-light">
                   <p>{post?.content}</p>
                 </div>
+
+                {post?.content && (
+                  <div className="mb-12">
+                    <AudioPlayer text={post.content} title={post.title} />
+                  </div>
+                )}
               </>
             )}
 
@@ -453,34 +391,6 @@ const PostDetailsComponent = () => {
                     bookmarks={post.bookmarks}
                     className="!border-none !px-0 bg-transparent hover:bg-transparent"
                   />
-                )}
-                <button
-                  onClick={handleTextToSpeech}
-                  className={`flex items-center space-x-2 transition-colors cursor-pointer ${
-                    isPlayingAudio
-                      ? isPausedAudio
-                        ? "text-amber-500 hover:text-amber-400"
-                        : "text-green-500 hover:text-green-400"
-                      : "text-gray-600 hover:text-gray-400"
-                  }`}
-                  title={isPlayingAudio ? (isPausedAudio ? "Resume Story" : "Pause Story") : "Listen to Story"}
-                >
-                  <i
-                    className={`fas ${
-                      isPlayingAudio ? (isPausedAudio ? "fa-circle-play" : "fa-circle-pause") : "fa-volume-high"
-                    }`}
-                  ></i>
-                  <span>{isPlayingAudio ? (isPausedAudio ? "Resume" : "Pause") : "Listen"}</span>
-                </button>
-                {isPlayingAudio && (
-                  <button
-                    onClick={handleStopAudio}
-                    className="flex items-center space-x-2 text-red-500 hover:text-red-400 transition-colors cursor-pointer"
-                    title="Stop Audio"
-                  >
-                    <i className="fas fa-circle-stop"></i>
-                    <span>Stop</span>
-                  </button>
                 )}
               </div>
 
@@ -635,4 +545,3 @@ const PostDetailsComponent = () => {
 };
 
 export default PostDetailsComponent;
-

--- a/frontend/src/hooks/useSpeechSynthesis.ts
+++ b/frontend/src/hooks/useSpeechSynthesis.ts
@@ -11,6 +11,21 @@ export interface SpeechProgress {
   percentage: number;
 }
 
+export interface SpeechVoiceOption {
+  id: string;
+  name: string;
+  lang: string;
+  label: string;
+  localService: boolean;
+  isDefault: boolean;
+}
+
+export interface SpeechLanguageOption {
+  lang: string;
+  label: string;
+  voiceCount: number;
+}
+
 export interface UseSpeechSynthesisResult {
   /** True when narration is actively playing. */
   isPlaying: boolean;
@@ -30,6 +45,18 @@ export interface UseSpeechSynthesisResult {
   rate: number;
   /** Update playback speed for future narration and active utterances when possible. */
   setRate: (nextRate: number) => void;
+  /** Available browser narration voices. */
+  voices: SpeechVoiceOption[];
+  /** Available languages inferred from browser voices. */
+  languageOptions: SpeechLanguageOption[];
+  /** Selected BCP 47 narration language, for example "en-US" or "hi-IN". */
+  selectedLanguage: string;
+  /** Update narration language and pick the first matching voice. */
+  setSelectedLanguage: (nextLanguage: string) => void;
+  /** Selected browser voice id. */
+  selectedVoiceId: string;
+  /** Update narration voice. */
+  setSelectedVoiceId: (nextVoiceId: string) => void;
   /** Word-level progress metadata for UI rendering and text highlighting. */
   progress: SpeechProgress;
   /** Browser support flag for the Web Speech API. */
@@ -97,6 +124,51 @@ const getWordIndexAtCharIndex = (
   return bestMatch;
 };
 
+const getVoiceId = (voice: SpeechSynthesisVoice): string => {
+  return voice.voiceURI || `${voice.name}-${voice.lang}`;
+};
+
+const getLanguageLabel = (languageCode: string): string => {
+  try {
+    const [language, region] = languageCode.split("-");
+    const displayNames = new Intl.DisplayNames([window.navigator.language || "en"], {
+      type: "language",
+    });
+    const languageName = displayNames.of(languageCode) || displayNames.of(language) || languageCode;
+
+    return region ? `${languageName} (${region})` : languageName;
+  } catch {
+    return languageCode;
+  }
+};
+
+const mapVoiceOption = (voice: SpeechSynthesisVoice): SpeechVoiceOption => ({
+  id: getVoiceId(voice),
+  name: voice.name,
+  lang: voice.lang,
+  label: `${voice.name} (${voice.lang})`,
+  localService: voice.localService,
+  isDefault: voice.default,
+});
+
+const getPreferredLanguage = (): string => {
+  return window.navigator.language || "en-US";
+};
+
+const findVoiceForLanguage = (
+  voices: SpeechVoiceOption[],
+  language: string,
+): SpeechVoiceOption | undefined => {
+  const normalizedLanguage = language.toLowerCase();
+  const languagePrefix = normalizedLanguage.split("-")[0];
+
+  return (
+    voices.find((voice) => voice.lang.toLowerCase() === normalizedLanguage) ||
+    voices.find((voice) => voice.lang.toLowerCase().startsWith(`${languagePrefix}-`)) ||
+    voices.find((voice) => voice.lang.toLowerCase().startsWith(languagePrefix))
+  );
+};
+
 /**
  * Typed Web Speech API hook for browser-based text-to-speech narration.
  *
@@ -116,6 +188,9 @@ export const useSpeechSynthesis = (text: string): UseSpeechSynthesisResult => {
   const [isSpeaking, setIsSpeaking] = useState(false);
   const [rateState, setRateState] = useState(1);
   const [currentWordIndex, setCurrentWordIndex] = useState(0);
+  const [voices, setVoices] = useState<SpeechVoiceOption[]>([]);
+  const [selectedLanguage, setSelectedLanguageState] = useState("");
+  const [selectedVoiceId, setSelectedVoiceIdState] = useState("");
 
   const wordRanges = useMemo(() => buildWordRanges(text), [text]);
   const totalWords = wordRanges.length;
@@ -132,6 +207,26 @@ export const useSpeechSynthesis = (text: string): UseSpeechSynthesisResult => {
       percentage: totalWords > 0 ? spokenWords / totalWords : 0,
     };
   }, [currentWordIndex, isPaused, isPlaying, totalWords]);
+
+  const languageOptions = useMemo<SpeechLanguageOption[]>(() => {
+    const languageCounts = new Map<string, number>();
+
+    voices.forEach((voice) => {
+      languageCounts.set(voice.lang, (languageCounts.get(voice.lang) || 0) + 1);
+    });
+
+    return Array.from(languageCounts.entries())
+      .map(([lang, voiceCount]) => ({
+        lang,
+        label: getLanguageLabel(lang),
+        voiceCount,
+      }))
+      .sort((first, second) => first.label.localeCompare(second.label));
+  }, [voices]);
+
+  const selectedVoice = useMemo(() => {
+    return voices.find((voice) => voice.id === selectedVoiceId);
+  }, [selectedVoiceId, voices]);
 
   const resetNarrationState = useCallback(() => {
     setIsPlaying(false);
@@ -184,7 +279,16 @@ export const useSpeechSynthesis = (text: string): UseSpeechSynthesisResult => {
 
     const utterance = new SpeechSynthesisUtterance(text);
     utterance.rate = rateState;
-    utterance.lang = window.navigator.language || "en-US";
+    utterance.lang = selectedVoice?.lang || selectedLanguage || getPreferredLanguage();
+
+    const browserVoice = speechSynthesis
+      .getVoices()
+      .find((voice) => getVoiceId(voice) === selectedVoiceId);
+
+    if (browserVoice) {
+      utterance.voice = browserVoice;
+      utterance.lang = browserVoice.lang;
+    }
 
     utterance.onstart = () => {
       if (sessionRef.current !== sessionId) {
@@ -235,7 +339,18 @@ export const useSpeechSynthesis = (text: string): UseSpeechSynthesisResult => {
 
     utteranceRef.current = utterance;
     speechSynthesis.speak(utterance);
-  }, [clearUtterance, isReady, isSupported, rateState, text, totalWords, wordRanges]);
+  }, [
+    clearUtterance,
+    isReady,
+    isSupported,
+    rateState,
+    selectedLanguage,
+    selectedVoice,
+    selectedVoiceId,
+    text,
+    totalWords,
+    wordRanges,
+  ]);
 
   const pause = useCallback(() => {
     if (!isSupported || !utteranceRef.current) {
@@ -277,6 +392,26 @@ export const useSpeechSynthesis = (text: string): UseSpeechSynthesisResult => {
     }
   }, []);
 
+  const setSelectedLanguage = useCallback((nextLanguage: string) => {
+    stop();
+    setError(null);
+    setSelectedLanguageState(nextLanguage);
+
+    const nextVoice = findVoiceForLanguage(voices, nextLanguage);
+    setSelectedVoiceIdState(nextVoice?.id || "");
+  }, [stop, voices]);
+
+  const setSelectedVoiceId = useCallback((nextVoiceId: string) => {
+    stop();
+    setError(null);
+    setSelectedVoiceIdState(nextVoiceId);
+
+    const nextVoice = voices.find((voice) => voice.id === nextVoiceId);
+    if (nextVoice) {
+      setSelectedLanguageState(nextVoice.lang);
+    }
+  }, [stop, voices]);
+
   useEffect(() => {
     const supported = hasSpeechSupport();
     setIsSupported(supported);
@@ -295,8 +430,19 @@ export const useSpeechSynthesis = (text: string): UseSpeechSynthesisResult => {
         return;
       }
 
-      const voices = speechSynthesis.getVoices();
-      setIsReady(voices.length > 0);
+      const availableVoices = speechSynthesis.getVoices().map(mapVoiceOption);
+      setVoices(availableVoices);
+      setIsReady(availableVoices.length > 0);
+
+      if (availableVoices.length > 0) {
+        setSelectedLanguageState((currentLanguage) => {
+          const nextLanguage = currentLanguage || getPreferredLanguage();
+          const matchedVoice = findVoiceForLanguage(availableVoices, nextLanguage) || availableVoices.find((voice) => voice.isDefault) || availableVoices[0];
+
+          setSelectedVoiceIdState((currentVoiceId) => currentVoiceId || matchedVoice.id);
+          return matchedVoice.lang || nextLanguage;
+        });
+      }
     };
 
     syncVoices();
@@ -344,6 +490,12 @@ export const useSpeechSynthesis = (text: string): UseSpeechSynthesisResult => {
     stop,
     rate: rateState,
     setRate,
+    voices,
+    languageOptions,
+    selectedLanguage,
+    setSelectedLanguage,
+    selectedVoiceId,
+    setSelectedVoiceId,
     progress,
     isSupported,
     isReady,


### PR DESCRIPTION
@ronisarkarexe Please Add Gssoc 26 Tag in it 
## What this PR does

Adds multilingual read-aloud support for story narration.

This PR extends the shared speech synthesis hook to load available browser voices, infer supported narration languages, select a matching voice for the chosen language, and apply the selected language/voice during playback.

The story audio player now includes:
- Play, pause, resume, and stop controls
- Narration progress
- Playback speed selection
- Narration language selection
- Voice/accent selection

Published story detail pages now reuse the shared `AudioPlayer` instead of the older English-only text-to-speech handler, so generated stories and published stories use the same multilingual narration experience.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

None

## More screenshots (optional)

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.