### PR TITLE
feat: implement client-side request timeout and safeguards for AI story generation

### DIFF
--- a/frontend/src/components/stories/stories.component.tsx
+++ b/frontend/src/components/stories/stories.component.tsx
@@ -589,7 +589,17 @@ useEffect(() => {
     isGenerationInProgressRef.current = true;
     setLoading(true);
 
+    let timeoutId: NodeJS.Timeout | null = null;
+
     try {
+      // 60-second client-side request timeout safeguard
+      timeoutId = setTimeout(() => {
+        if (isGenerationInProgressRef.current) {
+          toast.error("Story generation timed out. Please try again.");
+          handleCancelGeneration();
+        }
+      }, 60000);
+
       const payload = {
         prompt: selectedGenre
           ? `[Genre: ${selectedGenre}] ${data.prompt}`
@@ -630,6 +640,9 @@ useEffect(() => {
         toast.error(message);
       }
     } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
       activeGenerationRef.current = null;
       isGenerationInProgressRef.current = false;
       setLoading(false);


### PR DESCRIPTION


### The Problem
Previously, when the AI story generation API call took too long (due to a slow network, connection drops, or model overloading), the loading spinner ran indefinitely. There was no request timeout configured, no user-visible timeout error message was shown, and the user had to perform a full page refresh in order to cancel the loading state and retry.

### The Solution
We implemented a client-side request timeout and graceful abort safeguard inside the main story generation flow:

- **`stories.component.tsx`**: Added an automatic 60-second timer (`setTimeout`) inside the `onSubmit` handler.
- **Graceful Timeout Trigger**: If the AI story generation takes longer than 60 seconds:
  1. Displays a clear error notification to the user: `Story generation timed out. Please try again.`
  2. Automatically aborts the active RTK Query API request (`activeGenerationRef.current?.abort()`).
  3. Resets the `loading` state to `false`, immediately stopping the spinner and re-enabling the generation form and buttons so the user can edit their prompt and retry instantly without a page refresh.
- **Cleanup**: In the `finally` block, we clear the timeout (`clearTimeout`) if the request finishes successfully or throws a standard error before the 60-second limit is reached.
