### PR TITLE
fix(security): back rate limiters with MongoDB so limits hold on serverless

### DIFF
--- a/backend/src/app/middleware/free-ai.rate-limiter.ts
+++ b/backend/src/app/middleware/free-ai.rate-limiter.ts
@@ -1,87 +1,18 @@
-import { Request, Response, NextFunction } from "express";
-import ApiError from "../../errors/api_error";
-import httpStatus from "http-status";
+import { createRateLimiter } from "./ip.rate-limiter";
 
-interface RateRecord {
-  count: number;
-  firstRequestAt: number;
-  blockedUntil?: number;
-}
-
-const store = new Map<string, RateRecord>();
-
-// Configurable limits
-const WINDOW_MS = 24 * 60 * 60 * 1000; // 24 hours window
-const MAX_REQUESTS = 5; // max free generations per WINDOW_MS
-const BLOCK_TIME_MS = 24 * 60 * 60 * 1000; // block 24 hours when exceeded
-
-// Cleanup old keys periodically to prevent memory leak
-const cleanupInterval = setInterval(() => {
-  const now = Date.now();
-  for (const [key, rec] of store.entries()) {
-    const age = now - rec.firstRequestAt;
-    if ((rec.blockedUntil && rec.blockedUntil < now) || age > WINDOW_MS + BLOCK_TIME_MS) {
-      store.delete(key);
-    }
-  }
-}, 60 * 60 * 1000); // every hour
-cleanupInterval.unref(); // Allow Node process to exit cleanly
-
-export const freeAiRateLimiter = (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const ip = req.ip;
-    
-    if (!ip) {
-      throw new ApiError(httpStatus.FORBIDDEN, "Could not determine client IP address.");
-    }
-    
-    const now = Date.now();
-    const key = `free_ai_${ip}`;
-
-    let rec = store.get(key);
-    if (!rec) {
-      rec = { count: 1, firstRequestAt: now };
-      store.set(key, rec);
-      return next();
-    }
-
-    // If currently blocked
-    if (rec.blockedUntil && rec.blockedUntil > now) {
-      const retryAfter = Math.ceil((rec.blockedUntil - now) / 1000);
-      res.setHeader("Retry-After", String(retryAfter));
-      throw new ApiError(
-        httpStatus.TOO_MANY_REQUESTS,
-        `Daily limit for free generations reached. Try again after ${Math.ceil(retryAfter / 3600)} hours or sign in to use your monthly quota.`
-      );
-    }
-
-    // Reset window if elapsed
-    if (now - rec.firstRequestAt > WINDOW_MS) {
-      rec.count = 1;
-      rec.firstRequestAt = now;
-      rec.blockedUntil = undefined;
-      store.set(key, rec);
-      return next();
-    }
-
-    rec.count += 1;
-
-    if (rec.count > MAX_REQUESTS) {
-      rec.blockedUntil = now + BLOCK_TIME_MS;
-      store.set(key, rec);
-      const retryAfter = Math.ceil(BLOCK_TIME_MS / 1000);
-      res.setHeader("Retry-After", String(retryAfter));
-      throw new ApiError(
-        httpStatus.TOO_MANY_REQUESTS,
-        "Daily limit for free generations reached. Please sign in to continue generating stories."
-      );
-    }
-
-    store.set(key, rec);
-    return next();
-  } catch (error) {
-    next(error);
-  }
-};
+// Free guest AI generations: 5 per 24 hours, 24-hour block once exceeded.
+// Backed by the shared MongoDB store so the limit holds across serverless
+// instances and cold starts.
+export const freeAiRateLimiter = createRateLimiter({
+  windowMs: 24 * 60 * 60 * 1000,
+  maxRequests: 5,
+  blockTimeMs: 24 * 60 * 60 * 1000,
+  keyPrefix: "free_ai",
+  actionLabel: "free generation",
+  buildMessage: (retryAfterSec) =>
+    `Daily limit for free generations reached. Try again after ${Math.ceil(
+      retryAfterSec / 3600
+    )} hours or sign in to use your monthly quota.`,
+});
 
 export default freeAiRateLimiter;

