### PR TITLE
fix: remove hardcoded admin credentials from login.html input fields

### DIFF
--- a/login.html
+++ b/login.html
@@ -119,7 +119,7 @@
                     <label class="field-label" for="email-field">Email Address</label>
                     <div class="input-icon-wrapper">
                         <i class="fi fi-rr-envelope input-icon text-[16px] absolute left-4 top-1/2 -translate-y-1/2 text-on-surface-variant/80"></i>
-                        <input class="auth-field w-full bg-surface-container-high border border-white/10 text-on-surface placeholder:text-outline focus:border-primary transition-all pl-11" placeholder="name@storyspark.ai" type="email" id="email-field" required autocomplete="email" value="admin@gmail.com"/>
+                        <input class="auth-field w-full bg-surface-container-high border border-white/10 text-on-surface placeholder:text-outline focus:border-primary transition-all pl-11" placeholder="name@storyspark.ai" type="email" id="email-field" required autocomplete="email"/>
                     </div>
                     <span class="field-error-msg" id="email-error">Please enter a valid email address.</span>
                 </div>
@@ -131,7 +131,7 @@
                     </div>
                     <div class="input-icon-wrapper">
                         <i class="fi fi-rr-lock input-icon text-[16px] absolute left-4 top-1/2 -translate-y-1/2 text-on-surface-variant/80"></i>
-                        <input class="auth-field w-full bg-surface-container-high border border-white/10 text-on-surface placeholder:text-outline focus:border-primary transition-all pl-11 pr-11" id="password-field" placeholder="••••••••" type="password" required autocomplete="current-password" value="admin@123"/>
+                        <input class="auth-field w-full bg-surface-container-high border border-white/10 text-on-surface placeholder:text-outline focus:border-primary transition-all pl-11 pr-11" id="password-field" placeholder="••••••••" type="password" required autocomplete="current-password"/>
                         <button class="absolute right-3 top-1/2 -translate-y-1/2 text-on-surface-variant hover:text-primary transition-colors p-1 rounded" onclick="togglePasswordVisibility()" type="button" aria-label="Toggle password visibility">
                             <i class="fi fi-rr-eye-crossed text-[16px]" id="eye-icon"></i>
                         </button>


### PR DESCRIPTION
## Screenshot (when helpful)
N/A — no UI visual change; fields now render empty as expected.

## What this PR does
Removes hardcoded default credentials (`value="admin@gmail.com"` and `value="admin@123"`) from the email and password input fields in `login.html` (lines ~122 and ~134). These values posed a security risk by exposing default credentials in the source code and created a poor UX by requiring real users to manually clear the fields before logging in. The fix simply removes both `value` attributes so the fields start empty.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update

> This is a **bug fix / security fix** — hardcoded credentials are a security risk and bad UX.

## Related issue
Fixes #1555

## More screenshots (optional)
N/A

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.