### PR TITLE
docs: fix Unsplash environment variable typo and clarify media assets in ARCHITECTURE.md

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -137,16 +137,16 @@ Password hashing uses **bcrypt** (`SALT_ROUNDS`). Google OAuth is handled via `G
 
 ---
 
-### 4. 🤖 AI Layer
-StorySparkAI supports two AI providers — switchable via environment variables:
+### 4. 🤖 AI Layer & Media Assets
+StorySparkAI supports two AI providers and an image asset manager — configured via environment variables:
 
-| Provider | Env var | Used for |
+| Provider / Service | Env var | Used for |
 |---|---|---|
 | OpenAI | `OPEN_AI_KEY` | Story generation + analysis |
 | Google Gemini | `GEMINI_API_KEY` | Story generation + analysis |
-| Unsplash | `UNSPLASH_KEY_API` | Story cover image fetching |
+| Unsplash | `UNSPLASH_API_KEY` | Story cover image fetching |
 
-AI is used **only** for generation and analysis — all story data, user data, and bookmarks are stored in MongoDB.
+The AI layer and external media assets are used **only** for content generation and analysis — all persistent story data, user profiles, and bookmarks are stored securely in MongoDB.
 
 ---
 


### PR DESCRIPTION
closes #1240 



### Code Diff Preview
```diff
- ### 4. 🤖 AI Layer
- StorySparkAI supports two AI providers — switchable via environment variables:
+ ### 4. 🤖 AI Layer & Media Assets
+ StorySparkAI supports two AI providers and an image asset manager — configured via environment variables:

  | Provider | Env var | Used for |
  |---|---|---|
- | Unsplash | `UNSPLASH_KEY_API` | Story cover image fetching |
+ | Unsplash | `UNSPLASH_API_KEY` | Story cover image fetching |

- AI is used **only** for generation and analysis — all story data, user data, and bookmarks are stored in MongoDB.
+ The AI layer and external media assets are used **only** for content generation and analysis — all persistent story data, user profiles, and bookmarks are stored securely in MongoDB.

This PR addresses and fixes technical typographical errors along with conceptual design inconsistencies inside the architecture overview documentation file (`docs/ARCHITECTURE.md`):

1. **Standardizes Naming Conventions:** Corrects the environment variable string key name from `UNSPLASH_KEY_API` to `UNSPLASH_API_KEY` within the layer table to follow predictable production configuration rules.
2. **Clarifies Component Responsibilities:** Renames the block header to `### 4. 🤖 AI Layer & Media Assets` and rewrites the tracking description footer. The previous iteration stated that the entire layer was restricted to generative AI systems, structurally contradicting the inclusion of the Unsplash static image provider utility.
- [ yes] Documentation update



## Checklist
-{yes ] I have filled in the related issue number when there is one.
- [yes ] I have tested my changes.
- [yes ] I have done a self-review of the code.
