### PR TITLE
fix(auth): clear OTP rate limit attempts after successful verification

### DIFF
--- a/backend/src/app/modules/verify_email/otp.rate-limiter.middleware.ts
+++ b/backend/src/app/modules/verify_email/otp.rate-limiter.middleware.ts
@@ -93,3 +93,11 @@ export const otpRateLimiter = (
 
   next();
 };
+
+export const clearOtpAttempts = (email: string) => {
+  const normalizedEmail = email.toString().toLowerCase().trim();
+  const key = `otp_${normalizedEmail}`;
+  if (rateLimitStore[key]) {
+    delete rateLimitStore[key];
+  }
+};

--- a/backend/src/app/modules/verify_email/verify_email.service.ts
+++ b/backend/src/app/modules/verify_email/verify_email.service.ts
@@ -6,6 +6,7 @@ import config from "../../../config";
 import httpStatus from "http-status";
 import { OTPModel } from "./otp.model";
 import crypto from "crypto";
+import { clearOtpAttempts } from "./otp.rate-limiter.middleware";
 
 const transporter = nodemailer.createTransport({
   service: "Gmail",
@@ -164,6 +165,9 @@ const VerifyOtp = async (payload: IVerifyOtpBody) => {
   storedOtpRecord.verificationToken = verificationToken;
   storedOtpRecord.verificationTokenExpires = verificationTokenExpires;
   await storedOtpRecord.save();
+
+  // Clear memory rate limit attempts on success
+  clearOtpAttempts(email);
 
   return { 
     verified: true,


### PR DESCRIPTION
## What this PR does

This PR fixes an issue where OTP verification attempts remained stored in the in-memory rate limiter even after a user successfully verified their email.

Previously, failed OTP attempts were tracked correctly, but a successful verification did not clear the associated rate-limit record. As a result, users could carry over historical failed attempts into future verification flows and potentially encounter rate limits unexpectedly.

### Changes made

* Added a new `clearOtpAttempts(email)` helper in `otp.rate-limiter.middleware.ts`.
* Normalized the email before generating the cache key.
* Removed the stored rate-limit entry when a user successfully verifies their OTP.
* Imported and invoked `clearOtpAttempts(email)` in `verify_email.service.ts` immediately after successful OTP validation.

### Result

After a successful OTP verification:

* Rate-limit attempts are reset.
* Stale attempt history is removed.
* Future OTP verification flows start with a clean state.
* Memory usage is reduced by removing obsolete entries.

---

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

---

## Related issue

Fixes #1820 

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.
