### PR TITLE
Fixed frontend backend signup inconsistency for name

### DIFF
--- a/backend/src/app/modules/user/user.model.ts
+++ b/backend/src/app/modules/user/user.model.ts
@@ -9,7 +9,7 @@ import { USER_STATUS } from "../../../enums/user_status";
 export const UserSchema: Schema<IUser> = new Schema<IUser, UserModel>(
   {
     email: { type: String, required: true, unique: true, lowercase: true },
-    name: { type: String, maxlength: 100, minlength: 5 },
+    name: { type: String, maxlength: 100, minlength: 3 },
     password: { type: String, required: false, default: "" },
     role: {
       type: String,

--- a/backend/src/app/modules/user/user.validation.ts
+++ b/backend/src/app/modules/user/user.validation.ts
@@ -11,7 +11,9 @@ const passwordSchema = z
 const register = z.object({
   body: z.object({
     email: z.string({ required_error: "Email is required" }),
-    name: z.string({ required_error: "Name is required" }),
+    name: z
+      .string({ required_error: "Name is required" })
+      .min(3, "Name must be at least 3 characters long"),
     password: passwordSchema,
     confirmPassword: z.string({ required_error: "Confirm password is required" }),
     verificationToken: z

--- a/frontend/src/components/signup/signup.component.tsx
+++ b/frontend/src/components/signup/signup.component.tsx
@@ -296,8 +296,8 @@ const SignUpComponent = () => {
                 validation={{
                   required: "Name is required",
                 minLength: {
-                value: 2,
-                message: "Name must be at least 2 characters",
+                value: 3,
+                message: "Name must be at least 3 characters",
                 },
                   pattern: {
                     value: /^[A-Za-z0-9\s._]+$/,


### PR DESCRIPTION
## Screenshot (when helpful)

N/A – This change updates validation logic and does not introduce any UI changes.

---

## What this PR does

This PR fixes the inconsistent name validation rules across the frontend, backend validation layer, and database schema.

### Changes made

- Updated frontend validation in `signup.component.tsx` to require a minimum name length of **3 characters**.
- Updated the Mongoose schema in `user.model.ts` to use `minlength: 3`.
- Updated Zod validation in `user.validation.ts` to enforce a minimum length of **3 characters**.

### Result

- Validation is now consistent across the entire application stack.
- Users with names shorter than 3 characters are blocked before OTP generation.
- Names with 3 or more characters (e.g., `Sam`, `Ali`) can successfully complete the registration flow.
- Prevents OTP emails from being sent to users who would later fail registration due to validation mismatches.
- Improves user experience by providing clear and consistent validation behavior.

---

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

---

## Related issue

Fixes #1456 


## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
