### PR TITLE
Update auth-field styles for better layout

### DIFF
--- a/auth.css
+++ b/auth.css
@@ -141,13 +141,15 @@ input[type="password"] {
     appearance: none;
     -webkit-appearance: none;
     font-family: inherit;
-    width: 100%;
+    width: 100% !important;
+    max-width: 100%;
     height: var(--ds-input-height);
     line-height: var(--ds-input-height);
-    padding: 0 16px;
+    box-sizing: border-box; 
+    padding-left: 44px !important; 
+    padding-right: 44px !important;
     overflow: hidden;
 }
-
 .auth-field::placeholder {
     line-height: var(--ds-input-height);
 }


### PR DESCRIPTION
This pull request resolves a critical UI layout issue on the Login/Sign-In page where the email and password input fields were misaligned and overflowing outside of the main `.auth-form-card` glass container.

## Screenshot (when helpful)

<img width="1600" height="1041" alt="WhatsApp Image 2026-05-31 at 18 54 27" src="https://github.com/user-attachments/assets/ad414587-cadd-40ec-8fcc-e401067b378f" />




## What this PR does
This pull request resolves a layout bug on the Login/Sign-In page (`/login`) where the email and password input fields were misaligned and overflowing outside of the main `.auth-form-card` glass container wrapper.





## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

None


## Checklist
-[x]The selector constraints defined for `.auth-field` in `auth.css` lacked an explicit `box-sizing: border-box;` declaration. 
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
