### PR TITLE
Fix dead monthly quota reset cron on serverless deployments

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -9,7 +9,7 @@ import helmet from "helmet";
 import rateLimit from "express-rate-limit";
 import cors from "cors";
 import httpStatus from "http-status";
-import cron from "node-cron";
+
 import cookieParser from "cookie-parser";
 import config from "./config";
 import { Routers } from "./router";
@@ -75,14 +75,5 @@ app.use((req: Request, res: Response, _next: NextFunction) => {
 
 app.use(globalErrorHandler);
 
-if (!process.env.VERCEL) {
-  cron.schedule("0 0 1 * *", async () => {
-    try {
-      await User.updateMany({}, { $set: { requestsThisMonth: 0 } });
-    } catch (error) {
-      console.error("Failed to reset request counts:", error);
-    }
-  });
-}
 
 export default app;


### PR DESCRIPTION
## What this PR does

Removes the monthly quota-reset cron job from `backend/src/app.ts`.

### Why

The cron job is wrapped in `if (!process.env.VERCEL)` and therefore never runs on Vercel deployments. Additionally, scheduled cron execution inside application processes is unreliable on serverless platforms.

Monthly quota enforcement is already handled correctly by the lazy reset logic in `quota.service.ts`, making the cron job redundant.

### Changes made

* Removed the unused monthly quota-reset cron block from `app.ts`
* Removed related unused imports
* Preserved existing quota enforcement behavior

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

## Related issue

Closes #1664

## Screenshots

N/A – backend-only change.

## Checklist

* [x] N/A for screenshots (backend-only change)
* [x] Related issue linked
* [x] Tested changes
* [x] Self-reviewed code
