### PR TITLE
fix(security): guard dashboard admin routes and fix settings access

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -174,10 +174,15 @@ const router = createBrowserRouter([
         children: [
           { index: true, element: <DashboardComponent /> },
           { path: "profile", element: <ProfileComponent /> },
-          { path: "writers", element: <WriterApplicationComponent /> },
-          { path: "users", element: <UserComponent /> },
           {
-            element: <ProtectedRoute allowedRoles={[USER_ROLE.USER, USER_ROLE.WRITER]} />,
+            element: <ProtectedRoute allowedRoles={ELEVATED_ADMIN_ROLES} />,
+            children: [
+              { path: "writers", element: <WriterApplicationComponent /> },
+              { path: "users", element: <UserComponent /> },
+            ],
+          },
+          {
+            element: <ProtectedRoute allowedRoles={ALL_ROLES} />,
             children: [
               { path: "settings", element: <SettingComponent /> },
               {


### PR DESCRIPTION
## Description

Two route guard fixes in the dashboard:

1. **Under-guarded admin routes**: \/dashboard/writers\ and \/dashboard/users\ were direct children of the outer \ALL_ROLES\ guard, allowing any logged-in user to navigate to admin-only pages (CWE-863). Wrapped them in a \ProtectedRoute\ with \ELEVATED_ADMIN_ROLES\.

2. **Over-guarded settings route**: \/dashboard/settings\ was wrapped in \[USER, WRITER]\, explicitly excluding \ADMIN\ and \SUPER_ADMIN\ from accessing their own settings. Changed to \ALL_ROLES\.

Closes #1703

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings