### PR TITLE
Fix #1717: Do not silence console.warn and console.error

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -16,8 +16,6 @@ if (config.disable_logs) {
   console.log = noop;
   console.info = noop;
   console.debug = noop;
-  console.warn = noop;
-  console.error = noop;
 }
 
 async function connectDB() {


### PR DESCRIPTION
Resolves #1717 by keeping the error and warning channels intact when logs are disabled.