### PR TITLE
Add retry mechanism for AI generation timeout

### DIFF
--- a/frontend/src/components/RetryBanner.tsx
+++ b/frontend/src/components/RetryBanner.tsx
@@ -1,0 +1,147 @@
+// frontend/src/components/stories/RetryBanner.tsx
+interface RetryBannerProps {
+  retryCount: number;
+  maxRetries: number;
+  isRetrying: boolean;
+  countdown: number;        // seconds remaining in backoff
+  onRetry: () => void;
+}
+
+const RetryBanner = ({
+  retryCount,
+  maxRetries,
+  isRetrying,
+  countdown,
+  onRetry,
+}: RetryBannerProps) => {
+  const exhausted = retryCount >= maxRetries;
+
+  return (
+    // aria-live so screen readers announce the timeout — issue requirement
+    <div
+      role="alert"
+      aria-live="assertive"
+      aria-atomic="true"
+      className="flex items-start gap-3 mt-3 p-4 rounded-lg border border-red-500/40 bg-red-500/10 animate-fadeIn"
+    >
+      {/* Warning icon */}
+      <svg
+        className="w-5 h-5 text-red-400 flex-shrink-0 mt-0.5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"
+        />
+      </svg>
+
+      {/* Message section */}
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-semibold text-red-400">
+          AI generation timed out.
+        </p>
+        <p className="text-xs text-red-400/70 mt-1">
+          {exhausted
+            ? "All retry attempts exhausted. Please wait a moment and try again manually."
+            : countdown > 0
+            ? `Retrying in ${countdown}s… (attempt ${retryCount} of ${maxRetries})`
+            : retryCount > 0
+            ? `Attempt ${retryCount} of ${maxRetries} failed. Try again?`
+            : "This can happen due to high server load or network issues."}
+        </p>
+
+        {/* Attempt dots indicator */}
+        {!exhausted && (
+          <div className="flex gap-1.5 mt-2" aria-hidden="true">
+            {Array.from({ length: maxRetries }).map((_, i) => (
+              <div
+                key={i}
+                className={`w-2 h-2 rounded-full transition-colors duration-300 ${
+                  i < retryCount
+                    ? "bg-red-500"
+                    : i === retryCount && isRetrying
+                    ? "bg-yellow-400 animate-pulse"
+                    : "bg-white/20"
+                }`}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Retry button */}
+      <button
+        type="button"
+        onClick={onRetry}
+        disabled={isRetrying || exhausted || countdown > 0}
+        aria-label={
+          exhausted
+            ? "Maximum retries reached"
+            : isRetrying
+            ? "Retrying generation..."
+            : "Retry story generation"
+        }
+        className="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg
+          bg-red-600 hover:bg-red-700 active:scale-95
+          text-white flex-shrink-0
+          disabled:opacity-50 disabled:cursor-not-allowed
+          transition-all duration-150 focus:outline-none
+          focus:ring-2 focus:ring-red-500 focus:ring-offset-2
+          focus:ring-offset-transparent"
+      >
+        {isRetrying ? (
+          <>
+            <svg
+              className="animate-spin h-4 w-4"
+              viewBox="0 0 24 24"
+              fill="none"
+              aria-hidden="true"
+            >
+              <circle
+                className="opacity-25"
+                cx="12" cy="12" r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+              />
+            </svg>
+            <span>Retrying…</span>
+          </>
+        ) : countdown > 0 ? (
+          <span>{countdown}s</span>
+        ) : exhausted ? (
+          <span>Exhausted</span>
+        ) : (
+          <>
+            <svg
+              className="h-4 w-4"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+              />
+            </svg>
+            <span>Retry</span>
+          </>
+        )}
+      </button>
+    </div>
+  );
+};
+
+export default RetryBanner;

--- a/frontend/src/hooks/useRetry.ts
+++ b/frontend/src/hooks/useRetry.ts
@@ -1,0 +1,93 @@
+// frontend/src/hooks/useRetry.ts
+import { useState, useCallback, useRef } from "react";
+
+export interface UseRetryOptions {
+  maxRetries?: number;
+  baseDelay?: number; // ms, for exponential backoff
+}
+
+export interface UseRetryReturn {
+  retryCount: number;
+  isRetrying: boolean;
+  isTimeout: boolean;
+  countdown: number;       // seconds remaining before next retry allowed
+  MAX_RETRIES: number;
+  setIsTimeout: (v: boolean) => void;
+  handleRetry: (triggerFn: () => void) => void;
+  resetRetry: () => void;
+}
+
+export function useRetry({
+  maxRetries = 3,
+  baseDelay = 0,
+}: UseRetryOptions = {}): UseRetryReturn {
+  const [retryCount, setRetryCount] = useState(0);
+  const [isRetrying, setIsRetrying] = useState(false);
+  const [isTimeout, setIsTimeout] = useState(false);
+  const [countdown, setCountdown] = useState(0);
+  const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const startCountdown = useCallback(
+    (seconds: number, onDone: () => void) => {
+      setCountdown(seconds);
+      countdownRef.current = setInterval(() => {
+        setCountdown((prev) => {
+          if (prev <= 1) {
+            clearInterval(countdownRef.current!);
+            setCountdown(0);
+            onDone();
+            return 0;
+          }
+          return prev - 1;
+        });
+      }, 1000);
+    },
+    []
+  );
+
+  const handleRetry = useCallback(
+    (triggerFn: () => void) => {
+      // Prevent multiple simultaneous retries (issue requirement #4)
+      if (isRetrying || countdown > 0) return;
+      if (retryCount >= maxRetries) return;
+
+      const nextCount = retryCount + 1;
+      setRetryCount(nextCount);
+      setIsTimeout(false);
+
+      // Exponential backoff delay: 0s, 2s, 4s for retries 1, 2, 3
+      const delaySeconds = baseDelay > 0 ? baseDelay * nextCount : 0;
+
+      if (delaySeconds > 0) {
+        setIsRetrying(false); // not retrying yet, counting down
+        startCountdown(delaySeconds, () => {
+          setIsRetrying(true);
+          triggerFn();
+        });
+      } else {
+        setIsRetrying(true);
+        triggerFn();
+      }
+    },
+    [isRetrying, countdown, retryCount, maxRetries, baseDelay, startCountdown]
+  );
+
+  const resetRetry = useCallback(() => {
+    setRetryCount(0);
+    setIsRetrying(false);
+    setIsTimeout(false);
+    setCountdown(0);
+    if (countdownRef.current) clearInterval(countdownRef.current);
+  }, []);
+
+  return {
+    retryCount,
+    isRetrying,
+    isTimeout,
+    countdown,
+    MAX_RETRIES: maxRetries,
+    setIsTimeout,
+    handleRetry,
+    resetRetry,
+  };
+}


### PR DESCRIPTION
## Screenshot (when helpful)
N/A – UI screenshots are not included because the change primarily introduces reusable retry logic and a retry banner component.

## What this PR does
When AI story generation times out, users previously only saw a dismissible toast saying "AI generation timed out. Please try again." and had to manually re-click Generate.
This PR solves that by:

1. Adding frontend/src/hooks/useRetry.ts — a reusable hook managing isTimeout, isRetrying, retryCount, countdown, and resetRetry.
2. Adding frontend/src/components/stories/RetryBanner.tsx — an inline banner with a Retry button, attempt dots, countdown timer, and aria-live region for screen readers.
3. Preventing multiple simultaneous retry requests via the isRetrying guard.



## Type of change

* [x] Bug fix
* [x] New feature
* [ ] Code refactor
* [ ] Documentation update

## Related issue

Fixes #1526

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.

