### PR TITLE
fix: prevent double-refund in QuotaRefundGuard and simplify runWithQu…

### DIFF
--- a/backend/src/app/modules/ai_model/quota.lifecycle.ts
+++ b/backend/src/app/modules/ai_model/quota.lifecycle.ts
@@ -15,12 +15,7 @@ export class QuotaRefundGuard {
       return;
     }
     this.refunded = true;
-    try {
-      await this.refund();
-    } catch (error) {
-      this.refunded = false;
-      throw error;
-    }
+    await this.refund();
   }
 
   get hasRefunded(): boolean {
@@ -37,21 +32,19 @@ export const createGuestQuotaGuard = (guestId: string): QuotaRefundGuard =>
 /**
  * Runs an operation and refunds reserved quota in `finally` when it does not complete successfully.
  */
+
 export const runWithQuotaCleanup = async <T>(
-  guard: QuotaRefundGuard,
-  operation: () => Promise<T>
+    guard: QuotaRefundGuard,
+    operation: () => Promise<T>
 ): Promise<T> => {
-  let succeeded = false;
-  try {
-    const result = await operation();
-    succeeded = true;
-    return result;
-  } finally {
-    if (!succeeded) {
-      await guard.refundOnce();
+    try {
+        return await operation();
+    } catch (error) {
+        await guard.refundOnce();
+        throw error;
     }
-  }
 };
+
 
 export const assertSuccessfulGeneration = (
   result: unknown,


### PR DESCRIPTION
## Screenshot (when helpful)
N/A — no UI changes, pure logic fix

## What this PR does
Removes the `this.refunded = false` reset in `QuotaRefundGuard.refundOnce()` 
that allowed the guard to reopen after a failed refund attempt, which could 
cause a double-refund if `refundOnce()` was called again.

Also simplifies `runWithQuotaCleanup` by replacing the `succeeded flag + finally` 
pattern with a cleaner `try/catch + rethrow` approach. Same behavior, more readable.

## Type of change
- [x] Bug fix
- [x] Code refactor

## Related issue
Closes #1854 

## More screenshots (optional)
N/A

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.