### PR TITLE
fix(security): stop exposing user emails in post and bookmark responses

### DIFF
--- a/backend/src/app/modules/bookmark/bookmark.service.ts
+++ b/backend/src/app/modules/bookmark/bookmark.service.ts
@@ -77,12 +77,12 @@ const getBookmarks = async (
       path: "storyId",
       match: { isDeleted: { $ne: true } },
       populate: [
-        { path: "author", select: "name email createdAt profile.bio" },
+        { path: "author", select: "name createdAt profile.bio" },
         {
           path: "reactions",
-          populate: { path: "userId", select: "email" },
+          populate: { path: "userId", select: "_id" },
         },
-        { path: "bookmarks", select: "email" },
+        { path: "bookmarks", select: "_id" },
       ],
     });
 

--- a/backend/src/app/modules/post/post.service.ts
+++ b/backend/src/app/modules/post/post.service.ts
@@ -130,12 +130,12 @@ const getPosts = async (
     .sort(sortCondition)
     .skip(skip)
     .limit(limit)
-    .populate("author", "name email createdAt profile.bio")
+    .populate("author", "name createdAt profile.bio")
     .populate({
       path: "reactions",
-      populate: { path: "userId", select: "email" },
+      populate: { path: "userId", select: "_id" },
     })
-    .populate("bookmarks", "email");
+    .populate("bookmarks", "_id");
   const total = await Post.countDocuments(whereCondition);
   return {
     meta: {
@@ -189,12 +189,12 @@ const getPublishedPostsByAuthor = async (
     .sort(sortCondition)
     .skip(skip)
     .limit(limit)
-    .populate("author", "name email createdAt")
+    .populate("author", "name createdAt")
     .populate({
       path: "reactions",
-      populate: { path: "userId", select: "email" },
+      populate: { path: "userId", select: "_id" },
     })
-    .populate("bookmarks", "email");
+    .populate("bookmarks", "_id");
   const total = await Post.countDocuments(whereCondition);
 
   return {
@@ -212,12 +212,12 @@ const getLatestPosts = async () => {
     const res = await Post.find({ isDeleted: { $ne: true } })
       .sort({ createdAt: -1 })
       .limit(50)
-      .populate("author", "name email createdAt profile.bio")
+      .populate("author", "name createdAt profile.bio")
       .populate({
         path: "reactions",
-        populate: { path: "userId", select: "email" },
+        populate: { path: "userId", select: "_id" },
       })
-      .populate("bookmarks", "email");
+      .populate("bookmarks", "_id");
     return res;
   } catch (error) {
     throw new ApiError(
@@ -235,12 +235,12 @@ const getFeaturedPosts = async () => {
     })
       .sort({ createdAt: -1, updatedBy: -1 })
       .limit(10)
-      .populate("author", "name email createdAt profile.bio")
+      .populate("author", "name createdAt profile.bio")
       .populate({
         path: "reactions",
-        populate: { path: "userId", select: "email" },
+        populate: { path: "userId", select: "_id" },
       })
-      .populate("bookmarks", "email");
+      .populate("bookmarks", "_id");
     return res;
   } catch (error) {
     throw new ApiError(
@@ -268,12 +268,12 @@ const doFeaturedPosts = async (postId: string) => {
 
 const getSinglePost = async (id: string) => {
   const postById = await Post.findOne({ _id: id, isDeleted: { $ne: true } })
-    .populate("author", "name email createdAt profile.bio")
+    .populate("author", "name createdAt profile.bio")
     .populate({
       path: "reactions",
-      populate: { path: "userId", select: "email" },
+      populate: { path: "userId", select: "_id" },
     })
-    .populate("bookmarks", "email");
+    .populate("bookmarks", "_id");
   if (!postById) {
     throw new ApiError(httpStatus.NOT_FOUND, "Post not found!");
   }
@@ -287,12 +287,12 @@ const getPostsByTag = async (tag: string, excludeId?: string) => {
   }
   const result = await Post.find(query)
     .limit(2)
-    .populate("author", "name email createdAt profile.bio")
+    .populate("author", "name createdAt profile.bio")
     .populate({
       path: "reactions",
-      populate: { path: "userId", select: "email" },
+      populate: { path: "userId", select: "_id" },
     })
-    .populate("bookmarks", "email");
+    .populate("bookmarks", "_id");
   return result;
 };
 

--- a/frontend/src/components/BookmarkButton.tsx
+++ b/frontend/src/components/BookmarkButton.tsx
@@ -22,8 +22,8 @@ const BookmarkButton: React.FC<BookmarkButtonProps> = ({
   const [isLoading, setIsLoading] = useState(false);
 
   // Determine if currently bookmarked by logged in user
-  const isCurrentlyBookmarked = bookmarks.some(
-    (b) => b.email === currentUser?.email
+  const isCurrentlyBookmarked = Boolean(currentUser?.userId) && bookmarks.some(
+    (b) => b._id === currentUser?.userId
   );
 
   const handleBookmark = async (e: React.MouseEvent) => {

--- a/frontend/src/components/dashboard/posts/post_lists.component.tsx
+++ b/frontend/src/components/dashboard/posts/post_lists.component.tsx
@@ -240,9 +240,6 @@ const PostListsComponent: React.FC = () => {
                     <div className="text-sm text-gray-200">
                       {post.author?.name || 'Unknown User'}
                     </div>
-                    <div className="text-xs text-gray-500">
-                      {post.author?.email || 'N/A'}
-                    </div>
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
                     <div className="flex flex-wrap gap-1.5 max-w-[200px]">

--- a/frontend/src/components/post/post.details.component.tsx
+++ b/frontend/src/components/post/post.details.component.tsx
@@ -63,7 +63,7 @@ const PostDetailsComponent = () => {
 
   const authorId = post?.author?._id;
   const isOwner = Boolean(
-    currentUser?.email && post?.author?.email === currentUser.email
+    currentUser?.userId && authorId === currentUser.userId
   );
 
   const { data: followData } = useGetFollowStatusQuery(authorId || "", {
@@ -156,14 +156,12 @@ const PostDetailsComponent = () => {
   const hasUserReacted = post?.reactions?.some((r) => {
     const userId = r.userId;
 
-    const email =
-      typeof userId === "object" &&
-      userId !== null &&
-      "email" in userId
-        ? userId.email
-        : undefined;
+    const reactorId =
+      typeof userId === "object" && userId !== null && "_id" in userId
+        ? userId._id
+        : userId;
 
-    return email === currentUser?.email;
+    return Boolean(currentUser?.userId) && reactorId === currentUser?.userId;
   });
 
   const handleTwitterShare = () => {

--- a/frontend/src/models/post.ts
+++ b/frontend/src/models/post.ts
@@ -7,7 +7,7 @@ export interface Topic {
 
 interface Author {
   _id: string;
-  email: string;
+  email?: string;
   name: string;
   createdAt: string;
   profile?: {
@@ -25,14 +25,13 @@ interface Comment {
 
 interface Reaction {
   postId: string;
-  userId: { email: string } | string;
+  userId: { _id: string } | string;
   type: "like" | "love" | "laugh" | "angry" | "sad";
   _id: string;
 }
 
 interface Bookmark {
-  _id?: string;
-  email: string;
+  _id: string;
 }
 
 export interface Post {

--- a/frontend/src/services/auth.service.ts
+++ b/frontend/src/services/auth.service.ts
@@ -27,7 +27,7 @@ type AuthUserInfo = {
 
 const buildUserInfo = (decodedData: any): AuthUserInfo => ({
   email: decodedData.email || "",
-  userId: decodedData.userId || "",
+  userId: decodedData.userId || decodedData._id || "",
   name: decodedData.name || "",
   postsCount: decodedData.postsCount || 0,
   role: decodedData.role || "guest",


### PR DESCRIPTION
## Screenshot (when helpful)

N/A. Security and data shape fix. Verified via curl and type checks, described under What this PR does.

## What this PR does

Stops the post and bookmark endpoints from leaking personal email addresses, and migrates the frontend identity checks that relied on those emails over to the user `_id`.

### The leak

Read queries populated user relations with `email`:

```
.populate("author", "name email createdAt profile.bio")
.populate({ path: "reactions", populate: { path: "userId", select: "email" } })
.populate("bookmarks", "email");
```

The public post routes (`GET /post/lists`, `/latest-lists`, `/feature-lists`, `/:id`, `/tag/:tag`) have no auth, so author, reactor, and bookmarker emails were exposed to anyone, with pagination walking the whole user base. The authenticated `GET /bookmarks` endpoint leaked the same emails (including every co-bookmarker) to the caller. This is CWE-359 and OWASP API3:2023.

### Backend change

In all six post query blocks (`getPosts`, `getPublishedPostsByAuthor`, `getLatestPosts`, `getFeaturedPosts`, `getSinglePost`, `getPostsByTag`) and in `bookmark.service.ts` `getBookmarks`, the populated selects now return `_id` instead of `email`:

```
.populate("author", "name createdAt profile.bio")
.populate({ path: "reactions", populate: { path: "userId", select: "_id" } })
.populate("bookmarks", "_id");
```

`author._id` is still present (needed for follow and ownership), just without the email.

### Why the frontend also changes

The UI used these emails as identity for three checks: post ownership controls, like state, and bookmark state. They used email only because the intended `_id` identity was broken: `buildUserInfo` in `frontend/src/services/auth.service.ts` read `decodedData.userId`, but the JWT only carries `_id`, so `currentUser.userId` was always an empty string. The existing `_id` based check `isAuthor` in `post.details.component.tsx` was therefore silently dead.

Frontend changes:
- `auth.service.ts`: map `userId` from the token `_id` (`decodedData.userId || decodedData._id || ""`). Backward compatible and repairs the dead identity checks.
- `post.details.component.tsx`: `isOwner` and `hasUserReacted` now compare `_id` instead of email.
- `BookmarkButton.tsx`: bookmarked state now compares `b._id` against the current user id.
- `models/post.ts`: `author.email` optional, `reaction.userId` is `{ _id } | string`, `bookmark` is `{ _id }`.
- `dashboard/posts/post_lists.component.tsx`: removed the now redundant author email line (author name is shown directly above it).

Backend and frontend are in one PR on purpose so they deploy together and ownership/like/bookmark state never breaks in between.

### How I verified

1. Reproduced the leak live before the change: `GET /post/lists?limit=10` returned real author emails.
2. Mapped every frontend consumer of these emails before editing, to avoid breaking ownership, like, and bookmark state.
3. Ran `tsc` on backend and frontend. The files I changed compile cleanly. The only remaining errors are pre-existing and unrelated: `story_version.service.ts` on the backend and several `help_center` plus `latest_posts` JSX malformations on the frontend, none touched by this PR.
4. Confirmed the comment like subsystem is fed by the comment endpoints, not these services, so it is intentionally out of scope.

### Note for the maintainer

Admins who need author emails still have the admin user endpoints. This change only removes email from the post and bookmark surfaces.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #1512
Closes #1539

## More screenshots (optional)

N/A.

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.