### PR TITLE
fix(security): remove unauthenticated newsletter unsubscribe, use emailed token link

### DIFF
--- a/backend/src/app/modules/newsletter/newsletter.controller.ts
+++ b/backend/src/app/modules/newsletter/newsletter.controller.ts
@@ -13,11 +13,15 @@ export const subscribe = async (req: Request, res: Response) => {
     // Extract logged-in user id from JWT token if available
     const userId = (req as any).user?.id;
 
+    // Origin of the API request, used to build the unsubscribe link in the email.
+    const baseUrl = `${req.protocol}://${req.get("host")}`;
+
     const result = await newsletterService.subscribeNewsletter(
       email,
       name,
       source,
-      userId
+      userId,
+      baseUrl
     );
 
     res.status(200).json(result);
@@ -47,35 +51,7 @@ export const verify = async (req: Request, res: Response) => {
   }
 };
 
-// Unsubscribe user from newsletter
-export const unsubscribe = async (req: Request, res: Response) => {
-  try {
-    const { email } = req.body;
-
-    const result = await newsletterService.unsubscribeNewsletter(email);
-
-    res.status(200).json(result);
-  } catch (err: any) {
-    res.status(400).json({
-      message: err.message,
-    });
-  }
-};
-// Generate unsubscribe token (to be sent via email link)
-export const generateUnsubscribeToken = async (req: Request, res: Response) => {
-  try {
-    const { email } = req.body;
-    if (!email) {
-      return res.status(400).json({ message: "Email is required." });
-    }
-    const result = await newsletterService.generateUnsubscribeToken(email);
-    res.status(200).json(result);
-  } catch (err: any) {
-    res.status(400).json({ message: err.message });
-  }
-};
-
-// Unsubscribe via signed token — safe, no unauthenticated email enumeration
+// Unsubscribe via token from the email link. Safe, no email enumeration.
 export const unsubscribeByToken = async (req: Request, res: Response) => {
   try {
     const token = req.params.token as string;

--- a/backend/src/app/modules/newsletter/newsletter.model.ts
+++ b/backend/src/app/modules/newsletter/newsletter.model.ts
@@ -11,6 +11,7 @@ export interface INewsletterSubscriber {
   isVerified: boolean;
   verificationToken?: string;
   verificationTokenExpires?: Date;
+  unsubscribeToken?: string;
   subscribedAt?: Date;
   unsubscribedAt?: Date;
   createdAt?: Date;
@@ -50,6 +51,10 @@ const NewsletterSubscriberSchema = new Schema<INewsletterSubscriber>(
     },
     verificationTokenExpires: {
       type: Date,
+    },
+    unsubscribeToken: {
+      type: String,
+      index: true,
     },
     subscribedAt: {
       type: Date,

--- a/backend/src/app/modules/newsletter/newsletter.route.ts
+++ b/backend/src/app/modules/newsletter/newsletter.route.ts
@@ -1,9 +1,7 @@
 import { Router } from "express";
-import { subscribe, verify, unsubscribe, generateUnsubscribeToken, unsubscribeByToken } from "./newsletter.controller";
+import { subscribe, verify, unsubscribeByToken } from "./newsletter.controller";
 const router = Router();
 router.post("/subscribe", subscribe);
 router.get("/verify/:token", verify);
-router.post("/unsubscribe", unsubscribe);
-router.post("/unsubscribe-token", generateUnsubscribeToken);
 router.get("/unsubscribe/:token", unsubscribeByToken);
 export const NewsletterRouter = router;

--- a/backend/src/app/modules/newsletter/newsletter.service.ts
+++ b/backend/src/app/modules/newsletter/newsletter.service.ts
@@ -2,11 +2,17 @@ import crypto from "crypto";
 import { NewsletterSubscriber } from "./newsletter.model";
 import { sendVerificationEmail } from "../../../utils/email.util";
 
+// Builds the absolute link that the recipient clicks to unsubscribe. The token
+// is delivered only in the email, so it cannot be guessed or enumerated.
+const buildUnsubscribeUrl = (baseUrl: string | undefined, token: string) =>
+  baseUrl ? `${baseUrl}/api/v1/newsletter/unsubscribe/${token}` : undefined;
+
 export const subscribeNewsletter = async (
   email: string,
   name?: string,
   source?: string,
-  userId?: string
+  userId?: string,
+  baseUrl?: string
 ) => {
   const normalizedEmail = email.trim().toLowerCase();
   const existing = await NewsletterSubscriber.findOne({ email: normalizedEmail });
@@ -20,10 +26,16 @@ export const subscribeNewsletter = async (
       existing.unsubscribedAt = undefined;
       existing.verificationToken = crypto.randomBytes(32).toString("hex");
       existing.verificationTokenExpires = new Date(Date.now() + 24 * 60 * 60 * 1000);
+      if (!existing.unsubscribeToken) {
+        existing.unsubscribeToken = crypto.randomBytes(32).toString("hex");
+      }
       await existing.save();
 
-      // Send verification email
-      await sendVerificationEmail(normalizedEmail, existing.verificationToken);
+      await sendVerificationEmail(
+        normalizedEmail,
+        existing.verificationToken,
+        buildUnsubscribeUrl(baseUrl, existing.unsubscribeToken)
+      );
 
       return { message: "Re-subscribed. Please verify your email.", subscriber: existing };
     }
@@ -31,6 +43,7 @@ export const subscribeNewsletter = async (
 
   // New subscriber
   const token = crypto.randomBytes(32).toString("hex");
+  const unsubscribeToken = crypto.randomBytes(32).toString("hex");
   const subscriber = await NewsletterSubscriber.create({
     email: normalizedEmail,
     name,
@@ -40,10 +53,14 @@ export const subscribeNewsletter = async (
     isVerified: false,
     verificationToken: token,
     verificationTokenExpires: new Date(Date.now() + 24 * 60 * 60 * 1000),
+    unsubscribeToken,
   });
 
-  // Send verification email
-  await sendVerificationEmail(normalizedEmail, token);
+  await sendVerificationEmail(
+    normalizedEmail,
+    token,
+    buildUnsubscribeUrl(baseUrl, unsubscribeToken)
+  );
 
   return { message: "Subscribed! Please verify your email.", subscriber };
 };
@@ -66,43 +83,15 @@ export const verifyNewsletter = async (token: string) => {
   return { message: "Email verified successfully.", subscriber };
 };
 
-export const generateUnsubscribeToken = async (email: string) => {
-  const normalizedEmail = email.trim().toLowerCase();
-  const subscriber = await NewsletterSubscriber.findOne({ email: normalizedEmail });
-  if (!subscriber) throw new Error("Subscriber not found.");
-  if (subscriber.status === "unsubscribed") {
-    return { message: "Already unsubscribed." };
-  }
-  const token = crypto.randomBytes(32).toString("hex");
-  subscriber.verificationToken = token;
-  subscriber.verificationTokenExpires = new Date(Date.now() + 24 * 60 * 60 * 1000);
-  await subscriber.save();
-  return { token };
-};
-
-export const unsubscribeNewsletter = async (email: string) => {
-  const normalizedEmail = email.trim().toLowerCase();
-  const subscriber = await NewsletterSubscriber.findOne({ email: normalizedEmail });
-
-  if (!subscriber) throw new Error("Subscriber not found.");
-
-  subscriber.status = "unsubscribed";
-  subscriber.unsubscribedAt = new Date();
-  await subscriber.save();
-
-  return { message: "Unsubscribed successfully." };
-};
-
 export const unsubscribeByToken = async (token: string) => {
   const subscriber = await NewsletterSubscriber.findOne({
-    verificationToken: token,
-    verificationTokenExpires: { $gt: new Date() },
+    unsubscribeToken: token,
   });
-  if (!subscriber) throw new Error("Invalid or expired unsubscribe token.");
-  subscriber.status = "unsubscribed";
-  subscriber.unsubscribedAt = new Date();
-  subscriber.verificationToken = undefined;
-  subscriber.verificationTokenExpires = undefined;
-  await subscriber.save();
+  if (!subscriber) throw new Error("Invalid unsubscribe token.");
+  if (subscriber.status !== "unsubscribed") {
+    subscriber.status = "unsubscribed";
+    subscriber.unsubscribedAt = new Date();
+    await subscriber.save();
+  }
   return { message: "Unsubscribed successfully." };
 };

--- a/backend/src/utils/email.util.ts
+++ b/backend/src/utils/email.util.ts
@@ -1,7 +1,11 @@
 import nodemailer from "nodemailer";
 import config from "../config";
 
-export const sendVerificationEmail = async (to: string, token: string) => {
+export const sendVerificationEmail = async (
+  to: string,
+  token: string,
+  unsubscribeUrl?: string
+) => {
   if (!config.verify_email || !config.verify_password) {
     console.warn("Email configuration missing. Verification email not sent.");
     return;
@@ -17,6 +21,9 @@ export const sendVerificationEmail = async (to: string, token: string) => {
 
   const frontendUrl = config.cors_origins?.[0] || "http://localhost:4001";
   const verifyLink = `${frontendUrl}/verify-newsletter?token=${token}`;
+  const unsubscribeFooter = unsubscribeUrl
+    ? `<p style="color: #888; font-size: 12px;">Don't want these emails? <a href="${unsubscribeUrl}" style="color: #888;">Unsubscribe</a>.</p>`
+    : "";
 
   const mailOptions = {
     from: `"Story Spark AI" <${config.verify_email}>`,
@@ -34,6 +41,7 @@ export const sendVerificationEmail = async (to: string, token: string) => {
         <p style="color: #666; font-size: 14px;">This link will expire in 24 hours.</p>
         <hr style="border: none; border-top: 1px solid #eaeaea; margin: 30px 0;" />
         <p style="color: #888; font-size: 12px;">Best regards,<br/>The Story Spark AI Team</p>
+        ${unsubscribeFooter}
       </div>
     `,
   };


### PR DESCRIPTION
## Screenshot (when helpful)

N/A. Backend security and email-flow change. Verified via type check and a code trace, described below.

## What this PR does

Removes the two unauthenticated newsletter unsubscribe routes and replaces them with a working, token based unsubscribe that is delivered by email.

### The bugs

- `POST /unsubscribe` took a raw `{ email }` and unsubscribed it with no auth or proof of ownership (anyone could unsubscribe anyone).
- `POST /unsubscribe-token` minted a valid unsubscribe token for any `{ email }`, which is the same takeover via two steps.
- Both leaked subscriber existence (`Subscriber not found` vs success), which is email enumeration.

These are a regression from #999 / PR #1001, which added the safe `GET /unsubscribe/:token` but left the insecure POST routes mounted (CWE-639, CWE-204).

### Why a delete-only fix was not enough

No email ever delivered an unsubscribe token: the verification email only carries the verify link, and `verificationToken` is cleared on verify. So the safe `GET /unsubscribe/:token` was unreachable, and the only working unsubscribe was the insecure POST. Deleting the POSTs alone would leave no working unsubscribe at all.

### Changes

- `newsletter.route.ts`: removed `POST /unsubscribe` and `POST /unsubscribe-token`. Kept `GET /unsubscribe/:token`.
- `newsletter.controller.ts`: removed the two insecure handlers. `subscribe` now passes the request origin so the service can build an absolute unsubscribe link.
- `newsletter.service.ts`: removed `unsubscribeNewsletter` and `generateUnsubscribeToken`. Added a persistent `unsubscribeToken` generated at subscribe and re-subscribe. `unsubscribeByToken` now looks the subscriber up by that persistent token and is idempotent.
- `newsletter.model.ts`: added the indexed `unsubscribeToken` field.
- `email.util.ts`: `sendVerificationEmail` now accepts an optional unsubscribe URL and renders an Unsubscribe footer link.

The unsubscribe link points at `GET /api/v1/newsletter/unsubscribe/:token` using the request origin (`req.protocol` + host, correct behind Vercel since `trust proxy` is set), so it needs no new env var and no frontend page.

### How I verified

1. Confirmed both POST routes and their service functions are gone and nothing else references them.
2. Traced the flow: subscribe stores a persistent `unsubscribeToken` and emails the link; clicking it hits the GET, which unsubscribes by that token. The token is only ever delivered to the subscriber's inbox, so it cannot be guessed or enumerated.
3. Ran `tsc` on the backend. The changed files compile cleanly. The only remaining errors are the pre-existing ones in `story_version.service.ts`, unrelated to this PR.

### Out of scope (follow-ups)

- The GET endpoint returns JSON; a friendly confirmation page (or a small frontend route) would improve the click-through UX.
- Subscribers created before this change have no `unsubscribeToken`; a one-time backfill (or relying on re-subscribe) would cover them.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #1530

## More screenshots (optional)

N/A.

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.