### PR TITLE
fix(security): pin JWT algorithm to HS256 on sign and verify

### DIFF
--- a/backend/src/utils/jwt.helper.ts
+++ b/backend/src/utils/jwt.helper.ts
@@ -5,7 +5,7 @@ const createToken = (
   secret: Secret,
   expireTime: string
 ): string => {
-  const options = { expiresIn: expireTime } as SignOptions;
+  const options = { algorithm: "HS256", expiresIn: expireTime } as SignOptions;
   return jwt.sign(payload, secret, options);
 };
 
@@ -22,7 +22,8 @@ const createResetToken = (
 };
 
 const verifyToken = (token: string, secret: Secret): JwtPayload => {
-  return jwt.verify(token, secret) as JwtPayload;
+  // Pin the algorithm so a forged token cannot downgrade or switch the alg header.
+  return jwt.verify(token, secret, { algorithms: ["HS256"] }) as JwtPayload;
 };
 
 export const JwtHalers = {


### PR DESCRIPTION
## Screenshot (when helpful)

N/A. Backend cryptographic hardening. Verified via type check and a call-site trace, described below.

## What this PR does

Pins the JWT algorithm so the verifier no longer trusts the token's `alg` header.

`backend/src/utils/jwt.helper.ts` `verifyToken` called `jwt.verify(token, secret)` with no `algorithms` allowlist, so it accepted whatever algorithm a presented token claimed. Tokens are signed with HS256. This is CWE-347 and standard hardening that was missing.

Changes:
- `verifyToken` now passes `{ algorithms: ["HS256"] }`.
- `createToken` now sets `algorithm: "HS256"` explicitly (it already defaulted to HS256; this makes sign and verify explicitly aligned and matches the existing `createResetToken`).

### Why this one file covers everything

Every token check in the app delegates to `JwtHalers.verifyToken`: `auth.middleware.ts`, `check.request.limit.ts`, `token.ts`, the refresh path in `auth.service.ts`, the Socket.IO handshake in `server.ts`, and the collab namespace in `collab.socket.ts`. Pinning the algorithm in the shared helper hardens all of them at once, so no call site needs to change.

## How I verified

1. Confirmed all six verify call sites route through `JwtHalers.verifyToken`, so the central change applies everywhere.
2. Confirmed tokens are signed with HS256 (default in `createToken`, explicit in `createResetToken`), so `["HS256"]` matches and existing tokens keep verifying.
3. Ran `tsc` on the backend. The changed file compiles cleanly. The only remaining errors are the pre-existing ones in `story_version.service.ts`, unrelated to this PR.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #1523

## More screenshots (optional)

N/A.

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.