### PR TITLE
refactor(auth): explicitly set status and subscriptionType for auto-c…

### DIFF
--- a/backend/src/app/modules/auth/auth.service.ts
+++ b/backend/src/app/modules/auth/auth.service.ts
@@ -15,6 +15,7 @@ import { RefreshSession } from "./refresh_session.model";
 import { VerifyEmailService } from "../verify_email/verify_email.service";
 import { GamificationService } from "../gamification/gamification.service";
 import { USER_STATUS } from "../../../enums/user_status";
+import { SUBSCRIPTION_TYPE } from "../../../enums/subscription_type";
 
 const googleClient = new OAuth2Client(config.google_client_id);
 
@@ -262,6 +263,8 @@ const googleLogin = async (payload: { token: string }) => {
       const newUser: Partial<IUser> = {
         email: email as string,
         name: (googleName || email || "Google User").slice(0, 100),
+        status: USER_STATUS.ACTIVE,
+        subscriptionType: SUBSCRIPTION_TYPE.FREE,
         profile: {
           avatar: (picture as string) || "",
           bio: "",


### PR DESCRIPTION
---

## Explicitly set `status` and `subscriptionType` on Google auto-created users

Closes #1792

### What changed

In `googleLogin()` within `auth.service.ts`, when a first-time Google sign-in auto-creates a user, the `newUser` object now explicitly sets:

- `status: USER_STATUS.ACTIVE`
- `subscriptionType: SUBSCRIPTION_TYPE.FREE`

### Why

These fields were previously filled implicitly by Mongoose schema defaults. While there's **no functional bug today**, setting them explicitly:

- Makes the auto-created Google user shape **self-documenting** and consistent with the rest of the codebase
- Removes a **hidden dependency** on schema defaults — if someone later changes or removes the default on `status` or `subscriptionType`, Google users would silently get a wrong/empty value
- Aligns with the codebase treating these as meaningful fields (e.g., login now rejects non-Active users via `validateUserStatus`)

### Impact

- **Zero behavior change** — the explicit values match the existing schema defaults
- Low-severity, defensive clarity improvement

---
