### PR TITLE
fix(#1148): improve contact form alignment and layout

### DIFF
--- a/frontend/src/components/contactus/contactus.tsx
+++ b/frontend/src/components/contactus/contactus.tsx
@@ -144,7 +144,7 @@ export default function Contact() {
 
       <div className="absolute bottom-0 right-0 h-80 w-80 rounded-full bg-purple-500/20 blur-[140px]" />
 
-      <div className="relative z-10 mx-auto grid max-w-7xl items-center gap-20 lg:grid-cols-2">
+      <div className="relative z-10 mx-auto grid w-full max-w-7xl items-center gap-12 px-4 lg:grid-cols-2 lg:gap-20">
         {/* LEFT */}
         <motion.div
           initial={{ opacity: 0, x: -50 }}


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Fixes #1148
- **Description:** Fixed contact form alignment issue where the form was left-aligned with excessive empty space on the right side.
- **Screenshots:** Added below

## Screenshot (when helpful)

<!-- Add before/after screenshots if you have them, or write N/A -->
N/A

## What this PR does

Restructured the Contact section grid container by adding `w-full` for full width usage, improved responsive gap spacing with `gap-12` on mobile and `lg:gap-20` on desktop, and added `px-4` padding for better spacing on small screens. This ensures a balanced two-column layout across all viewports.

## Type of change

- [x] Bug fix

## Related issue

Fixes #1148

## More screenshots (optional)

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.