### PR TITLE
fix: add pagination to story version history endpoint

### DIFF
--- a/backend/src/app/modules/story_version/story_version.controller.ts
+++ b/backend/src/app/modules/story_version/story_version.controller.ts
@@ -5,6 +5,8 @@ import sendResponse from "../../../shared/send_response";
 import { StoryVersionService } from "./story_version.service";
 import ApiError from "../../../errors/api_error";
 import { routeParam } from "../../../shared/route_param";
+import { paginationFields } from "../../../constants/pagination";
+import pick from "../../../shared/pick";
 
 const getVersionsByStoryId = catchAsync(async (req: Request, res: Response) => {
   const id = routeParam(req.params.id);
@@ -13,13 +15,21 @@ const getVersionsByStoryId = catchAsync(async (req: Request, res: Response) => {
     throw new ApiError(httpStatus.UNAUTHORIZED, "User is not authorized");
   }
 
-  const result = await StoryVersionService.getVersionsByStoryId(id, user._id);
-  sendResponse(res, {
-    statusCode: httpStatus.OK,
-    success: true,
-    message: "Story version timeline retrieved successfully!",
-    data: result,
-  });
+  const pagination = pick(req.query, paginationFields);
+
+const result = await StoryVersionService.getVersionsByStoryId(
+  id,
+  user._id,
+  pagination
+);
+
+sendResponse(res, {
+  statusCode: httpStatus.OK,
+  success: true,
+  message: "Story version timeline retrieved successfully!",
+  data: result.data,
+  meta: result.meta,
+});
 });
 
 const getVersionById = catchAsync(async (req: Request, res: Response) => {

--- a/backend/src/app/modules/story_version/story_version.service.ts
+++ b/backend/src/app/modules/story_version/story_version.service.ts
@@ -6,6 +6,11 @@ import { Post } from "../post/post.model";
 import { StoryVersion } from "./story_version.model";
 import { IStoryVersion } from "./story_version.interface";
 import { IPost } from "../post/post.interface";
+import paginationHelper from "../../../utils/pagination_helper";
+import {
+  IPaginationOptions,
+  IGenericResponse,
+} from "../../../interfaces/pagination";
 
 const createVersionSnapshot = async (
   storyId: string,
@@ -58,8 +63,10 @@ const createVersionSnapshot = async (
 
 const getVersionsByStoryId = async (
   storyId: string,
-  userId: string
-): Promise<IStoryVersion[]> => {
+  userId: string,
+  pagination: IPaginationOptions
+): Promise<IGenericResponse<IStoryVersion[]>> => {
+  const { page, limit, skip } = paginationHelper(pagination);
   const post = await Post.findById(storyId);
   if (!post) {
     throw new ApiError(httpStatus.NOT_FOUND, "Story not found!");
@@ -70,7 +77,21 @@ const getVersionsByStoryId = async (
     throw new ApiError(httpStatus.FORBIDDEN, "You do not have access to this story history!");
   }
 
-  return await StoryVersion.find({ storyId }).sort({ versionNumber: -1 });
+const data = await StoryVersion.find({ storyId })
+  .sort({ versionNumber: -1 })
+  .skip(skip)
+  .limit(limit);
+
+const total = await StoryVersion.countDocuments({ storyId });
+
+return {
+  meta: {
+    page,
+    limit,
+    total,
+  },
+  data,
+};
 };
 
 const getVersionById = async (


### PR DESCRIPTION
## Related Issue

Closes #1808

## Summary

Added pagination support to the story version history endpoint to prevent unbounded MongoDB queries as story edit history grows.

## Changes Made

* Added pagination query handling in `story_version.controller.ts`
* Reused the existing project pagination utilities (`paginationHelper`, `IPaginationOptions`)
* Added `.skip()` and `.limit()` to the story version query
* Added pagination metadata (`page`, `limit`, `total`)
* Updated the API response to return paginated data and meta information

## Before

`getVersionsByStoryId` returned all versions for a story:

```ts
StoryVersion.find({ storyId }).sort({ versionNumber: -1 });
```

This resulted in unbounded MongoDB reads as version history increased.

## After

The endpoint now returns paginated results using the project's standard pagination pattern.

## Validation

* Backend TypeScript build passes successfully
* Pagination metadata is returned with the response
* Query results are limited using `skip` and `limit`
* Existing sort order is preserved
