### PR TITLE
refactor(bookmark): make Bookmark collection the single source of truth

### DIFF
--- a/backend/scripts/migrate-bookmarks.ts
+++ b/backend/scripts/migrate-bookmarks.ts
@@ -1,0 +1,51 @@
+import mongoose from "mongoose";
+import { Post } from "../src/app/modules/post/post.model";
+import { Bookmark } from "../src/app/modules/bookmark/bookmark.model";
+import config from "../src/config";
+
+// Idempotent migration: backfill legacy Post.bookmarks into Bookmark docs + bookmarksCount.
+const migrateBookmarks = async () => {
+  await mongoose.connect(config.database_url as string);
+
+  // Read the legacy array directly; the Post schema no longer defines it.
+  const docs = await Post.collection
+    .find({ bookmarks: { $exists: true, $type: "array" } })
+    .project({ bookmarks: 1 })
+    .toArray();
+
+  let createdBookmarks = 0;
+  let updatedPosts = 0;
+
+  for (const doc of docs) {
+    const userIds: mongoose.Types.ObjectId[] = Array.isArray(doc.bookmarks)
+      ? doc.bookmarks
+      : [];
+
+    for (const userId of userIds) {
+      const res = await Bookmark.updateOne(
+        { userId, storyId: doc._id },
+        { $setOnInsert: { userId, storyId: doc._id } },
+        { upsert: true }
+      );
+      if (res.upsertedCount) createdBookmarks += 1;
+    }
+
+    const count = await Bookmark.countDocuments({ storyId: doc._id });
+    await Post.collection.updateOne(
+      { _id: doc._id },
+      { $set: { bookmarksCount: count }, $unset: { bookmarks: "" } }
+    );
+    updatedPosts += 1;
+  }
+
+  console.log(
+    `Migration complete. Posts updated: ${updatedPosts}, bookmarks created: ${createdBookmarks}.`
+  );
+  await mongoose.disconnect();
+};
+
+migrateBookmarks().catch(async (error) => {
+  console.error("Bookmark migration failed:", error);
+  await mongoose.disconnect();
+  process.exit(1);
+});

--- a/backend/src/app/modules/bookmark/bookmark.service.ts
+++ b/backend/src/app/modules/bookmark/bookmark.service.ts
@@ -20,42 +20,30 @@ const toggleBookmark = async (storyId: string, token: ITokenPayload) => {
     throw new ApiError(httpStatus.BAD_REQUEST, "Story not found!");
   }
 
-  // Atomically find and delete the bookmark if it exists
+  // Bookmark collection is the single source of truth; bookmarksCount mirrors it.
   const deletedBookmark = await Bookmark.findOneAndDelete({
     userId: user._id,
     storyId: post._id,
   });
 
   if (deletedBookmark) {
-    // Atomically pull the user from the bookmarks array
-    await Post.findOneAndUpdate(
-      { _id: post._id },
-      { $pull: { bookmarks: user._id } }
+    await Post.updateOne(
+      { _id: post._id, bookmarksCount: { $gt: 0 } },
+      { $inc: { bookmarksCount: -1 } }
     );
-
     return { message: "Bookmark removed", isBookmarked: false };
-  } else {
-    // Add bookmark atomically
-    try {
-      await Bookmark.create({
-        userId: user._id,
-        storyId: post._id,
-      });
+  }
 
-      // Atomically add the user to the bookmarks array if not already present
-      await Post.findOneAndUpdate(
-        { _id: post._id },
-        { $addToSet: { bookmarks: user._id } }
-      );
-
+  try {
+    await Bookmark.create({ userId: user._id, storyId: post._id });
+    await Post.updateOne({ _id: post._id }, { $inc: { bookmarksCount: 1 } });
+    return { message: "Story bookmarked!", isBookmarked: true };
+  } catch (error: any) {
+    // Duplicate means it was already bookmarked; treat as a no-op success.
+    if (error.code === 11000) {
       return { message: "Story bookmarked!", isBookmarked: true };
-    } catch (error: any) {
-      // Handle rare duplicate bookmark race condition
-      if (error.code === 11000) {
-        return { message: "Story bookmarked!", isBookmarked: true };
-      }
-      throw error;
     }
+    throw error;
   }
 };
 
@@ -85,7 +73,6 @@ const getBookmarks = async (
           path: "reactions",
           populate: { path: "userId", select: "_id" },
         },
-        { path: "bookmarks", select: "_id" },
       ],
     });
 
