### PR TITLE
fix(auth): correct placeholder layout and styling in SSInput

### DIFF
--- a/frontend/src/components/ui-component/ss-input/ss-input.tsx
+++ b/frontend/src/components/ui-component/ss-input/ss-input.tsx
@@ -35,56 +35,65 @@ const SSInput = <T extends FieldValues>({
 }: SSInputProps<T>) => {
   const [showPassword, setShowPassword] = useState(false);
 
-
-
   const inputType =
-
     type === "password" ? (showPassword ? "text" : "password") : type;
 
-
-
   return (
-    <div className="w-full min-w-0">
-      <label htmlFor={name} className="block text-sm font-medium text-gray-600 dark:text-gray-400">
-        {label}
-      </label>
-      <div className="relative mt-2 w-full min-w-0">
+    <div className="w-full min-w-0 flex flex-col gap-1.5">
+      {/* Outer Integrated Card Container */}
+      <div
+        className={`flex items-center gap-3.5 w-full rounded-xl border bg-[#0b1120]/40 px-4 py-2.5 transition-all duration-300 ${
+          error
+            ? "border-red-500/50 focus-within:border-red-500 focus-within:ring-2 focus-within:ring-red-500/10"
+            : "border-slate-200 dark:border-slate-700/60 hover:border-blue-400/40 focus-within:border-blue-500 focus-within:ring-2 focus-within:ring-blue-500/20"
+        }`}
+      >
+        {/* Left Icon (Envelope, Lock, etc.) */}
         {icon && (
-          <span className="absolute inset-y-0 left-0 pl-2 sm:pl-3 flex items-center text-gray-500 pointer-events-none">
+          <span className="flex items-center text-slate-400 dark:text-blue-300/80 shrink-0 text-base">
             <i className={icon}></i>
           </span>
         )}
 
-       <input
-  type={inputType}
-  id={name}
-  className={`w-full box-border pl-6 sm:pl-8 pr-8 sm:pr-10 py-2 sm:py-2.5 text-sm sm:text-base text-gray-900 dark:text-gray-200 bg-white dark:bg-slate-800 transition-all duration-200 ${
-    error
-      ? "border-2 border-red-500"
-      : "focus:ring-2 focus:ring-indigo-500/20 focus:outline-none"
-  }`}
-  placeholder={placeholder}
-  autoComplete={autoComplete}
-  autoFocus={autoFocus}
-  {...register(name, validation)}
-/>
+        {/* Text Area Content Stack */}
+        <div className="flex flex-col flex-grow min-w-0">
+          <label
+            htmlFor={name}
+            className="block text-[10px] font-bold uppercase tracking-wider text-slate-400 dark:text-slate-400/80 mb-0.5"
+          >
+            {label}
+          </label>
+          <input
+            type={inputType}
+            id={name}
+            className="w-full bg-transparent p-0 border-none outline-none focus:ring-0 text-sm sm:text-base text-gray-900 dark:text-gray-100 placeholder-slate-400/60 dark:placeholder-slate-500"
+            placeholder={placeholder}
+            autoComplete={autoComplete}
+            autoFocus={autoFocus}
+            {...register(name, validation)}
+          />
+        </div>
+
+        {/* Password Eye Visibility Toggle Trigger */}
         {type === "password" && (
-  <button
-    type="button"
-    onClick={() => setShowPassword(!showPassword)}
-    className="absolute inset-y-0 right-2 flex items-center text-gray-500"
-    aria-label={showPassword ? "Hide password" : "Show password"}
-    title={showPassword ? "Hide password" : "Show password"}
-  >
-    <i className={showPassword ? "fi fi-rr-eye" : "fi fi-rr-eye-crossed"}></i>
-  </button>
-)}
+          <button
+            type="button"
+            onClick={() => setShowPassword(!showPassword)}
+            className="flex items-center text-slate-400 hover:text-slate-300 transition-colors pl-1 shrink-0"
+            aria-label={showPassword ? "Hide password" : "Show password"}
+            title={showPassword ? "Hide password" : "Show password"}
+          >
+            <i className={showPassword ? "fi fi-rr-eye" : "fi fi-rr-eye-crossed"}></i>
+          </button>
+        )}
       </div>
+
+      {/* Input Field Validation Error Message */}
       {error && (
-        <p className="text-red-400 text-sm mt-1 w-full break-words overflow-hidden">
-        {error.message}
+        <p className="text-red-400 text-xs font-medium pl-2 w-full break-words overflow-hidden">
+          {error.message}
         </p>
-    )}
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Screenshot 

**Before:** *<img width="1901" height="946" alt="Screenshot 2026-06-02 230702" src="https://github.com/user-attachments/assets/f836558a-0164-4707-a938-69147c1ca275" />*

**After:** *<img width="1910" height="960" alt="Screenshot 2026-06-02 231552" src="https://github.com/user-attachments/assets/71c47a48-8f49-4e1e-983b-b50be41a7600" />*

---

## What this PR does

This PR fixes the layout issue on the Login page where input fields extend beyond the boundaries of the authentication card.

### Changes made

* Corrected input field sizing to properly respect the parent container width.
* Fixed layout overflow affecting the login form.
* Improved visual consistency between form elements and the authentication card.
* Preserved existing login functionality and behavior.

The change is purely related to UI/layout and does not affect authentication logic, validation, or API interactions.

---

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

---

## Related issue

Closes #1994 

---

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.
