### PR TITLE
fix: bypass confirmPassword validation checks on OTP step

### DIFF
--- a/frontend/src/components/signup/signup.component.tsx
+++ b/frontend/src/components/signup/signup.component.tsx
@@ -293,10 +293,10 @@ const SignUpComponent = () => {
                 autoComplete="name"
                 validation={{
                   required: "Name is required",
-                minLength: {
-                value: 2,
-                message: "Name must be at least 2 characters",
-                },
+                  minLength: {
+                    value: 2,
+                    message: "Name must be at least 2 characters",
+                  },
                   pattern: {
                     value: /^[A-Za-z0-9\s._]+$/,
                     message:
@@ -331,54 +331,62 @@ const SignUpComponent = () => {
               />
 
               {password?.length > 0 && (
-              <div className="space-y-3 -mt-2 min-w-0 overflow-hidden">
-                <div
-                  className="w-full h-2 bg-slate-700 rounded-full overflow-hidden"
-                  role="progressbar"
-                  aria-valuenow={passedChecks}
-                  aria-valuemin={0}
-                  aria-valuemax={PASSWORD_REQUIREMENTS.length}
-                  aria-label="Password strength"
-                >
+                <div className="space-y-3 -mt-2 min-w-0 overflow-hidden">
                   <div
-                    className={`h-full transition-all duration-300 ${barColor} ${barWidth}`}
-                  ></div>
+                    className="w-full h-2 bg-slate-700 rounded-full overflow-hidden"
+                    role="progressbar"
+                    aria-valuenow={passedChecks}
+                    aria-valuemin={0}
+                    aria-valuemax={PASSWORD_REQUIREMENTS.length}
+                    aria-label="Password strength"
+                  >
+                    <div
+                      className={`h-full transition-all duration-300 ${barColor} ${barWidth}`}
+                    ></div>
+                  </div>
+
+                  <p
+                    className={`text-sm font-medium truncate ${textColor}`}
+                    aria-live="polite"
+                  >
+                    {strengthLabel} Password
+                  </p>
+
+                  <ul className="space-y-1 text-xs min-w-0">
+                    {PASSWORD_REQUIREMENTS.map(({ key, label }) => {
+                      const met = passwordChecks[key];
+                      return (
+                        <li
+                          key={key}
+                          className={`${met ? "text-green-400" : "text-red-400"} truncate`}
+                          aria-label={`${label}: ${met ? "met" : "not met"}`}
+                        >
+                          <span aria-hidden="true">{met ? "✔️" : "❌"}</span>{" "}
+                          {label}
+                        </li>
+                      );
+                    })}
+                  </ul>
                 </div>
-
-                <p
-                  className={`text-sm font-medium truncate ${textColor}`}
-                  aria-live="polite"
-                >
-                  {strengthLabel} Password
-                </p>
-
-                <ul className="space-y-1 text-xs min-w-0">
-                  {PASSWORD_REQUIREMENTS.map(({ key, label }) => {
-                    const met = passwordChecks[key];
-                    return (
-                      <li
-                        key={key}
-                        className={`${met ? "text-green-400" : "text-red-400"} truncate`}
-                        aria-label={`${label}: ${met ? "met" : "not met"}`}
-                      >
-                        <span aria-hidden="true">{met ? "Γ£à" : "Γ¥î"}</span>{" "}
-                        {label}
-                      </li>
-                    );
-                  })}
-                </ul>
-              </div>
-)}
+              )}
 
               <SSInput
                 label="Confirm Password"
                 name="confirmPassword"
                 type="password"
                 placeholder="Confirm your password"
-                required={true}
+                required={!showOtpField}
                 icon="fi fi-rr-eye"
                 register={register}
                 autoComplete="new-password"
+                validation={{
+                  validate: (value) => {
+                    if (showOtpField) return true;
+                    if (!value) return "Confirm password is required";
+                    if (value !== password) return "Passwords do not match!";
+                    return true;
+                  }
+                }}
                 error={errors.confirmPassword}
               />
 


### PR DESCRIPTION
Before you open this PR
Issue: Closes #1966

Description: Fixed form validation state block on the signup view.

Screenshots: N/A (Tested locally via form state inspection)

Screenshot (when helpful)
N/A - Local layout testing confirmed state transitions are non-blocking.

What this PR does
This PR resolves a critical form validation state bug on the user registration flow (/signup).

The Problem:
Previously, the SignUpComponent utilized a unified useForm<Inputs> canvas engine tracking all authentication parameters simultaneously. When a user completed the first stage (account details) and advanced to the email validation stage (showOtpField === true), the Confirm Password DOM elements unmounted from the viewport layout. Upon submitting the OTP code, the React Hook Form core re-evaluated the tree state, caught the now-empty hidden configuration keys, and erroneously threw a top-right toast alert stating "Confirm password is required", entirely blocking the onboarding workflow.

The Solution:
Integrated a dynamic, state-conditional constraint within the confirmPassword target block.

Adjusted the primary field wrapper rule to toggle field requirement properties based on state layers (required={!showOtpField}).

Injected a custom validation callback logic handler mapping that explicitly exits structural assertions if the component structure has stepped into the OTP sequence (if (showOtpField) return true;).

Type of change
[x] Bug fix

[ ] New feature

[ ] Code refactor

[ ] Documentation update

Related issue
Closes #1966

More screenshots (optional)
N/A

Checklist
[x] I have noted N/A for screenshots with a brief explanation.

[x] I have filled in the related issue number when there is one.

[x] I have tested my changes.

[x] I have done a self-review of the code.