### PR TITLE
fix: add post id type to IPost interface

### DIFF
--- a/backend/src/app/modules/post/post.interface.ts
+++ b/backend/src/app/modules/post/post.interface.ts
@@ -19,6 +19,7 @@ export interface IPostPayload {
 }
 
 export interface IPost extends IPostPayload {
+  _id?: Types.ObjectId;
   author: Types.ObjectId;
   likesCount: number;
   commentsCount: number;


### PR DESCRIPTION

## Screenshot (when helpful): 
N/A — this is a backend TypeScript type fix and does not include any UI changes.

## What this PR does
This PR adds the missing ` _id?: Types.ObjectId` field to the `IPost` interface.
The recommendation service accesses `r._id` while mapping recommended posts, but `_id` was not defined in the `IPost` type, which caused a TypeScript error during backend build. Adding `_id` to the shared post interface fixes the type mismatch without changing runtime behavior.

## Testing
- Attempted `npm run build:backend`
- The original recommendation service `_id` type error is no longer present
- Backend build currently fails due to unrelated existing errors:
   - `src/app.ts:23` - `app.use(limiter)` overload error
   - `src/app/modules/comment/comment.service.ts:46` - `Cannot find name 'main'`

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue
Fixes #1669 

## More Screenshots (Optional)
N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
