### PR TITLE
fix(collab): connect client to /collab namespace

### DIFF
--- a/frontend/src/socket/socket.oi.ts
+++ b/frontend/src/socket/socket.oi.ts
@@ -25,8 +25,8 @@ export const connectSocket = (): Socket => {
     console.warn("[Story Spark] User not authenticated. Cannot connect to Socket.IO.");
     return null as unknown as Socket;
   }
-
-  socketIoInstance = io(socketUrl, {
+socketIoInstance = io(`${socketUrl}/collab`, {
+  
     transports: ["websocket", "polling"],
     autoConnect: false,
     reconnectionAttempts: 5,


### PR DESCRIPTION
## Issue

Fixes #1434

## Description

The collaboration backend registers its Socket.IO handlers under the `/collab` namespace.

The frontend client was connecting to the default namespace, which prevented collaboration events from reaching the correct handlers.

## Changes Made

* Updated the Socket.IO client connection to use the `/collab` namespace.
* Ensured collaboration events are routed to the correct backend namespace.

## Testing

* Verified the client now attempts to connect to the `/collab` namespace.
* Reviewed collaboration event flow between client and server.

## Screenshots

N/A
