### PR TITLE
fix: remove duplicate help route and update footer component link

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -103,7 +103,6 @@ const router = createBrowserRouter([
       { path: "forgot-password", element: <ForgotPasswordComponent /> },
       { path: "pricing", element: <PricingComponent /> },
       { path: "post/:id", element: <PostDetailsComponent /> },
-      { path: "help", element: <HelpCenterComponent /> },
       { path: "contact-us", element: <Contact /> },
       { path: "about-us", element: <AboutUsComponent /> },
       { path: "career", element: <CareerComponent /> },

--- a/frontend/src/components/footer/footer.component.tsx
+++ b/frontend/src/components/footer/footer.component.tsx
@@ -53,7 +53,7 @@ const FooterComponent = () => {
 
   const resourceLinks = [
     { label: "Blog",         to: "/blog"        },
-    { label: "Help Center",  to: "/help"        },
+    { label: "Help Center",  to: "/help-center"    },
     // ─── FIXED: Changed from "/community" to match the secure dashboard sub-route ───
     { label: "Community",    to: "/dashboard/community" },
     { label: "Contributors", to: "/contributors"},


### PR DESCRIPTION
program: gssoc

## description

## What this PR does

This PR resolves a duplicate routing issue where both `/help` and `/help-center` paths were rendering the same `HelpCenterComponent` in the frontend application. 

### Fixes implemented:
1. Removed the redundant `path: "help"` route configuration from `frontend/src/App.tsx`.
2. Updated the "Help Center" navigation link from `to="/help"` to the descriptive canonical path `to="/help-center"` inside the footer component (`frontend/src/components/footer/footer.component.tsx`).

This cleans up the frontend navigation architecture and prevents broken route alias mappings across the user interface.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #1771


## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.