### PR TITLE
fix(audio): restart utterance with new rate on speed change

### DIFF
--- a/frontend/src/hooks/useSpeechSynthesis.ts
+++ b/frontend/src/hooks/useSpeechSynthesis.ts
@@ -202,7 +202,9 @@ export const useSpeechSynthesis = (text: string): UseSpeechSynthesisResult => {
       }
 
       if (typeof event.charIndex === "number") {
-        setCurrentWordIndex(getWordIndexAtCharIndex(event.charIndex, wordRanges));
+        const idx = getWordIndexAtCharIndex(event.charIndex, wordRanges);
+        setCurrentWordIndex(idx);
+        currentWordIndexRef.current = idx;
       }
     };
 
@@ -269,13 +271,79 @@ export const useSpeechSynthesis = (text: string): UseSpeechSynthesisResult => {
     setIsSpeaking(true);
   }, [isSupported]);
 
+  const currentWordIndexRef = useRef(0);
+
   const setRate = useCallback((nextRate: number) => {
     setRateState(nextRate);
 
-    if (utteranceRef.current) {
-      utteranceRef.current.rate = nextRate;
+    // The Web Speech API does not apply rate changes to an active utterance.
+    // We must stop and restart from the current word to apply the new rate.
+    if (!utteranceRef.current || !window.speechSynthesis.speaking) {
+      return;
     }
-  }, []);
+
+    const speechSynthesis = window.speechSynthesis;
+    const wasPaused = speechSynthesis.paused;
+    const resumeFromWord = currentWordIndexRef.current;
+
+    // Cancel current utterance
+    speechSynthesis.cancel();
+    utteranceRef.current = null;
+
+    if (wasPaused) {
+      // If paused, don't restart — just update rate for next play
+      setIsPlaying(false);
+      setIsPaused(false);
+      setIsSpeaking(false);
+      return;
+    }
+
+    // Restart from the current word with the new rate
+    const remainingText = text
+      .split(/\s+/)
+      .slice(resumeFromWord)
+      .join(" ");
+
+    if (!remainingText.trim()) return;
+
+    sessionRef.current += 1;
+    const sessionId = sessionRef.current;
+
+    const utterance = new SpeechSynthesisUtterance(remainingText);
+    utterance.rate = nextRate;
+    utterance.lang = window.navigator.language || "en-US";
+
+    utterance.onboundary = (event: SpeechSynthesisEvent) => {
+      if (sessionRef.current !== sessionId) return;
+      if (typeof event.charIndex === "number") {
+        const localIndex = getWordIndexAtCharIndex(event.charIndex, buildWordRanges(remainingText));
+        setCurrentWordIndex(resumeFromWord + localIndex);
+        currentWordIndexRef.current = resumeFromWord + localIndex;
+      }
+    };
+
+    utterance.onend = () => {
+      if (sessionRef.current !== sessionId) return;
+      utteranceRef.current = null;
+      setIsPlaying(false);
+      setIsPaused(false);
+      setIsSpeaking(false);
+      setCurrentWordIndex(totalWords);
+      currentWordIndexRef.current = totalWords;
+    };
+
+    utterance.onerror = (event: SpeechSynthesisErrorEvent) => {
+      if (sessionRef.current !== sessionId) return;
+      utteranceRef.current = null;
+      setIsPlaying(false);
+      setIsPaused(false);
+      setIsSpeaking(false);
+      if (event.error !== "interrupted") setError("Narration failed to play.");
+    };
+
+    utteranceRef.current = utterance;
+    speechSynthesis.speak(utterance);
+  }, [text, totalWords]);
 
   useEffect(() => {
     const supported = hasSpeechSupport();


### PR DESCRIPTION

## What this PR does
The playback speed selector on the Stories page had no effect on audio
playback. Selecting 2× (or any speed) updated the UI visually but the
narration continued at 1× speed.

**Root cause:** The Web Speech API silently ignores `rate` changes on an
already-speaking `SpeechSynthesisUtterance`. Setting
`utterance.rate = newRate` after `speak()` has been called does nothing.

**Fix:** In `useSpeechSynthesis.ts`, the `setRate` function now:
1. Cancels the active utterance when speed is changed mid-playback
2. Slices the remaining text from the current word index
3. Creates a new utterance with the updated rate and resumes from that point
4. Tracks `currentWordIndex` in a ref so the callback always has a fresh
   value without a stale closure

If narration is paused when speed changes, playback stops gracefully since
resuming mid-utterance with a new rate is not reliable cross-browser.

**To verify the fix:**
1. Go to `/stories`, generate or open a story
2. Start audio playback
3. Change speed to 2× — narration should immediately restart at double speed
4. Change back to 1× — narration should restart at normal speed

## Type of change
- [x] Bug fix

## Related issue
Closes #1327 

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.