### PR TITLE
fix: make DNS resolver override opt-in via DNS_SERVERS env var

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,6 +3,8 @@ NODE_ENV=development
 PORT=5000
 # Optional: comma-separated frontend origins for CORS (e.g. http://localhost:4001)
 CORS_ORIGINS=http://localhost:4001
+# Optional: comma-separated custom DNS resolvers (e.g. 1.1.1.1,8.8.8.8); unset uses the platform resolver
+# DNS_SERVERS=
 
 # Database
 # MongoDB connection string (local or Atlas)

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -3,9 +3,7 @@ import path from "path";
 
 dotenv.config({ path: path.join(__dirname, "../../.env") });
 
-const parseCorsOrigins = (
-  raw: string | undefined
-): string[] | undefined => {
+const parseList = (raw: string | undefined): string[] | undefined => {
   if (!raw?.trim()) return undefined;
   return raw
     .split(",")
@@ -26,7 +24,8 @@ export default {
     }
     return url;
   })(),
-  cors_origins: parseCorsOrigins(process.env.CORS_ORIGINS),
+  cors_origins: parseList(process.env.CORS_ORIGINS),
+  dns_servers: parseList(process.env.DNS_SERVERS),
   bcrypt_salt_rounds: (() => {
     const raw = process.env.SALT_ROUNDS;
     const parsed = raw ? Number(raw) : NaN;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -9,7 +9,10 @@ import { JwtHalers } from "./utils/jwt.helper";
 import { Secret } from "jsonwebtoken";
 import logger from "./utils/logger.util";
 
-dns.setServers(["1.1.1.1", "8.8.8.8"]);
+// Override DNS resolvers only when explicitly configured; default to the platform resolver.
+if (config.dns_servers?.length) {
+  dns.setServers(config.dns_servers);
+}
 
 if (config.disable_logs) {
   const noop = () => undefined;


### PR DESCRIPTION
## Description

Removes the unconditional global DNS override in `server.ts`. Previously `dns.setServers(["1.1.1.1", "8.8.8.8"])` ran at import time on every boot, a process-wide side effect that overrides the platform resolver for all lookups and could break private or internal hostname resolution.

It is now opt-in via a new optional `DNS_SERVERS` env var:

- `config/index.ts`: parse `DNS_SERVERS` (comma-separated) using the same list helper as `CORS_ORIGINS` (renamed `parseCorsOrigins` to the generic `parseList`).
- `server.ts`: call `dns.setServers(config.dns_servers)` only when `DNS_SERVERS` is set; otherwise use the platform resolver.
- `.env.example`: document `DNS_SERVERS` as optional.

Anyone who needs custom resolvers (for example certain MongoDB Atlas SRV setups) can set `DNS_SERVERS=1.1.1.1,8.8.8.8` to restore the old behavior; the default no longer forces it.

Verified: `dns` was imported only for this single call, and `tsc` on the backend shows `config/index.ts` and `server.ts` clean (only unrelated pre-existing errors remain).

## Related Issue

Closes #1721

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Code refactor
- [ ] Other (please describe):

## Checklist

- [x] I have tested my changes
- [x] I have updated documentation if necessary
- [x] My code follows the project's coding style
- [x] This PR does not introduce any breaking changes
- [x] I have linked the related issue above
