### PR TITLE
fix(security): generate OTP with crypto.randomInt instead of Math.random

### DIFF
--- a/backend/src/app/modules/verify_email/verify_email.service.ts
+++ b/backend/src/app/modules/verify_email/verify_email.service.ts
@@ -18,7 +18,8 @@ const transporter = nodemailer.createTransport({
 const VerifyEmail = async (payload: IEmailBody) => {
   try {
     const { email, name } = payload;
-    const otp = Math.floor(100000 + Math.random() * 900000).toString();
+    // Use a cryptographically secure RNG so OTPs cannot be predicted.
+    const otp = crypto.randomInt(100000, 1000000).toString();
     const expiresAt = new Date(Date.now() + 10 * 60 * 1000); // 10 minutes from now
     
     // Delete any existing OTP for this email


### PR DESCRIPTION
## Screenshot (when helpful)

N/A. One-line backend cryptographic fix. Verified via type check and range equivalence, described below.

## What this PR does

Replaces the OTP generator with a cryptographically secure RNG.

Before, the email verification and password reset OTP was derived from `Math.random()`:

```
const otp = Math.floor(100000 + Math.random() * 900000).toString();
```

`Math.random()` is not cryptographically secure (V8 xorshift128+, seeded once per process), so its output is predictable from a few observed samples, and entropy is low on serverless cold starts. This OTP gates both signup verification and password reset, so predictability weakens account takeover protection. This is CWE-338.

After:

```
const otp = crypto.randomInt(100000, 1000000).toString();
```

`crypto` was already imported in this file (it is used for the verification tokens). `crypto.randomInt(100000, 1000000)` returns an integer in `[100000, 1000000)`, i.e. 100000 to 999999, the exact same 6-digit range as before, so the OTP format and everything downstream is unchanged.

## How I verified

1. Confirmed this is the only OTP generation site; the other `Math.random()` uses are the guest user id (tracked separately in #1275) and the collab room id, which this PR does not touch.
2. Confirmed `crypto.randomInt(100000, 1000000)` yields a 6-digit string in the same range as the old expression.
3. Ran `tsc` on the backend. The changed file compiles cleanly. The only remaining errors are the pre-existing ones in `story_version.service.ts`, unrelated to this PR.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #1521

## More screenshots (optional)

N/A.

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.