### PR TITLE
fix(auth): reject Google ID tokens with email_verified: false (CWE-287)

### DIFF
--- a/backend/src/app/modules/auth/auth.service.ts
+++ b/backend/src/app/modules/auth/auth.service.ts
@@ -172,6 +172,18 @@ const googleLogin = async (payload: { token: string }) => {
       throw new ApiError(httpStatus.BAD_REQUEST, "Invalid Google token");
     }
 
+    // FIX: Verify that the email address has been verified by Google.
+    // A validly signed token is NOT proof of email ownership — Google Workspace
+    // admins can create accounts with arbitrary, unverified addresses.
+    // Without this check an attacker can obtain a signed token with
+    // email_verified: false and take over any email-keyed account (CWE-287).
+    if (!payload_data.email_verified) {
+      throw new ApiError(
+        httpStatus.UNAUTHORIZED,
+        "Google email is not verified"
+      );
+    }
+
     const { email, name: googleName, picture } = payload_data;
     let user = await User.findOne({ email });
 


### PR DESCRIPTION
## Summary
Fixes a missing email_verified claim check in the Google OAuth login flow.

File: backend/src/app/modules/auth/auth.service.ts (googleLogin)
Endpoint: POST /api/v1/auth/google-login

## What happened?
verifyIdToken() only verifies the JWT signature - it does NOT check email ownership. Without this check, an attacker with a signed token where email_verified is false can create or log into any email-keyed account (account takeover).

CWE: CWE-287 Improper Authentication

## Fix applied
Added email_verified guard after the existing null check, before any DB access:

if (!payload_data.email_verified) {
  throw new ApiError(httpStatus.UNAUTHORIZED, "Google email is not verified");
}

## Impact
- Legitimate users (email_verified: true) are unaffected.
- - Returns 401 for tokens with unverified emails.
- - No DB access occurs for unverified tokens.