### PR TITLE
fix(auth): prevent blocked and inactive users from logging in

### DIFF
--- a/backend/src/app/modules/auth/auth.service.ts
+++ b/backend/src/app/modules/auth/auth.service.ts
@@ -14,8 +14,18 @@ import { OTPModel } from "../verify_email/otp.model";
 import { RefreshSession } from "./refresh_session.model";
 import { VerifyEmailService } from "../verify_email/verify_email.service";
 import { GamificationService } from "../gamification/gamification.service";
+import { USER_STATUS } from "../../../enums/user_status";
 
 const googleClient = new OAuth2Client(config.google_client_id);
+
+const validateUserStatus = (status?: string) => {
+  if (status === USER_STATUS.BLOCKED) {
+    throw new ApiError(httpStatus.FORBIDDEN, "Your account has been blocked.");
+  }
+  if (status === USER_STATUS.INACTIVE) {
+    throw new ApiError(httpStatus.FORBIDDEN, "Your account is inactive.");
+  }
+};
 
 // Token claims; tokenVersion enables global session revocation.
 const buildClaims = (user: any) => ({
@@ -57,6 +67,8 @@ const login = async (payload: AuthModel & { rememberMe?: boolean }) => {
   if (!isExistUser) {
     throw new ApiError(httpStatus.NOT_FOUND, "User not found!");
   }
+
+  validateUserStatus(isExistUser.status);
 
   // Check if user has password (Google users might not)
   if (!isExistUser.password) {
@@ -264,6 +276,8 @@ const googleLogin = async (payload: { token: string }) => {
 
       user = await User.create(newUser);
     }
+
+    validateUserStatus(user.status);
 
     const accessToken = issueAccessToken(user);
     const refreshTokenData = await issueRefreshToken(user);


### PR DESCRIPTION
## Fixes #1786

### Summary

Added user status validation during authentication to prevent users with non-active accounts from obtaining access and refresh tokens.

### Changes

- Imported `USER_STATUS` in `auth.service.ts`
- Added a reusable `validateUserStatus()` helper
- Applied status validation in:
  - `login()`
  - `googleLogin()`
- Return HTTP 403 for:
  - Blocked accounts
  - Inactive accounts

### Validation

- TypeScript compilation passes
- Existing login flow for active users remains unchanged
- Blocked users are denied authentication
- Inactive users are denied authentication
- No changes to JWT generation or session handling

### Security Impact

Prevents blocked and inactive accounts from authenticating and receiving valid access/refresh tokens.