### PR TITLE
fix: replace duplicate eye icon with lock icon in confirm password field

### DIFF
--- a/frontend/src/components/signup/signup.component.tsx
+++ b/frontend/src/components/signup/signup.component.tsx
@@ -378,7 +378,7 @@ const SignUpComponent = () => {
                 type="password"
                 placeholder="Confirm your password"
                 required={true}
-                icon="fi fi-rr-eye"
+                icon="fi fi-rr-lock" 
                 register={register}
                 autoComplete="new-password"
                 error={errors.confirmPassword}


### PR DESCRIPTION
## Screenshot 

<img width="508" height="333" alt="image" src="https://github.com/user-attachments/assets/24d06d03-6951-4dda-a1a8-bda443b81ca7" />


– This change is limited to correcting an incorrect icon in the Confirm Password field.

## What this PR does

* Replaces the left-side eye icon in the Confirm Password field with a lock icon.
* Prevents the confusing double-eye icon appearance because the password visibility toggle already provides an eye icon on the right side.
* Keeps the existing password visibility functionality unchanged.

### Note

While investigating this issue, I tested the latest source code from the repository and could not reproduce the reported input-field overflow, sizing inconsistencies, or spacing issues locally. However the Confirm Password field icon issue was indentified, reproduced and has been fixed in this PR.

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

## Related issue

Fixes #1293 

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.