@@ -134,9 +121,9 @@ const deleteBookmark = async (storyId: string, token: ITokenPayload) => {
   });
 
   if (deletedBookmark) {
-    await Post.findOneAndUpdate(
-      { _id: storyId },
-      { $pull: { bookmarks: user._id } }
+    await Post.updateOne(
+      { _id: storyId, bookmarksCount: { $gt: 0 } },
+      { $inc: { bookmarksCount: -1 } }
     );
   }
 

--- a/backend/src/app/modules/post/post.interface.ts
+++ b/backend/src/app/modules/post/post.interface.ts
@@ -33,7 +33,7 @@ export interface IPost extends IPostPayload {
   attachments?: string[];
   comments?: Types.ObjectId[];
   reactions?: Types.ObjectId[];
-  bookmarks?: Types.ObjectId[];
+  bookmarksCount: number;
 }
 
 export type PostModel = Model<IPost, object>;

--- a/backend/src/app/modules/post/post.model.ts
+++ b/backend/src/app/modules/post/post.model.ts
@@ -20,6 +20,7 @@ export const PostSchema: Schema<IPost> = new Schema<IPost, PostModel>(
     author: { type: Schema.Types.ObjectId, ref: "User" },
     likesCount: { type: Number, default: 0 },
     commentsCount: { type: Number, default: 0 },
+    bookmarksCount: { type: Number, default: 0 },
     viewsCount: { type: Number, default: 0 },
     isPublished: { type: Boolean, default: true },
     isFeaturedPost: { type: Boolean, default: false },
@@ -31,7 +32,6 @@ export const PostSchema: Schema<IPost> = new Schema<IPost, PostModel>(
     attachments: [{ type: String }],
     comments: [{ type: Schema.Types.ObjectId, ref: "Comment" }],
     reactions: [{ type: Schema.Types.ObjectId, ref: "Reaction" }],
-    bookmarks: [{ type: Schema.Types.ObjectId, ref: "User", default: [] }],
   },
   {
     timestamps: true,

--- a/backend/src/app/modules/post/post.service.ts
+++ b/backend/src/app/modules/post/post.service.ts
@@ -4,6 +4,7 @@ import { User } from "../user/user.model";
 import { IPost, IPostPayload, IPostSearchFields } from "./post.interface";
 import httpStatus from "http-status";
 import { Post } from "./post.model";
+import { Bookmark } from "../bookmark/bookmark.model";
 import { StoryVersionService } from "../story_version/story_version.service";
 import {
   IGenericResponse,
@@ -138,8 +139,7 @@ const getPosts = async (
     .populate({
       path: "reactions",
       populate: { path: "userId", select: "_id" },
-    })
-    .populate("bookmarks", "_id");
+    });
   const total = await Post.countDocuments(whereCondition);
   return {
     meta: {
@@ -197,8 +197,7 @@ const getPublishedPostsByAuthor = async (
     .populate({
       path: "reactions",
       populate: { path: "userId", select: "_id" },
-    })
-    .populate("bookmarks", "_id");
+    });
   const total = await Post.countDocuments(whereCondition);
 
   return {
@@ -222,8 +221,7 @@ const getLatestPosts = async () => {
       .populate({
         path: "reactions",
         populate: { path: "userId", select: "_id" },
-      })
-      .populate("bookmarks", "_id");
+      });
     return res;
   } catch (error) {
     throw new ApiError(
@@ -247,8 +245,7 @@ const getFeaturedPosts = async () => {
       .populate({
         path: "reactions",
         populate: { path: "userId", select: "_id" },
-      })
-      .populate("bookmarks", "_id");
+      });
     return res;
   } catch (error) {
     throw new ApiError(
@@ -280,8 +277,7 @@ const getSinglePost = async (id: string) => {
     .populate({
       path: "reactions",
       populate: { path: "userId", select: "_id" },
-    })
-    .populate("bookmarks", "_id");
+    });
   if (!postById) {
     throw new ApiError(httpStatus.NOT_FOUND, "Post not found!");
   }
@@ -308,8 +304,7 @@ const getSinglePost = async (id: string) => {
     .populate({
       path: "reactions",
       populate: { path: "userId", select: "_id" },
-    })
-    .populate("bookmarks", "_id");
+    });
   return result;
 };
 
@@ -323,23 +318,30 @@ const toggleBookmark = async (postId: string, token: ITokenPayload) => {
   if (!post) {
     throw new ApiError(httpStatus.BAD_REQUEST, "Post not found!");
   }
-  // Check bookmark status atomically via a DB query instead of loading the full document
-  const isBookmarked = await Post.exists({ _id: postId, bookmarks: user._id });
 
-  if (isBookmarked) {
-    // Remove bookmark atomically
+  // Bookmark collection is the single source of truth; bookmarksCount mirrors it.
+  const deleted = await Bookmark.findOneAndDelete({
+    userId: user._id,
+    storyId: post._id,
+  });
+
+  if (deleted) {
     await Post.updateOne(
-      { _id: postId },
-      { $pull: { bookmarks: user._id } }
+      { _id: postId, bookmarksCount: { $gt: 0 } },
+      { $inc: { bookmarksCount: -1 } }
     );
     return { message: "Bookmark removed", bookmarked: false };
-  } else {
-    // Add bookmark atomically — $addToSet prevents duplicates
-    await Post.updateOne(
-      { _id: postId },
-      { $addToSet: { bookmarks: user._id } }
-    );
+  }
+
+  try {
+    await Bookmark.create({ userId: user._id, storyId: post._id });
+    await Post.updateOne({ _id: postId }, { $inc: { bookmarksCount: 1 } });
     return { message: "Bookmark added", bookmarked: true };
+  } catch (error: any) {
+    if (error.code === 11000) {
+      return { message: "Bookmark added", bookmarked: true };
+    }
+    throw error;
   }
 }
 

--- a/backend/src/app/modules/user/user.service.ts
+++ b/backend/src/app/modules/user/user.service.ts
@@ -99,11 +99,6 @@ const deleteUser = async (id: string): Promise<void> => {
   await Comment.deleteMany({ postId: { $in: postIds } });
   await Bookmark.deleteMany({ storyId: { $in: postIds } });
 
-  await Post.updateMany(
-    { bookmarks: id },
-    { $pull: { bookmarks: id } }
-  );
-
   await Bookmark.deleteMany({ userId: id });
   await Reaction.deleteMany({ userId: id });
   await Comment.deleteMany({ userId: id });

--- a/frontend/src/components/BookmarkButton.tsx
+++ b/frontend/src/components/BookmarkButton.tsx
@@ -2,18 +2,18 @@ import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-hot-toast";
 import { getUserInfo } from "../services/auth.service";
-import { useToggleBookmarkMutation } from "../redux/apis/bookmark.api";
-import { Post } from "../models/post";
+import {
+  useToggleBookmarkMutation,
+  useCheckBookmarkStatusQuery,
+} from "../redux/apis/bookmark.api";
 
 interface BookmarkButtonProps {
   storyId: string;
-  bookmarks?: Post["bookmarks"];
   className?: string;
 }
 
 const BookmarkButton: React.FC<BookmarkButtonProps> = ({
   storyId,
-  bookmarks = [],
   className = "",
 }) => {
   const navigate = useNavigate();
@@ -21,10 +21,11 @@ const BookmarkButton: React.FC<BookmarkButtonProps> = ({
   const [toggleBookmark] = useToggleBookmarkMutation();
   const [isLoading, setIsLoading] = useState(false);
 
-  // Determine if currently bookmarked by logged in user
-  const isCurrentlyBookmarked = Boolean(currentUser?.userId) && bookmarks.some(
-    (b) => b._id === currentUser?.userId
-  );
+  // Bookmark state comes from the per-user status endpoint (single source of truth).
+  const { data: statusData } = useCheckBookmarkStatusQuery(storyId, {
+    skip: !currentUser?.userId || !storyId,
+  });
+  const isCurrentlyBookmarked = Boolean(statusData?.isBookmarked);
 
   const handleBookmark = async (e: React.MouseEvent) => {
     e.stopPropagation();

--- a/frontend/src/components/home/community_spotlight/community_spotlight.component.tsx
+++ b/frontend/src/components/home/community_spotlight/community_spotlight.component.tsx
@@ -19,7 +19,7 @@ type SpotlightWriter = {
 
 const TOP_WRITERS_LIMIT = 3;
 
-const getBookmarkCount = (post: Post) => post.bookmarks?.length ?? 0;
+const getBookmarkCount = (post: Post) => post.bookmarksCount ?? 0;
 
 const getPostEngagementScore = (post: Post) =>
   (post.likesCount ?? 0) * 3 +

--- a/frontend/src/components/home/feature/feature.component.tsx
+++ b/frontend/src/components/home/feature/feature.component.tsx
@@ -101,7 +101,6 @@ const FeatureComponent = () => {
                       <div onClick={(e) => e.stopPropagation()} className="relative z-10">
                         <BookmarkButton
                           storyId={post._id}
-                          bookmarks={post.bookmarks}
                           className="rounded-full p-1.5 text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
                         />
                       </div>

--- a/frontend/src/components/post/post.details.component.tsx
+++ b/frontend/src/components/post/post.details.component.tsx
@@ -402,7 +402,6 @@ const PostDetailsComponent = () => {
                 {post && (
                   <BookmarkButton
                     storyId={post._id}
-                    bookmarks={post.bookmarks}
                     className="!border-none !px-0 bg-transparent hover:bg-transparent"
                   />
                 )}

--- a/frontend/src/components/post/post.view.list.component.tsx
+++ b/frontend/src/components/post/post.view.list.component.tsx
@@ -120,7 +120,6 @@ const ExploreViewListComponent: React.FC<IExploreViewListComponentProps> = ({
                 <div className="absolute top-4 right-4 z-10" onClick={(e) => e.stopPropagation()}>
                   <BookmarkButton
                     storyId={story._id}
-                    bookmarks={story.bookmarks}
                     className="backdrop-blur-md bg-white/10 dark:bg-black/20 border border-white/20 hover:bg-white/30 p-2 !rounded-full shadow-lg hover:scale-110 transition-all duration-300"
                   />
                 </div>

--- a/frontend/src/models/post.ts
+++ b/frontend/src/models/post.ts
@@ -30,10 +30,6 @@ interface Reaction {
   _id: string;
 }
 
-interface Bookmark {
-  _id: string;
-}
-
 export interface Post {
   _id: string;
   title: string;
@@ -47,6 +43,7 @@ export interface Post {
   author: Author;
   likesCount: number;
   commentsCount: number;
+  bookmarksCount: number;
   viewsCount: number;
   isPublished: boolean;
   isFeaturedPost: boolean;
@@ -57,7 +54,6 @@ export interface Post {
   attachments: string[];
   comments: Comment[];
   reactions: Reaction[];
-  bookmarks?: Bookmark[];
   createdAt: string;
   updatedAt: string;
   emotions?: string[];


### PR DESCRIPTION
## Screenshot (when helpful)

N/A. Backend + frontend data-model refactor. Verified via type checks and a code trace, described below.

## What this PR does

Removes the dual source of truth for bookmarks. Previously bookmarks lived both in the `Bookmark` collection and in a `Post.bookmarks` array of user ids, kept in sync by hand across two endpoints. This PR makes the `Bookmark` collection authoritative and replaces the array with a denormalized `bookmarksCount` integer.

### Backend
- `post.model.ts` / `post.interface.ts`: drop the `bookmarks` array, add `bookmarksCount: number` (default 0).
- `bookmark.service.ts`: `toggleBookmark` and `deleteBookmark` operate on the `Bookmark` collection and atomically `$inc` `Post.bookmarksCount` (decrement guarded by `bookmarksCount > 0`). The duplicate-key race is still handled as a no-op success. `getBookmarks` no longer populates the removed array.
- `post.service.ts`: the parallel `toggleBookmark` (mounted at `POST /post/bookmark/:id`) now uses the `Bookmark` collection too, so both endpoints share one source of truth. Removed the six `.populate("bookmarks", ...)` calls.
- `user.service.ts`: account deletion no longer `$pull`s from the removed array; `Bookmark.deleteMany({ userId })` already removes the user's bookmarks.

### Frontend
- `BookmarkButton.tsx`: derives the bookmarked state from the existing `GET /bookmarks/status/:storyId` endpoint via `useCheckBookmarkStatusQuery` (skipped for guests), instead of scanning a `bookmarks` array prop. The `bookmarks` prop is removed.
- `feature`, `post.details`, `post.view.list`: drop the now-removed `bookmarks={...}` prop.
- `community_spotlight.component.tsx`: bookmark count now reads `post.bookmarksCount`.
- `models/post.ts`: remove the `Bookmark` array type, add `bookmarksCount`.

### Migration
- `backend/scripts/migrate-bookmarks.ts`: idempotent one-time script that backfills existing `Post.bookmarks` arrays into `Bookmark` documents (upsert) and sets `bookmarksCount`, then unsets the legacy array. Mirrors the connection pattern of `seed-admin.ts`. Run once after deploy: `npx ts-node scripts/migrate-bookmarks.ts`.

## How I verified

1. Confirmed every reader of `Post.bookmarks` (two backend toggles, user cleanup, frontend button, community-spotlight count) is migrated; no `Post.bookmarks` array reference remains in backend or frontend.
2. Backend `tsc`: my changed files compile cleanly; only the two unrelated pre-existing errors remain (`comment.service.ts`, `recommendation.service.ts`).
3. Frontend `tsc`: the error count is identical before and after this change (the frontend has many pre-existing JSX parse errors on `main`), and `BookmarkButton.tsx` and `models/post.ts`, the files carrying the real logic change, are clean in both runs, so this PR introduces no new type errors.
4. The migration script is under `scripts/` which is outside the `tsc` build (same as `seed-admin.ts`), so it does not affect CI typecheck.

## Note for the maintainer

The frontend on `main` currently has many pre-existing JSX build errors unrelated to this PR (for example in `feature.component.tsx`, `community_spotlight.component.tsx`, `post.view.list.component.tsx`). They predate this change and are out of scope here. Please run `scripts/migrate-bookmarks.ts` once after merge to backfill existing data.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Documentation update

## Related issue

Closes #1673

## More screenshots (optional)

N/A.

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.