### PR TITLE
fix: import validateRequest and PostValidator and validate create-post body

### DIFF
--- a/backend/src/app/modules/post/post.router.ts
+++ b/backend/src/app/modules/post/post.router.ts
@@ -2,6 +2,8 @@ import express from "express";
 import { PostController } from "./post.controller";
 import auth from "../../middleware/auth.middleware";
 import checkRequestLimit from "../../middleware/check.request.limit";
+import validateRequest from "../../middleware/validate.request";
+import { PostValidator } from "./post.validation";
 import { ENUM_USER_ROLE } from "../../../enums/user";
 
 const router = express.Router();
@@ -13,6 +15,7 @@ const router = express.Router();
 router.post(
   "/create-post",
   auth(),
+  validateRequest(PostValidator.createPost),
   PostController.createPost
 );
 


### PR DESCRIPTION
## Screenshot (when helpful)

N/A. Small backend fix. Verified via type check and a code trace, described below.

## What this PR does

Repairs the post payload validation wiring so it actually runs.

`post.router.ts` calls `validateRequest(PostValidator.updatePost)` on the `PATCH /:id` route, but neither `validateRequest` nor `PostValidator` is imported in that file. At runtime that is a `ReferenceError` on the update-post route (the dev server uses `ts-node-dev --transpile-only`, so it is not caught at build time, and a separate pre-existing parse error in `review.service.ts` currently masks it from `tsc`). The create-post route also has no validation at all.

This change:
- Imports `validateRequest` (from `../../middleware/validate.request`) and `PostValidator` (from `./post.validation`), so the existing `updatePost` validation works instead of throwing.
- Adds `validateRequest(PostValidator.createPost)` to the `POST /create-post` route so create payloads are validated too.

Together this makes the post create and update endpoints reject malformed or operator-laden bodies (for example a `content` value of `{ "$ne": null }`) before they reach Mongoose, which is the validation hardening described in #1191.

## How I verified

1. Confirmed `validateRequest` and `PostValidator` were used on the PATCH route but never imported.
2. Confirmed both symbols exist with the expected paths and shapes (the auth router imports them the same way).
3. Ran `tsc` on the backend. With the unrelated pre-existing parse error in `review.service.ts` temporarily set aside, `post.router.ts` type-checks cleanly with the imports added, and no new errors are introduced. The only remaining error on the branch is that pre-existing `review.service.ts` one, which is unrelated to this change.

## Related issue

Relates to #1191 (post create/update payload validation).

## Note for the maintainer

While verifying this I noticed two separate pre-existing issues that this PR intentionally does not touch: a parse error in `backend/src/app/modules/review/review.service.ts` (line 83) and a leftover `Cannot find name 'main'` merge artifact in `backend/src/app/modules/comment/comment.service.ts` (line 46). Both break the backend build independently and are worth their own fixes.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## More screenshots (optional)

N/A.

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.