### PR TITLE
fix(frontend): use shared getBaseUrl instead of localhost fallback

### DIFF
--- a/frontend/src/components/analytics/AnalyticsDashboard.tsx
+++ b/frontend/src/components/analytics/AnalyticsDashboard.tsx
@@ -4,8 +4,9 @@ import {
   PieChart, Pie, Cell, CartesianGrid,
 } from "recharts";
 import { Link } from "react-router-dom";
+import { getBaseUrl } from "../../helpers/config";
 
-const API_BASE = import.meta.env.VITE_BASE_URL || "http://localhost:5000/api/v1";
+const API_BASE = getBaseUrl();
 
 const COLORS = ["#6366f1", "#8b5cf6", "#ec4899", "#f59e0b", "#10b981", "#3b82f6", "#ef4444", "#14b8a6"];
 

--- a/frontend/src/components/dashboard/analytics/analytics.page.tsx
+++ b/frontend/src/components/dashboard/analytics/analytics.page.tsx
@@ -4,8 +4,9 @@ import {
   PieChart, Pie, Cell, CartesianGrid,
 } from "recharts";
 import { getToken } from "../../../services/auth.service";
+import { getBaseUrl } from "../../../helpers/config";
 
-const API_BASE = import.meta.env.VITE_BASE_URL || "http://localhost:5000/api/v1";
+const API_BASE = getBaseUrl();
 
 const COLORS = ["#6366f1", "#8b5cf6", "#ec4899", "#f59e0b", "#10b981", "#3b82f6", "#ef4444", "#14b8a6"];
 

--- a/frontend/src/services/ai.service.ts
+++ b/frontend/src/services/ai.service.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
+import { getBaseUrl } from "../helpers/config";
 
-const API_BASE = import.meta.env.VITE_BASE_URL || "http://localhost:5000/api/v1";
+const API_BASE = getBaseUrl();
 
 export interface IChatMessage {
   role: "user" | "model";


### PR DESCRIPTION
## Screenshot (when helpful)

N/A. Small frontend config fix. Verified via type check, described below.

## What this PR does

Removes the hardcoded `http://localhost:5000/api/v1` fallback from three modules and routes them through the existing shared `getBaseUrl()` helper, so there is a single source of truth for the API base URL and no silent localhost requests in a deployed environment when `VITE_BASE_URL` is unset.

Changed files (each replaced `import.meta.env.VITE_BASE_URL || "http://localhost:5000/api/v1"` with `getBaseUrl()`):
- `components/dashboard/analytics/analytics.page.tsx` (the routed analytics page)
- `components/analytics/AnalyticsDashboard.tsx`
- `services/ai.service.ts`

`getBaseUrl()` (in `helpers/config.ts`) already returns the configured URL and warns in development when it is missing, and is the same helper the axios layer uses, so this aligns these modules with the rest of the app.

## How I verified

1. Confirmed no `localhost:5000/api/v1` fallback remains in the three files.
2. Ran `tsc -b` on the frontend. The error count is identical before and after this change, and all three changed files are clean. The remaining errors are pre-existing JSX parse errors on `main`, unrelated to this PR.

## Note for the maintainer

The frontend on `main` currently has many pre-existing JSX build errors unrelated to this change. They predate this PR and are out of scope here. I did not change `getBaseUrl()` itself to hard-throw on a missing variable, since the helper intentionally tolerates development with a warning; routing these modules through it is the consistent, lower-risk fix.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #1694

## More screenshots (optional)

N/A.

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.