### PR TITLE
fix: prevent privilege escalation through user profile update endpoint

### DIFF
--- a/backend/src/app/modules/auth/auth.controller.ts
+++ b/backend/src/app/modules/auth/auth.controller.ts
@@ -92,6 +92,7 @@ const changePassword = catchAsync(async (req: Request, res: Response) => {
     message: "Password changed successfully. All previous sessions have been invalidated.",
     data: null,
   });
+});
 
 const forgotPassword = catchAsync(async (req: Request, res: Response) => {
   const { email } = req.body;

--- a/backend/src/app/modules/auth/auth.router.ts
+++ b/backend/src/app/modules/auth/auth.router.ts
@@ -47,7 +47,6 @@ router.post(
     ENUM_USER_ROLE.ADMIN,
     ENUM_USER_ROLE.SUPER_ADMIN
   ),
-);
   AuthController.changePassword
 );
 // Forgot Password API route

--- a/backend/src/app/modules/user/user.validation.ts
+++ b/backend/src/app/modules/user/user.validation.ts
@@ -63,12 +63,15 @@ const updateUser = z.object({
               instagram: z.string().optional(),
             })
             .partial()
+            .strict()
             .optional(),
         })
         .partial()
+        .strict()
         .optional(),
     })
-    .partial(),
+    .partial()
+    .strict(),
 });
 
 export const UserValidator = {


### PR DESCRIPTION
Description
This PR fixes a privilege escalation vulnerability in the user profile update flow.

Previously, authenticated users could submit privileged fields such as:

role
subscriptionType
through the self-service profile update endpoint.

Since these fields were persisted directly, users could obtain elevated permissions after re-authentication.

Changes Made
Restricted profile updates to user-editable fields only.
Prevented modification of authorization-related fields.
Preserved existing profile update functionality for legitimate user data.
Improved validation around profile update requests.
Issue Fixed
Users should only be able to modify their own profile information and must not be able to alter permission-related attributes through the profile update endpoint.

Testing
Verified normal profile updates continue to work.
Verified privileged fields are rejected/ignored.
Verified users cannot gain elevated permissions through profile updates.
Closes https://github.com/ronisarkarexe/story-spark-ai/issues/1613