### PR TITLE
fix: set guest userId cookie with security flags on all free AI endpoints

### DIFF
--- a/backend/src/app/modules/ai_model/ai_model.controller.ts
+++ b/backend/src/app/modules/ai_model/ai_model.controller.ts
@@ -41,7 +41,7 @@ const aiFreeModelGenerate = catchAsync(async (req: Request, res: Response) => {
 
   if (!userId) {
     userId = Math.random().toString(36).substring(7);
-    setGuestUserIdCookie(res, userId);  // ✅ Fixed: now includes sameSite
+    setGuestUserIdCookie(res, userId);
   }
 
   const guard = createGuestQuotaGuard(userId);
@@ -86,7 +86,7 @@ const aiFreeModelAlternateEndings = catchAsync(
 
     if (!userId) {
       userId = Math.random().toString(36).substring(7);
-      setGuestUserIdCookie(res, userId);  // ✅ Fixed: now includes sameSite
+      setGuestUserIdCookie(res, userId);
     }
 
     const guard = createGuestQuotaGuard(userId);
@@ -163,7 +163,7 @@ const aiFreeModelRemix = catchAsync(async (req: Request, res: Response) => {
 
   if (!userId) {
     userId = Math.random().toString(36).substring(7);
-    res.cookie("userId", userId, { maxAge: 30 * 24 * 60 * 60 * 1000 });
+    setGuestUserIdCookie(res, userId);
   }
 
   const guard = createGuestQuotaGuard(userId);
@@ -207,7 +207,7 @@ const aiFreeModelTranslate = catchAsync(async (req: Request, res: Response) => {
 
   if (!userId) {
     userId = Math.random().toString(36).substring(7);
-    res.cookie("userId", userId, { maxAge: 30 * 24 * 60 * 60 * 1000 });
+    setGuestUserIdCookie(res, userId);
   }
 
   const guard = createGuestQuotaGuard(userId);
@@ -251,7 +251,7 @@ const aiFreeModelChat = catchAsync(async (req: Request, res: Response) => {
 
   if (!userId) {
     userId = Math.random().toString(36).substring(7);
-    res.cookie("userId", userId, { maxAge: 30 * 24 * 60 * 60 * 1000 });
+    setGuestUserIdCookie(res, userId);
   }
 
   const guard = createGuestQuotaGuard(userId);


### PR DESCRIPTION
## Screenshot (when helpful)

N/A. Backend cookie configuration change. Verified via type check, described below.

## What this PR does

Makes the guest `userId` cookie consistent and secure across all five free (guest) AI endpoints in `ai_model.controller.ts`.

Three endpoints (`aiFreeModelRemix`, `aiFreeModelTranslate`, `aiFreeModelChat`) were setting the cookie with `res.cookie("userId", userId, { maxAge })` and no `httpOnly`, `secure`, or `sameSite` flags. The other two already used the shared `setGuestUserIdCookie` helper from `utils/cookie.util.ts`, which applies `httpOnly`, `secure` (in production), and `sameSite`.

This PR replaces those three raw `res.cookie` calls with `setGuestUserIdCookie(res, userId)`, so all five endpoints set the cookie identically and securely. It also removes two stale inline comments next to the two already-migrated calls so the five call sites read the same.

Out of scope: the guest id is still generated with `Math.random()`. That weakness is already tracked in #1275 (assigned to another contributor), so this PR does not change it.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #1725

## More screenshots (optional)

N/A.

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
