### PR TITLE
fix(security): hide error stack traces outside development

### DIFF
--- a/backend/src/app/middleware/global.error.handler.ts
+++ b/backend/src/app/middleware/global.error.handler.ts
@@ -73,7 +73,9 @@ const globalErrorHandler: ErrorRequestHandler = (
     success: false,
     message,
     errorMessage,
-    stack: config.env != "production" ? err.stack : undefined,
+    // Expose stack only in explicit development; hide by default so any
+    // non-development environment (including an unset NODE_ENV) stays safe.
+    stack: config.env === "development" ? err.stack : undefined,
   });
 };
 


### PR DESCRIPTION
## Screenshot (when helpful)

N/A. This is a backend security fix verified via `curl`. Reproduction and verification are described under What this PR does.

## What this PR does

Stops the live API from returning full Node.js stack traces to anonymous callers.

The global error handler serialized `err.stack` into every error response whenever `NODE_ENV` was not exactly `"production"`. Because the live deployment does not have `NODE_ENV=production`, this exposed absolute server paths (for example `/var/task/backend/src/app/modules/auth/auth.service.js`), the internal module layout, and pinned dependency versions (for example `mongoose@8.24.0`) to unauthenticated users. This is CWE-209 and OWASP ASVS V7.4.1.

The check was fail-open: it leaked for every environment except one exact string. This PR makes it fail-closed so the stack is only ever exposed in explicit development.

### Change

`backend/src/app/middleware/global.error.handler.ts`

```
- stack: config.env != "production" ? err.stack : undefined,
+ stack: config.env === "development" ? err.stack : undefined,
```

Now any value of `NODE_ENV` other than `development` (including unset, `production`, or `staging`) hides the stack. The leak is closed regardless of how the deployment environment is configured, so the fix does not depend on a separate env var change.

### Why this approach and not vercel.json

The linked issue suggested also forcing `NODE_ENV=production` in `backend/vercel.json`. I deliberately did not do that. The Vercel build runs `npm run build` which calls `tsc`, and `typescript` is a devDependency. Setting `NODE_ENV=production` so that it applies during install would prune devDependencies and break the build. If the maintainer also wants correct production logging behavior, `NODE_ENV=production` should be set as a runtime scoped Production environment variable in the Vercel dashboard instead. The code level fail-closed change here is the primary fix and stands on its own.

### How I verified

1. Reproduced the leak live before the change on two different error classes (an ApiError on `/auth/forgot-password` and a CastError on `/post/<bad id>`); both responses contained `stack` with internal paths and dependency versions.
2. Traced the new code path: in any non development environment `config.env === "development"` is false, so `stack` is `undefined` and is omitted from the JSON. Local development still keeps the stack when `NODE_ENV=development`.
3. Ran `tsc --noEmit` on the backend. The changed file compiles cleanly. The only pre-existing errors are in `story_version.service.ts` and are unrelated to this change.
4. Confirmed no test asserts on the `stack` field.

### Scope note

This PR is intentionally limited to the stack trace leak so it stays focused and easy to review. It does not change middleware ordering or the 404 handler (that is #633), and it does not change the `err.message` echo on unexpected 500s, which is worth a separate follow-up.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #1508

## More screenshots (optional)

N/A.

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.