### PR TITLE
fix: keep console.warn and console.error when logs are disabled

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -12,12 +12,11 @@ import logger from "./utils/logger.util";
 dns.setServers(["1.1.1.1", "8.8.8.8"]);
 
 if (config.disable_logs) {
+  // Silence only verbose channels; keep warn/error so failures stay visible in logs.
   const noop = () => undefined;
   console.log = noop;
   console.info = noop;
   console.debug = noop;
-  console.warn = noop;
-  console.error = noop;
 }
 
 async function connectDB() {


### PR DESCRIPTION
## Screenshot (when helpful)

N/A. Small backend logging fix. Verified via type check, described below.

## What this PR does

Stops `disable_logs` from silencing the error channel in production.

In `server.ts`, when `DISABLE_LOGS=true` or on Vercel (`VERCEL=1`), the code replaced every console method with a no-op, including `console.warn` and `console.error`. Since `config.disable_logs` is true on Vercel by default, this hid all failures reported via `console.error`, including the fire-and-forget `catch(console.error)` paths in `auth.service.ts` and `post.service.ts`. Those errors vanished from the Vercel logs, making production issues undebuggable (CWE-778).

This change silences only `console.log`, `console.info`, and `console.debug`, and keeps `console.warn` and `console.error` working so warnings and errors still reach the platform logs.

## How I verified

1. Confirmed the block previously stubbed `console.warn` and `console.error`, and that several `catch(console.error)` call sites depend on `console.error` being functional.
2. Ran `tsc` on the backend. `server.ts` is clean; only the two unrelated pre-existing errors remain.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #1717

## More screenshots (optional)

N/A.

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.