### PR TITLE
fix(security): generate collab room IDs with crypto CSPRNG

### DIFF
--- a/backend/src/socket/collab.socket.ts
+++ b/backend/src/socket/collab.socket.ts
@@ -1,4 +1,5 @@
 import { Server, Socket } from "socket.io";
+import crypto from "crypto";
 import logger from "../utils/logger.util";
 import { GoogleGenerativeAI } from "@google/generative-ai";
 import config from "../config";
@@ -45,7 +46,8 @@ const rooms = new Map<string, IRoom>();
 const cleanupTimeouts = new Map<string, NodeJS.Timeout>();
 
 function generateRoomId(): string {
-  return Math.random().toString(36).substring(2, 10);
+  // 128 bits of CSPRNG entropy so the room id is an unguessable join capability.
+  return crypto.randomBytes(16).toString("hex");
 }
 
 function getColorForUser(index: number): string {


### PR DESCRIPTION
## Screenshot (when helpful)

N/A. One-line backend randomness fix. Verified via type check, described below.

## What this PR does

Makes collaboration room IDs unguessable.

`generateRoomId` in `backend/src/socket/collab.socket.ts` used `Math.random().toString(36).substring(2, 10)`, which is 8 base-36 characters of non-cryptographic entropy (about 41 bits). Since `collab:join_room` admits any authenticated user who presents a valid room ID, a guessable ID lets an attacker enumerate rooms, read a private in-progress story, and trigger `collab:ai_continue`, which spends a participant's AI quota. This is CWE-338 / CWE-330.

Change:

```
import crypto from "crypto";

function generateRoomId(): string {
  return crypto.randomBytes(16).toString("hex"); // 128-bit
}
```

The room ID stays a plain string used as the Map key and Socket.IO room name, so nothing else changes. With 128 bits of CSPRNG entropy the ID becomes an unguessable capability, which closes the guess and enumerate vector. The existing share-the-link join model is preserved.

## How I verified

1. Confirmed `generateRoomId` was the only room ID source and that `join_room` grants access purely on room ID.
2. The output remains a hex string usable as a key and room name; length change is harmless.
3. Ran `tsc` on the backend. The changed file compiles cleanly. The only remaining errors are the pre-existing ones in `story_version.service.ts`, unrelated to this PR.

## Out of scope (follow-up)

An explicit invite or allowlist so a leaked link cannot be reused by an uninvited user. That needs a frontend invite flow (the client currently joins with only a room ID), so it is best handled as its own change.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #1532

## More screenshots (optional)

N/A.

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.