### PR TITLE
fix(backend): bound rate-limit store memory by pruning stale entries

### DIFF
--- a/backend/src/__tests__/rateLimitMiddleware.test.ts
+++ b/backend/src/__tests__/rateLimitMiddleware.test.ts
@@ -121,4 +121,35 @@ describe("storyRateLimiter — store management", () => {
     storyRateLimiter(r2, s2, n2);
     expect((s2 as any).statusCode).toBe(429);
   });
+
+  it("prunes entries whose timestamps are all outside the window (memory-leak fix)", () => {
+    // Bug: store grew unbounded because entries with only stale timestamps
+    // were never deleted. Fix: pruneStaleEntries removes entries with zero
+    // active timestamps whenever a request triggers a prune pass.
+    const nowSpy = jest.spyOn(Date, "now");
+
+    // Anchor to real Date.now() so the module-level lastPruneAt (updated
+    // by previous tests) does not cause a future-pinned time to look
+    // "before" a stale prune watermark.
+    const t0 = Date.now();
+    nowSpy.mockReturnValue(t0);
+    const a = buildMocks("10.0.0.40");
+    storyRateLimiter(a.req, a.res, a.next);
+    expect(getRateLimitStatus("10.0.0.40").count).toBe(1);
+
+    // t = t0 + 120s: well past WINDOW_MS (60s) and PRUNE_INTERVAL_MS (60s).
+    // Any new request will now run the prune pass.
+    nowSpy.mockReturnValue(t0 + 120_000);
+    const b = buildMocks("10.0.0.41");
+    storyRateLimiter(b.req, b.res, b.next);
+
+    // 10.0.0.40's only timestamp is now 120s old → older than the 60s window.
+    // The entry should be deleted, not just stale. getRateLimitStatus
+    // distinguishes the two: deleted → resetInMs=0; stale-but-present → resetInMs=WINDOW_MS.
+    const status = getRateLimitStatus("10.0.0.40");
+    expect(status.count).toBe(0);
+    expect(status.resetInMs).toBe(0);
+
+    nowSpy.mockRestore();
+  });
 });

--- a/backend/src/middlewares/rateLimitMiddleware.ts
+++ b/backend/src/middlewares/rateLimitMiddleware.ts
@@ -7,10 +7,12 @@
  *  • 10 requests / minute  per IP for unauthenticated guests
  *  • Returns 429 + Retry-After header when exceeded
  *  • Zero external dependencies
+ *  • Self-pruning store (bounded memory under long uptime)
  *
  * GSSoC 2026 | feat/rate-limiting-api-key-rotation
  */
 import { Request, Response, NextFunction } from "express";
