### PR TITLE
fix: update dashboard sidebar active state

### DIFF
--- a/frontend/src/components/dashboard/dashboard_layout.component.tsx
+++ b/frontend/src/components/dashboard/dashboard_layout.component.tsx
@@ -259,9 +259,11 @@ const { data } = useGetProfileInfoQuery();
         >
           <nav className="p-4 space-y-2 overflow-y-auto h-full">
             {accessibleMenuItems.map((item) => {
-              const isActive =
-                location.pathname === item.path ||
-                location.pathname.startsWith(item.path + "/");
+             const isActive =
+  item.path === "/dashboard"
+    ? location.pathname === "/dashboard"
+    : location.pathname === item.path ||
+      location.pathname.startsWith(item.path + "/");
 
               return (
                 <div key={item.name}>


### PR DESCRIPTION
## Screenshot (when helpful)

N/A — This change updates route matching logic in the dashboard sidebar. No visual assets were required.

## What this PR does

This PR fixes the issue where the Dashboard sidebar item remained highlighted even after navigating to other dashboard routes such as Settings, Profile, or Users.

### Changes Made

* Added exact route matching for the `/dashboard` route.
* Preserved nested route matching behavior for other sidebar items.

### Result

* Dashboard is highlighted only when the current route is `/dashboard`.
* Settings, Profile, Users, and other dashboard routes correctly display their active state.
* Sidebar navigation now reflects the current route accurately.

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

## Related issue

Fixes #1507

## More screenshots (optional)

N/A

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.
