### PR TITLE
feat: Add Story Export as Markdown File (#1774)

### DIFF
--- a/backend/src/app/modules/auth/auth.service.ts
+++ b/backend/src/app/modules/auth/auth.service.ts
@@ -16,8 +16,6 @@ import { OTPModel } from "../verify_email/otp.model";
 import { RefreshSession } from "./refresh_session.model";
 import { VerifyEmailService } from "../verify_email/verify_email.service";
 import { GamificationService } from "../gamification/gamification.service";
-import { USER_STATUS } from "../../../enums/user_status";
-import { SUBSCRIPTION_TYPE } from "../../../enums/subscription_type";
 
 const googleClient = new OAuth2Client(config.google_client_id);
 

--- a/frontend/src/components/stories/stories.component.tsx
+++ b/frontend/src/components/stories/stories.component.tsx
@@ -1,4 +1,4 @@
-﻿import React, { useState, useEffect, useRef, useMemo } from "react";
+import React, { useState, useEffect, useRef, useMemo } from "react";
 import StoriesViewComponent, { IStories } from "./stories.view.component";
 import RecentPromptsPanel from "./RecentPromptsPanel";
 import { Link, useLocation, useNavigate } from "react-router-dom";
@@ -1028,11 +1028,11 @@ useEffect(() => {
                     <div className="flex items-center justify-between mt-1 px-1">
                       {isOverLimit ? (
                         <p className="text-xs text-red-400 flex items-center gap-1">
-                          <span>âš </span> {text.characterLimit}
+                          <span>⚠️</span> {text.characterLimit}
                         </p>
                       ) : isNearLimit ? (
                         <p className="text-xs text-yellow-400 flex items-center gap-1">
-                          <span>âš </span>{" "}
+                          <span>⚠️</span>{" "}
                           {MAX_PROMPT_LENGTH - textareaValue.length} {text.charactersRemaining}
                         </p>
                       ) : (

--- a/frontend/src/components/stories/stories.view.component.tsx
+++ b/frontend/src/components/stories/stories.view.component.tsx
@@ -1,4 +1,4 @@
-﻿import React, { useEffect, useState, useRef, useMemo } from "react";
+import React, { useEffect, useState, useRef, useMemo } from "react";
 import { getShortenedText, ITopicData, topicsData, getWordCount, SELECTED_TOPIC_CLASSES } from "./stories.utils";
 import toast, { Toaster } from "react-hot-toast";
 import { useCreatePostMutation, useDeletePostMutation } from "../../redux/apis/post.api";
@@ -643,7 +643,8 @@ const [, setShowRemix] = useState<boolean>(false);
 };
 
 const getSafeFileName = (title: string, ext: string) => {
-  return `${title.replace(/[^a-z0-9]/gi, "_").toLowerCase()}.${ext}`;
+  const cleanTitle = title.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  return `${cleanTitle || "story"}.${ext}`;
 };
 
 const handleExportMarkdown = () => {
@@ -811,7 +812,7 @@ if (isLoading) {
                   onClick={handleExportMarkdown}
                   disabled={!selectedStory}
                 >
-                  ⬇️ Export Markdown
+                  ⬇️ Export as Markdown
                 </button>
                 <button
                   type="button"

--- a/frontend/src/components/story/StoryWorkspace.tsx
+++ b/frontend/src/components/story/StoryWorkspace.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import { useSelector } from "react-redux";
+import toast, { Toaster } from "react-hot-toast";
 
 import { RootState } from "../../redux/store";
+import { getUserInfo } from "../../services/auth.service";
 
 import ChapterSidebar from "./ChapterSidebar";
 import StoryViewer from "./StoryViewer";
@@ -11,6 +13,44 @@ const StoryWorkspace = () => {
   const currentStory = useSelector(
     (state: RootState) => state.story.currentStory
   );
+
+  const handleExportMarkdown = () => {
+    if (!currentStory) {
+      toast.error("No story available to export.");
+      return;
+    }
+    try {
+      const title = currentStory.title || "Story";
+      const user = getUserInfo();
+      const authorName = user?.name || "Anonymous";
+      const isoDate = new Date().toISOString().split("T")[0];
+      
+      let chaptersContent = "";
+      if (currentStory.chapters && currentStory.chapters.length > 0) {
+        currentStory.chapters.forEach((chapter) => {
+          chaptersContent += `## ${chapter.title}\n\n${chapter.content}\n\n`;
+        });
+      } else {
+        chaptersContent = "*No chapters in this story.*";
+      }
+
+      const markdownContent = `---\ntitle: "${title.replace(/"/g, '\\"')}"\nauthor: "${authorName.replace(/"/g, '\\"')}"\ndate: "${isoDate}"\n---\n\n# ${title}\n\n${chaptersContent}`;
+      const blob = new Blob([markdownContent], { type: "text/markdown;charset=utf-8;" });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      const cleanTitle = title.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+      link.setAttribute("download", `${cleanTitle || "story"}.md`);
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+      toast.success("Markdown downloaded!");
+    } catch (error) {
+      console.error(error);
+      toast.error("Failed to export Markdown.");
+    }
+  };
 
   if (!currentStory) {
     return (
@@ -22,11 +62,24 @@ const StoryWorkspace = () => {
 
   return (
     <div className="flex bg-black h-screen">
+      <Toaster position="top-right" reverseOrder={false} />
       <ChapterSidebar
         chapters={currentStory.chapters}
       />
 
       <div className="flex flex-col flex-1">
+        <div className="flex justify-between items-center p-4 border-b border-zinc-800 bg-zinc-900">
+          <h2 className="text-white text-lg font-bold">{currentStory.title}</h2>
+          <div className="flex items-center gap-3">
+            <button
+              onClick={handleExportMarkdown}
+              className="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded shadow transition flex items-center gap-2 font-semibold cursor-pointer"
+            >
+              ⬇️ Export as Markdown
+            </button>
+          </div>
+        </div>
+
         <StoryViewer
           chapters={currentStory.chapters}
         />

--- a/frontend/src/models/user.ts
+++ b/frontend/src/models/user.ts
@@ -31,4 +31,8 @@ export interface User {
   createdAt: string;
   updatedAt: string;
   profile: UserProfile;
+  writingGoals?: {
+    dailyWordCount: number;
+    weeklyWordCount: number;
+  };
 }


### PR DESCRIPTION
### Describe the feature
This PR implements the requested "Export as Markdown" feature directly from the application. It allows writers and content creators to download generated stories or active workspace sessions in a portable, readable `.md` file.

### Key Changes
1. **Stories View Component (`stories.view.component.tsx`)**:
   - Renamed the button label from "⬇️ Export Markdown" to "⬇️ Export as Markdown" for exact alignment with acceptance criteria.
   - Refined filename cleaning logic to avoid leading/trailing hyphens.
2. **Story Workspace (`StoryWorkspace.tsx`)**:
   - Introduced a matching "⬇️ Export as Markdown" button in the header.
   - Implemented `handleExportMarkdown` to compile all chapters of the active story sequentially into a single Markdown file.
   - Included frontmatter metadata containing title, author name, and date.
   - Used `Toaster` and `toast` for successful file download feedback.

### Acceptance Criteria Verified
- [x] An "Export as Markdown" button is visible after story generation.
- [x] Clicking the button downloads the story as a `.md` file.
- [x] The downloaded file contains the story title and chapter content.
- [x] The filename follows a readable format (e.g., `story-title.md`).
- [x] Build successfully passes type checks and bundles correctly.

Closes #1774