### PR TITLE
fix: read report reporter id from token._id instead of missing userId

### DIFF
--- a/backend/src/app/modules/report/report.controller.ts
+++ b/backend/src/app/modules/report/report.controller.ts
@@ -3,9 +3,11 @@ import catchAsync from "../../../shared/catch_async";
 import sendResponse from "../../../shared/send_response";
 import { ReportService } from "./report.service";
 import { ReportTargetType } from "../../../enums/report.enum";
+import { ITokenPayload } from "../../../interfaces/token";
 
 const createReport = catchAsync(async (req: Request, res: Response) => {
-  const reportedBy = req.user?.userId;
+  const token = req.user as ITokenPayload;
+  const reportedBy = token?._id;
   const payload = { ...req.body, reportedBy };
   const result = await ReportService.createReport(payload);
   sendResponse(res, {


### PR DESCRIPTION
## Screenshot (when helpful)

N/A. Backend controller fix. Verified via type check and a runtime smoke test, described below.

## What this PR does

Fixes report submission, which was broken for every user.

`createReport` read the reporter id as `req.user?.userId`, but the JWT payload written to `req.user` by the auth middleware contains `_id`, not `userId`. So `reportedBy` was always `undefined`, and since the `Report` model defines `reportedBy` as `required: true`, `Report.create()` failed Mongoose validation on every request.

The fix reads `_id` from the token (cast to `ITokenPayload`, the shape the middleware actually sets), matching the convention already used by `story_version.controller` (`user._id`), `payment.controller` (`token._id`), and `notification.service`:

```ts
const token = req.user as ITokenPayload;
const reportedBy = token?._id;
```

## How I tested

1. `tsc` on the backend: `report.controller.ts` is clean, no new errors.
2. Runtime smoke test with a token shaped like `buildClaims` (has `_id`, no `userId`): the old `req.user.userId` read is `undefined`, while the new `token._id` read yields the valid id string. Confirms the fix produces a valid `reportedBy`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #1795

## More screenshots (optional)

N/A.

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
