### PR TITLE
fix(post): prevent drafts exposure in public endpoints

### DIFF
--- a/backend/src/app/modules/post/__tests__/post.service.test.ts
+++ b/backend/src/app/modules/post/__tests__/post.service.test.ts
@@ -1,0 +1,61 @@
+import { Post } from "../post.model";
+import { PostService } from "../post.service";
+
+jest.mock("../post.model", () => ({
+  Post: {
+    find: jest.fn().mockReturnThis(),
+    sort: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    populate: jest.fn().mockReturnThis(),
+    countDocuments: jest.fn(),
+  },
+}));
+
+const mockedPost = Post as jest.Mocked<typeof Post>;
+
+describe("PostService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("getLatestPosts", () => {
+    it("should filter by isDeleted: { $ne: true } and isPublished: true", async () => {
+      const chain = {
+        sort: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        populate: jest.fn().mockReturnThis(),
+        then: jest.fn((resolve) => resolve([])),
+        catch: jest.fn(),
+      };
+      mockedPost.find.mockReturnValue(chain as any);
+
+      await PostService.getLatestPosts();
+
+      expect(mockedPost.find).toHaveBeenCalledWith({
+        isDeleted: { $ne: true },
+        isPublished: true,
+      });
+    });
+  });
+
+  describe("getFeaturedPosts", () => {
+    it("should filter by isDeleted: { $ne: true }, isFeaturedPost: true and isPublished: true", async () => {
+      const chain = {
+        sort: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        populate: jest.fn().mockReturnThis(),
+        then: jest.fn((resolve) => resolve([])),
+        catch: jest.fn(),
+      };
+      mockedPost.find.mockReturnValue(chain as any);
+
+      await PostService.getFeaturedPosts();
+
+      expect(mockedPost.find).toHaveBeenCalledWith({
+        isFeaturedPost: true,
+        isDeleted: { $ne: true },
+        isPublished: true,
+      });
+    });
+  });
+});

--- a/backend/src/app/modules/post/post.service.ts
+++ b/backend/src/app/modules/post/post.service.ts
@@ -66,6 +66,7 @@ const getPosts = async (
     filters;
   const andCondition: Record<string, unknown>[] = [
     { isDeleted: { $ne: true } },
+    { isPublished: true },
   ];
 
  if (searchTerm) {
@@ -213,7 +214,7 @@ const getPublishedPostsByAuthor = async (
 
 const getLatestPosts = async () => {
   try {
-    const res = await Post.find({ isDeleted: { $ne: true } })
+    const res = await Post.find({ isDeleted: { $ne: true }, isPublished: true })
       .sort({ createdAt: -1 })
       .limit(3)
       .populate("author", "name email createdAt")
@@ -238,6 +239,7 @@ const getFeaturedPosts = async () => {
     const res = await Post.find({
       isFeaturedPost: true,
       isDeleted: { $ne: true },
+      isPublished: true,
     })
       .sort({ createdAt: -1, updatedBy: -1 })
       .limit(3)


### PR DESCRIPTION
Fixes #1034.

This PR updates the database queries in \getLatestPosts\, \getFeaturedPosts\, and \getPosts\ within \post.service.ts\ to enforce \isPublished: true\.

Before this change, posts saved as drafts were inadvertently returned through these public-facing endpoints because they were only filtering by \isDeleted: { $ne: true }\.

Included Jest tests to ensure the correct filter criteria are applied during the DB lookup operations.