### PR TITLE
fix: add validateRequest middleware to remix/translate endpoints and fix socket namespace

### DIFF
--- a/backend/src/app/modules/ai_model/ai_model.router.ts
+++ b/backend/src/app/modules/ai_model/ai_model.router.ts
@@ -66,6 +66,7 @@ router.post(
   aiGenerationRateLimiter,
   auth(),
   checkRequestLimit(),
+  validateRequest(AIModelValidator.aiRemix),
   AiModelController.aiModelRemix
 );
 
@@ -73,6 +74,7 @@ router.post(
 router.post(
   "/remix-free",
   freeAiRateLimiter,
+  validateRequest(AIModelValidator.aiRemix),
   AiModelController.aiFreeModelRemix
 );
 
@@ -84,6 +86,7 @@ router.post(
   aiGenerationRateLimiter,
   auth(),
   checkRequestLimit(),
+  validateRequest(AIModelValidator.aiTranslate),
   AiModelController.aiModelTranslate
 );
 
@@ -91,6 +94,7 @@ router.post(
 router.post(
   "/translate-free",
   freeAiRateLimiter,
+  validateRequest(AIModelValidator.aiTranslate),
   AiModelController.aiFreeModelTranslate
 );
 

--- a/backend/src/app/modules/ai_model/ai_model.validation.ts
+++ b/backend/src/app/modules/ai_model/ai_model.validation.ts
@@ -41,8 +41,31 @@ const aiChat = z.object({
     })).optional(),
   }),
 });
+
+const REMIX_TYPES = ["genre_shift", "tone_shift", "perspective_shift"] as const;
+
+const aiRemix = z.object({
+  body: z.object({
+    title: z.string({ required_error: "Title is required!" }),
+    content: z.string().min(10).max(10000),
+    tag: z.string({ required_error: "Tag is required!" }),
+    remixType: z.enum(REMIX_TYPES, { required_error: "Remix type is required!" }),
+    remixOption: z.string().max(200).optional(),
+    language: z.string().max(50).optional(),
+  }),
+});
+
+const aiTranslate = z.object({
+  body: z.object({
+    title: z.string({ required_error: "Title is required!" }),
+    content: z.string().min(10).max(10000),
+    language: z.string({ required_error: "Language is required!" }),
+  }),
+});
 export const AIModelValidator = {
   aiModel,
   aiAlternateEndings,
   aiChat,
+  aiRemix,
+  aiTranslate,
 };

--- a/frontend/src/socket/socket.oi.ts
+++ b/frontend/src/socket/socket.oi.ts
@@ -25,7 +25,7 @@ export const connectSocket = (): Socket => {
     console.warn("[Story Spark] User not authenticated. Cannot connect to Socket.IO.");
     return null as unknown as Socket;
   }
-socketIoInstance = io(`${socketUrl}/collab`, {
+socketIoInstance = io(socketUrl, {
   
     transports: ["websocket", "polling"],
     autoConnect: false,


### PR DESCRIPTION

## Before you open this PR

- **Issue:** Closes #1770
- also closes #1759 
- **Description:** The shared socket in `socket.oi.ts` was hardcoded to connect to `/collab` namespace. `useNotifications.ts` uses this same socket instance to listen for `notification:new` and `pushNotification` events, but the backend emits these from the root namespace. This mismatch caused real-time notifications to silently fail for all users.
- **Screenshots:** N/A — no UI changes, backend socket config fix only.

## What this PR does
Changed `io(\`${socketUrl}/collab\`, {...})` to `io(socketUrl, {...})` so the shared socket connects to root namespace. The collab feature should create its own separate socket instance when needed.

## Type of change
- [x] Bug fix

## Related issue
Closes #1770
also closes #1759 

## Checklist
- [x] I have filled in the related issue number.
- [x] I have done a self-review of the code.
- [x] I have tested my changes.
- [x] N/A — no screenshots needed for this fix.