### PR TITLE
fix: overlap of recommended writer and latest post

### DIFF
--- a/frontend/src/components/home/home.component.tsx
+++ b/frontend/src/components/home/home.component.tsx
@@ -19,14 +19,14 @@ const HomeComponent = () => {
   return (
     <>
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 pt-10 pb-10">
-        <div className="grid grid-cols-12 items-start gap-8 mb-10">
-          <div className="col-span-12 lg:col-span-8 min-w-0 flex flex-col gap-8">
+        <div className="grid grid-cols-1 items-start gap-8 mb-10 xl:grid-cols-[minmax(0,1fr)_minmax(18rem,22rem)]">
+          <div className="flex w-full min-w-0 max-w-full flex-col gap-8">
             <FeatureComponent />
             <LatestPostsComponent />
           </div>
 
-          <div className="col-span-12 lg:col-span-4 min-w-0">
-            <div className="sticky top-24 flex flex-col gap-6">
+          <div className="w-full min-w-0 max-w-full xl:max-w-[22rem] xl:justify-self-end">
+            <div className="sticky top-24 flex w-full min-w-0 flex-col gap-6">
               {isLogin && <FeatureProfileComponent />}
               {isLogin && <PersonalizedRecommendationsComponent />}
               <TrendingTopicComponent />

--- a/frontend/src/components/home/latest_posts/latest_posts.component.tsx
+++ b/frontend/src/components/home/latest_posts/latest_posts.component.tsx
@@ -53,9 +53,9 @@ const LatestPostsComponent = () => {
   };
 
   return (
-    <section className="text-slate-100">
+    <section className="w-full min-w-0 max-w-full text-slate-100">
       <h2 className="mb-6 text-2xl font-bold">Latest Posts</h2>
-      <div className="space-y-3">
+      <div className="max-w-full space-y-3">
         {visiblePosts.length > 0 ? (
           visiblePosts.map((post: Post) => {
             const isExpanded = expandedPostId === post._id;
@@ -63,14 +63,14 @@ const LatestPostsComponent = () => {
             return (
               <div
                 key={post._id}
-                className="motion-card-subtle story-panel rounded-lg overflow-hidden border border-slate-700/30 bg-[#252b3d]/40 transition-all duration-200"
+                className="motion-card-subtle story-panel w-full max-w-full rounded-lg overflow-hidden border border-slate-700/30 bg-[#252b3d]/40 transition-all duration-200"
               >
                 <button
                   onClick={() => toggleAccordion(post._id)}
-                  className="w-full flex items-center justify-between p-4 text-left font-bold text-slate-100 hover:bg-slate-700/20 transition-colors"
+                  className="flex w-full min-w-0 items-center justify-between p-4 text-left font-bold text-slate-100 hover:bg-slate-700/20 transition-colors"
                 >
-                  <span className="text-lg md:text-xl pr-4">{post.title}</span>
-                  <span className="text-slate-400 font-mono text-sm transition-transform duration-200 select-none">
+                  <span className="min-w-0 pr-4 text-lg break-words md:text-xl">{post.title}</span>
+                  <span className="shrink-0 text-slate-400 font-mono text-sm transition-transform duration-200 select-none">
                     {isExpanded ? "▼" : "▶"}
                   </span>
                 </button>
@@ -80,8 +80,8 @@ const LatestPostsComponent = () => {
                     isExpanded ? "max-h-[500px] border-t border-slate-700/30" : "max-h-0"
                   }`}
                 >
-                  <div className="p-5 bg-[#1e2330]/30">
-                    <p className="text-slate-400 text-sm md:text-base leading-relaxed mb-4 whitespace-pre-wrap">
+                  <div className="min-w-0 p-5 bg-[#1e2330]/30">
+                    <p className="text-slate-400 text-sm md:text-base leading-relaxed mb-4 whitespace-pre-wrap break-words">
                       {post.content || "No preview content available."}
                     </p>
 

--- a/frontend/src/components/home/recommended_writers/recommended_writers.component.tsx
+++ b/frontend/src/components/home/recommended_writers/recommended_writers.component.tsx
@@ -50,26 +50,26 @@ const RecommendedWritersComponent = () => {
 
   return (
     <>
-      <section className="bg-blue-500/10 rounded-lg shadow-sm p-6">
+      <section className="w-full max-w-full overflow-hidden bg-blue-500/10 rounded-lg shadow-sm p-6">
         <h3 className="text-lg font-semibold text-slate-900 dark:text-gray-300 mb-4">
           Recommended Writers
         </h3>
 
         <div className="space-y-4">
           {recommendedWriters.map((writer, index) => (
-            <div key={writer.id} className="flex items-center justify-between">
-              <div className="flex items-center">
+            <div key={writer.id} className="flex min-w-0 items-center justify-between gap-3">
+              <div className="flex min-w-0 items-center">
                 <img
-                  className="h-10 w-10 rounded-full"
+                  className="h-10 w-10 shrink-0 rounded-full"
                   src={writer.image}
                   alt={writer.name}
                 />
 
-                <div className="ml-3">
-                  <p className="text-sm font-medium text-slate-700 dark:text-gray-400">
+                <div className="ml-3 min-w-0">
+                  <p className="truncate text-sm font-medium text-slate-700 dark:text-gray-400">
                     {writer.name}
                   </p>
-                  <p className="text-xs text-slate-500 dark:text-gray-500">
+                  <p className="truncate text-xs text-slate-500 dark:text-gray-500">
                     {writer.role}
                   </p>
                 </div>
@@ -78,7 +78,7 @@ const RecommendedWritersComponent = () => {
               <button
                 onClick={() => toggleFollow(index, writer.id)}
                 disabled={isLoading}
-                className="!rounded-button text-indigo-600 text-sm font-medium hover:text-indigo-700 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                className="!rounded-button shrink-0 text-indigo-600 text-sm font-medium hover:text-indigo-700 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {following.includes(index) ? "Following" : "Follow"}
               </button>


### PR DESCRIPTION
## What this PR does

Fixes the homepage layout collision where Latest Posts cards could overlap the Recommended Writers sidebar. The homepage content/sidebar grid now stays stacked until there is enough horizontal space, then switches to a constrained `xl` two-column layout. Latest Posts cards also explicitly respect their container width and wrap long titles/content instead of forcing the main column wider.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Documentation update

## Related issue
#1755
## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.  
- [x] I have filled in the related issue number when there is one.
- [x] I have done a self-review of the code.