### PR TITLE
fix: prevent login input overflow in production

### DIFF
--- a/frontend/src/components/ui-component/ss-input/ss-input.tsx
+++ b/frontend/src/components/ui-component/ss-input/ss-input.tsx
@@ -53,7 +53,7 @@ const inputType =
         <input
           type={inputType}
           id={name}
-          className={`w-full pl-10 pr-10 py-2 text-base text-gray-900 dark:text-gray-200 bg-white dark:bg-slate-800 border rounded-md sm:text-sm transition-all focus:outline-none ${
+          className={`w-full max-w-full box-border pl-10 pr-10 py-2 text-base text-gray-900 dark:text-gray-200 bg-white dark:bg-slate-800 border rounded-md sm:text-sm transition-all focus:outline-none ${
           error
           ? "border-red-500 focus:border-red-500 focus:ring-1 focus:ring-red-500 dark:border-red-500"
           : "border-gray-300 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 dark:border-slate-600 dark:focus:border-blue-500"


### PR DESCRIPTION
## Summary
Fixed login page input overflow issue seen on production deployment.

## Changes
- Added box-border utility
- Added max-w-full constraint
- Prevented input fields from exceeding parent container width

## Result
Login form now renders consistently in both local and production environments.
Before 
<img width="1452" height="753" alt="bef" src="https://github.com/user-attachments/assets/fd195a0d-62f6-4636-a92b-3fcef7fc4a5b" />
after 
<img width="1045" height="769" alt="image" src="https://github.com/user-attachments/assets/48190bf7-a25b-4429-b276-82875c29c8c0" />