--- a/backend/src/app/middleware/ip.rate-limiter.ts
+++ b/backend/src/app/middleware/ip.rate-limiter.ts
@@ -1,12 +1,7 @@
 import { Request, Response, NextFunction } from "express";
 import ApiError from "../../errors/api_error";
 import httpStatus from "http-status";
-
-interface RateRecord {
-  count: number;
-  firstRequestAt: number;
-  blockedUntil?: number;
-}
+import { consumeRateLimit } from "./rate_limit.store";
 
 interface RateLimiterOptions {
   /** Time window in milliseconds */
@@ -19,82 +14,40 @@ interface RateLimiterOptions {
   keyPrefix: string;
   /** Human-readable label used in error messages (e.g. "login", "password reset") */
   actionLabel?: string;
+  /** Optional custom message builder for the 429 response */
+  buildMessage?: (retryAfterSec: number) => string;
 }
 
-const store = new Map<string, RateRecord>();
-
-// Cleanup old keys periodically to prevent memory leak
-const cleanupInterval = setInterval(() => {
-  const now = Date.now();
-  for (const [key, rec] of store.entries()) {
-    // Use a generous max age for cleanup — 25 hours covers the largest block time
-    const MAX_AGE = 25 * 60 * 60 * 1000;
-    if ((rec.blockedUntil && rec.blockedUntil < now) || now - rec.firstRequestAt > MAX_AGE) {
-      store.delete(key);
-    }
-  }
-}, 60 * 60 * 1000); // every hour
-cleanupInterval.unref(); // Allow Node process to exit cleanly
-
 /**
- * Factory function to create a rate-limiting middleware with custom thresholds.
- * Each call returns an independent middleware that shares the global in-memory store
- * but uses a unique key prefix so limits are tracked separately per endpoint.
+ * Factory that builds a rate-limiting middleware backed by the shared MongoDB
+ * store, so limits hold across all serverless instances and cold starts.
+ * Each prefix tracks its endpoint independently.
  */
 export const createRateLimiter = (options: RateLimiterOptions) => {
-  const { windowMs, maxRequests, blockTimeMs, keyPrefix, actionLabel = "request" } = options;
+  const { windowMs, maxRequests, blockTimeMs, keyPrefix, actionLabel = "request", buildMessage } = options;
 
-  return (req: Request, res: Response, next: NextFunction) => {
+  return async (req: Request, res: Response, next: NextFunction) => {
     try {
       const ip = req.ip;
-
       if (!ip) {
         throw new ApiError(httpStatus.FORBIDDEN, "Could not determine client IP address.");
       }
 
-      const now = Date.now();
-      const key = `${keyPrefix}_${ip}`;
+      const { allowed, retryAfterSec } = await consumeRateLimit({
+        key: `${keyPrefix}_${ip}`,
+        windowMs,
+        maxRequests,
+        blockTimeMs,
+      });
 
-      let rec = store.get(key);
-      if (!rec) {
-        rec = { count: 1, firstRequestAt: now };
-        store.set(key, rec);
-        return next();
+      if (!allowed) {
+        res.setHeader("Retry-After", String(retryAfterSec));
+        const message = buildMessage
+          ? buildMessage(retryAfterSec)
+          : `Too many ${actionLabel} attempts. Please try again after ${Math.ceil(retryAfterSec / 60)} minutes.`;
+        throw new ApiError(httpStatus.TOO_MANY_REQUESTS, message);
       }
 
-      // If currently blocked
-      if (rec.blockedUntil && rec.blockedUntil > now) {
-        const retryAfter = Math.ceil((rec.blockedUntil - now) / 1000);
-        res.setHeader("Retry-After", String(retryAfter));
-        throw new ApiError(
-          httpStatus.TOO_MANY_REQUESTS,
-          `Too many ${actionLabel} attempts from this IP. Try again after ${Math.ceil(retryAfter / 60)} minutes.`
-        );
-      }
-
-      // Reset window if elapsed
-      if (now - rec.firstRequestAt > windowMs) {
-        rec.count = 1;
-        rec.firstRequestAt = now;
-        rec.blockedUntil = undefined;
-        store.set(key, rec);
-        return next();
-      }
-
-      rec.count += 1;
-
-      if (rec.count > maxRequests) {
-        rec.blockedUntil = now + blockTimeMs;
-        store.set(key, rec);
-        const retryAfter = Math.ceil(blockTimeMs / 1000);
-        res.setHeader("Retry-After", String(retryAfter));
-        throw new ApiError(
-          httpStatus.TOO_MANY_REQUESTS,
-          `Too many ${actionLabel} attempts. This IP has been temporarily blocked.`
-        );
-      }
-
-      store.set(key, rec);
       return next();
     } catch (error) {
       next(error);
@@ -141,4 +94,3 @@ export const resetPasswordRateLimiter = createRateLimiter({
 });
 
 export default ipRateLimiter;
-

--- a/backend/src/app/middleware/rate_limit.store.ts
+++ b/backend/src/app/middleware/rate_limit.store.ts
@@ -1,0 +1,127 @@
+import { Schema, model } from "mongoose";
+import logger from "../../utils/logger.util";
+
+// Shared, serverless safe rate limit store backed by MongoDB. The previous
+// in-memory Map could not work across Vercel function instances or cold starts,
+// so every instance enforced its own counter and the limit was bypassable.
+
+interface IRateLimitRecord {
+  key: string;
+  count: number;
+  firstRequestAt: Date | null;
+  blockedUntil: Date | null;
+  expireAt: Date;
+}
+
+const rateLimitSchema = new Schema<IRateLimitRecord>({
+  key: { type: String, required: true, unique: true },
+  count: { type: Number, default: 0 },
+  firstRequestAt: { type: Date, default: null },
+  blockedUntil: { type: Date, default: null },
+  expireAt: { type: Date, required: true },
+});
+
+// TTL index: Mongo removes the document once expireAt passes, so stale keys are
+// cleaned up automatically without an in-process interval.
+rateLimitSchema.index({ expireAt: 1 }, { expireAfterSeconds: 0 });
+
+const RateLimitRecord = model<IRateLimitRecord>(
+  "RateLimitRecord",
+  rateLimitSchema
+);
+
+export interface ConsumeOptions {
+  key: string;
+  windowMs: number;
+  maxRequests: number;
+  blockTimeMs: number;
+}
+
+export interface ConsumeResult {
+  allowed: boolean;
+  retryAfterSec: number;
+}
+
+// Atomically records one hit for a key and decides whether it is allowed.
+// The whole window-and-block state transition runs in a single pipeline update
+// so concurrent requests cannot race. Fails open on store errors.
+export const consumeRateLimit = async (
+  opts: ConsumeOptions
+): Promise<ConsumeResult> => {
+  const { key, windowMs, maxRequests, blockTimeMs } = opts;
+  const now = new Date();
+  const ttlMs = Math.max(windowMs, blockTimeMs) + 60_000;
+
+  try {
+    const prevCount = { $ifNull: ["$count", 0] };
+    const prevFirst = { $ifNull: ["$firstRequestAt", now] };
+    const prevBlocked = { $ifNull: ["$blockedUntil", null] };
+    const currentlyBlocked = {
+      $and: [{ $ne: [prevBlocked, null] }, { $gt: [prevBlocked, now] }],
+    };
+    const windowElapsed = { $gt: [{ $subtract: [now, prevFirst] }, windowMs] };
+
+    const updated = await RateLimitRecord.findOneAndUpdate(
+      { key },
+      [
+        {
+          $set: {
+            _blocked: currentlyBlocked,
+            _prevBlocked: prevBlocked,
+            _count: {
+              $cond: [
+                currentlyBlocked,
+                prevCount,
+                { $cond: [windowElapsed, 1, { $add: [prevCount, 1] }] },
+              ],
+            },
+            _first: {
+              $cond: [
+                currentlyBlocked,
+                prevFirst,
+                { $cond: [windowElapsed, now, prevFirst] },
+              ],
+            },
+          },
+        },
+        {
+          $set: {
+            count: "$_count",
+            firstRequestAt: "$_first",
+            blockedUntil: {
+              $cond: [
+                "$_blocked",
+                "$_prevBlocked",
+                {
+                  $cond: [
+                    { $gt: ["$_count", maxRequests] },
+                    new Date(now.getTime() + blockTimeMs),
+                    null,
+                  ],
+                },
+              ],
+            },
+            expireAt: new Date(now.getTime() + ttlMs),
+          },
+        },
+        { $unset: ["_blocked", "_prevBlocked", "_count", "_first"] },
+      ],
+      { new: true, upsert: true, setDefaultsOnInsert: true }
+    );
+
+    const blockedUntil = updated?.blockedUntil ?? null;
+    if (blockedUntil && blockedUntil.getTime() > now.getTime()) {
+      return {
+        allowed: false,
+        retryAfterSec: Math.ceil(
+          (blockedUntil.getTime() - now.getTime()) / 1000
+        ),
+      };
+    }
+    return { allowed: true, retryAfterSec: 0 };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error(`Rate limit store error for ${key}: ${message}`);
+    return { allowed: true, retryAfterSec: 0 };
+  }
+};


### PR DESCRIPTION
## Screenshot (when helpful)

N/A. Backend middleware change. Verified live (the bug) and via type checks and a code trace, described below.

## What this PR does

Makes the authentication and free-AI rate limiters actually enforce their limits on the Vercel serverless deployment.

### The bug

`ip.rate-limiter.ts` (login, registration, forgot-password, reset-password) and `free-ai.rate-limiter.ts` stored their counters in a per-process in-memory `Map`. On Vercel each function instance has its own memory and cold starts begin empty, so the counters are never shared and the limits are bypassable. I confirmed this live: eight forgot-password requests (limit 3 per hour) all returned `404` and none returned `429`.

### The fix

- New `backend/src/app/middleware/rate_limit.store.ts`: a shared MongoDB-backed store (`rate_limit_records`) with a TTL index on `expireAt`, plus `consumeRateLimit(...)`. The window-and-block state transition runs as a single atomic aggregation-pipeline `findOneAndUpdate` (the same atomic pattern already used in `quota.service.ts`), so concurrent requests cannot race. It fails open and logs if the store is briefly unavailable, so a database blip cannot lock everyone out of auth.
- `ip.rate-limiter.ts`: `createRateLimiter` now awaits the shared store instead of a `Map`. All four pre-configured limiters keep their exact thresholds and block windows (registration 5/hour with 24h block, login 10/15min, forgot 3/hour, reset 5/hour). Added an optional `buildMessage` so callers can keep their own 429 wording.
- `free-ai.rate-limiter.ts`: now defined via the same factory (5 per 24h, 24h block), preserving its original message. The duplicated in-memory logic and the in-process cleanup interval are gone (the TTL index handles expiry).

No route or call site changes: the exported limiters are still Express middleware (now async, which Express handles natively). Thresholds are unchanged.

### Why MongoDB and not Redis

Mongo is already required and connected. There is no `REDIS_URL` provisioned and `redis.client.ts` defaults to `127.0.0.1:6379`, which does not exist on Vercel, so a Redis-backed limiter would fail there. Mongo needs no new infrastructure or env var. (Confirmed with the maintainer direction to use Mongo and fail open.)

### How I verified

1. Reproduced the bypass live before the change (eight requests, zero 429).
2. Traced the new atomic pipeline for the new-key, within-window, window-elapsed, just-exceeded, and already-blocked cases; the post-update `blockedUntil > now` check yields the correct allow/deny in each, matching the previous behavior.
3. Ran `tsc` on the backend. The three changed files compile cleanly. The only remaining errors are the pre-existing ones in `story_version.service.ts`, unrelated to this PR.
4. Confirmed no test references these limiters (the existing rate-limit test targets the separate `middlewares/rateLimitMiddleware.ts`).

### Out of scope (follow-ups)

- The global `express-rate-limit` in `app.ts` uses the library default in-memory store and has the same serverless limitation.
- `app.ts` references an unimported `storyRoutes`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #1519

## More screenshots (optional)

N/A.

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.