### PR TITLE
fix: set status and subscriptionType explicitly on google auto-created users

### DIFF
--- a/backend/src/app/modules/auth/auth.service.ts
+++ b/backend/src/app/modules/auth/auth.service.ts
@@ -10,6 +10,8 @@ import logger from "../../../utils/logger.util";
 import config from "../../../config";
 import ApiError from "../../../errors/api_error";
 import { IUser } from "../user/user.interface";
+import { USER_STATUS } from "../../../enums/user_status";
+import { SUBSCRIPTION_TYPE } from "../../../enums/subscription_type";
 import { OTPModel } from "../verify_email/otp.model";
 import { RefreshSession } from "./refresh_session.model";
 import { VerifyEmailService } from "../verify_email/verify_email.service";
@@ -250,6 +252,8 @@ const googleLogin = async (payload: { token: string }) => {
       const newUser: Partial<IUser> = {
         email: email as string,
         name: (googleName || email || "Google User").slice(0, 100),
+        status: USER_STATUS.ACTIVE,
+        subscriptionType: SUBSCRIPTION_TYPE.FREE,
         profile: {
           avatar: (picture as string) || "",
           bio: "",


### PR DESCRIPTION
## Screenshot (when helpful)

N/A. Small backend object-construction change. Verified via type check.

## What this PR does

When `googleLogin()` auto-creates a user for a first-time Google sign-in, the `newUser` object now sets `status` and `subscriptionType` explicitly:

- `status: USER_STATUS.ACTIVE`
- `subscriptionType: SUBSCRIPTION_TYPE.FREE`

These were previously filled by the Mongoose schema defaults (`Active` / `free`), so there is no behavior change. Setting them at the call site makes the created-user shape self-documenting and removes a hidden dependency on the schema default (if the default were ever removed or changed, Google users would otherwise silently get a wrong value).

## How I tested

`tsc` on the backend: `auth.service.ts` is clean, no new errors. `SUBSCRIPTION_TYPE.FREE` and `USER_STATUS.ACTIVE` type-check against the `IUser` fields.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Documentation update

## Related issue

Closes #1792

## More screenshots (optional)

N/A.

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
