### PR TITLE
fix(auth): support Bearer token parsing

### DIFF
--- a/backend/src/app/middleware/auth.middleware.ts
+++ b/backend/src/app/middleware/auth.middleware.ts
@@ -10,7 +10,10 @@ const auth =
   (...requiredRole: string[]) =>
   async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const token = req.headers.authorization as string;
+      const authHeader = (req.headers.authorization || '') as string;
+      const token = authHeader.startsWith('Bearer ')
+        ? authHeader.slice(7).trim()
+        : authHeader.trim();
       if (!token) {
         throw new ApiError(
           httpStatus.UNAUTHORIZED,


### PR DESCRIPTION
## What this PR does
This PR fixes two authentication-related issues.

The authentication middleware previously attempted to verify the entire Authorization header value instead of extracting the JWT from the standard Bearer format.

Before:

```http
Authorization: Bearer <token>
```

was verified as:

```text
Bearer <token>
```

which caused JWT verification to fail.

The middleware now:

* Detects the `Bearer` scheme
* Extracts the token portion
* Trims surrounding whitespace
* Verifies only the JWT value

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [x] Documentation update

---

## Related issue

Closes #1591 

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.