+import logger from "../utils/logger.util";
 
 interface WindowEntry {
   timestamps: number[];
@@ -18,8 +20,43 @@ interface WindowEntry {
 
 const store = new Map<string, WindowEntry>();
 
-const WINDOW_MS    = 60_000; // 1 minute sliding window
-const MAX_REQUESTS = 10;     // max requests per window
+const WINDOW_MS          = 60_000; // 1 minute sliding window
+const MAX_REQUESTS       = 10;     // max requests per window
+const PRUNE_INTERVAL_MS  = 60_000; // at most one full prune per minute
+let lastPruneAt         = 0;
+
+/**
+ * Prune the in-memory store to prevent unbounded growth.
+ *
+ * Without this, every unique key (IP / user id) that ever hit the
+ * limiter would persist in `store` forever with stale timestamps,
+ * leaking memory for the lifetime of the process. Pruning is
+ * piggy-backed on real traffic and runs at most once per minute so
+ * it has zero steady-state cost on hot paths.
+ */
+function pruneStaleEntries(now: number): void {
+  if (now - lastPruneAt < PRUNE_INTERVAL_MS) return;
+  lastPruneAt = now;
+
+  let removed = 0;
+  let trimmed = 0;
+  for (const [key, entry] of store.entries()) {
+    const active = entry.timestamps.filter((t) => now - t < WINDOW_MS);
+    if (active.length === 0) {
+      store.delete(key);
+      removed++;
+    } else if (active.length !== entry.timestamps.length) {
+      store.set(key, { timestamps: active });
+      trimmed++;
+    }
+  }
+
+  if (removed > 0 || trimmed > 0) {
+    logger.debug(
+      `rateLimitMiddleware: pruned ${removed} empty entries, trimmed ${trimmed} entries`
+    );
+  }
+}
 
 /**
  * Express middleware — apply to any AI generation route:
@@ -40,8 +77,9 @@ export function storyRateLimiter(
     req.ip ??
     "anonymous";
 
-  const now    = Date.now();
-  const entry  = store.get(key) ?? { timestamps: [] };
+  const now   = Date.now();
+  pruneStaleEntries(now);
+  const entry = store.get(key) ?? { timestamps: [] };
 
   // Evict timestamps outside the sliding window
   entry.timestamps = entry.timestamps.filter((t) => now - t < WINDOW_MS);


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Closes #1740
- **Description:** Memory-leak fix in `rateLimitMiddleware` — see below.
- **Screenshots:** N/A (backend-only change; test output pasted below)

## Screenshot (when helpful)

N/A — no UI change. Test run output:

```
PASS src/__tests__/rateLimitMiddleware.test.ts
  storyRateLimiter — basic behaviour
    ✓ allows exactly 10 requests from the same IP
    ✓ blocks the 11th request with 429
    ✓ uses user.id as key for authenticated requests
    ✓ reports correct remaining count via getRateLimitStatus
  storyRateLimiter — X-Forwarded-For spoofing
    ✓ ignores X-Forwarded-For and keys on req.ip
    ✓ does not create separate buckets per X-Forwarded-For value
  storyRateLimiter — store management
    ✓ clearRateLimitStore(key) removes only that key
    ✓ prunes entries whose timestamps are all outside the window (memory-leak fix)

Test Suites: 1 passed, 1 total
Tests:       8 passed, 8 total
```

## What this PR does

**Problem.** `rateLimitMiddleware.ts` keeps a `Map<string, WindowEntry>` (`store`) where each entry is the sliding-window timestamp list for one rate-limit key (per-user `user.id` or per-IP `req.ip`). For every request, the middleware writes the entry back via `store.set(key, entry)` — but the code never deletes entries whose timestamps have *all* expired. On a long-running server, every unique key that ever hit the limiter stays in the map forever, even after the window has rolled over. The map grows unbounded and is never reclaimed.

**Fix.** Add `pruneStaleEntries(now)` that:

1. Throttles itself to **at most once per minute** (using a module-level `lastPruneAt` watermark) so it has zero steady-state cost on the hot path.
2. Iterates `store.entries()`, filters timestamps to the active window, and:
   - **deletes** entries with no active timestamps (the actual leak),
   - **rewrites** entries where some timestamps are stale (keeps the map tidy, prevents the filter+push from running over long stale arrays).

The function is called at the very top of `storyRateLimiter`, *before* the per-request window filter, so it piggy-backs on real traffic — no background timer, no test-isolation headaches, no impact on hot-path latency beyond a single integer compare.

A debug log (`rateLimitMiddleware: pruned N empty entries, trimmed M entries`) is emitted via the existing `logger` when work was done, so it stays silent on idle servers.

**Test.** New unit test `prunes entries whose timestamps are all outside the window (memory-leak fix)` anchors `Date.now()` to a real timestamp, advances by 120 s, and asserts that the stale entry is **deleted** (not just stale-but-present), distinguishing the two states via `getRateLimitStatus(...).resetInMs` (0 if deleted, `WINDOW_MS` if stale-but-present).

**Files touched.**

- `backend/src/middlewares/rateLimitMiddleware.ts` — +46 / −4 lines
- `backend/src/__tests__/rateLimitMiddleware.test.ts` — +31 / 0 lines

## Type of change

- [x] Bug fix
- [x] Code refactor
- [ ] New feature
- [ ] Documentation update

## Related issue

Closes #1740

## More screenshots (optional)

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes (`npx jest src/__tests__/rateLimitMiddleware.test.ts` — 8/8 pass; full backend suite has 5 pre-existing failures in `ai_model.service.test.ts` and `quota.integration.test.ts` that are unrelated to this change and reproduce on `main`).
- [x] I have done a self-review of the code.

---

### Contributor note

This PR is submitted as part of **GirlScript Summer of Code 2026 (GSSoC'26)**. I would appreciate the **`gssoc'26`** label and a difficulty rating — this is a small, well-scoped backend bug fix that does not require knowledge of the broader codebase, so I would suggest **`level:beginner`** (PR < 100 lines, single concern, no new public API).

AI tool disclosure: I used an LLM as a research/code-review assistant to help identify the memory leak in the existing sliding-window implementation and to draft this PR description. All code, test, and review decisions were made by me.
