### PR TITLE
fix(security): log path without query string in ErrorBoundary diagnostics

### DIFF
--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -40,7 +40,11 @@ class ErrorBoundary extends Component<Props, State> {
         message: error.toString(),
         stack: error.stack,
         componentStack: errorInfo.componentStack,
-        url: typeof window !== "undefined" ? window.location.href : "",
+        // Path only, no query string, so tokens or PII in params are not persisted.
+        url:
+          typeof window !== "undefined"
+            ? window.location.origin + window.location.pathname
+            : "",
         userAgent: typeof navigator !== "undefined" ? navigator.userAgent : "",
       };
 


### PR DESCRIPTION
## Screenshot (when helpful)

N/A. One-line frontend security fix. Verified via type check, described below.

## What this PR does

Stops the ErrorBoundary from persisting the query string to `localStorage`.

`componentDidCatch` logged `window.location.href` (which includes the query string) into `app_error_log`. If a URL ever carries sensitive params (preview or reset tokens, `?ref=`, `?email=`), they would be persisted to `localStorage` and survive logout. This change logs only `window.location.origin + window.location.pathname`, so the path is still useful for diagnostics but no query data is stored. This is CWE-532.

## How I verified

1. Confirmed the logged `url` no longer includes the query string.
2. Ran `tsc -b` on the frontend. `ErrorBoundary.tsx` is clean and the error count is unchanged (the remaining errors are pre-existing and unrelated to this file).

## Note for the maintainer

The issue also suggests clearing `app_error_log` on logout. That belongs in `removeUserInfo` in `frontend/src/services/auth.service.ts`, but that file is currently corrupted by an unresolved merge (duplicate and interleaved declarations, it does not parse) and I have filed that separately. The logout cleanup should be added once that file is repaired, so it is intentionally not included here to keep this PR focused and mergeable.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #1697

## More screenshots (optional)

N/A.

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.