### PR TITLE
fix: add max length validation for selectedChoice

### DIFF
--- a/backend/src/routes/stories.ts
+++ b/backend/src/routes/stories.ts
@@ -10,7 +10,11 @@ const router = express.Router();
 const branchingStorySchema = z.object({
   body: z.object({
     storyContext: z.string({ required_error: "storyContext is required!" }).max(8000),
-    selectedChoice: z.string({ required_error: "selectedChoice is required!" }),
+
+    selectedChoice: z
+      .string({ required_error: "selectedChoice is required!" })
+      .max(500, "selectedChoice must not exceed 500 characters"),
+
     genre: z.string().max(120).optional(),
   }),
 });


### PR DESCRIPTION
## What this PR does

This PR adds a maximum length validation to the `selectedChoice` field in the branching story endpoint.

Previously, `selectedChoice` accepted unbounded user input and could be forwarded directly into AI prompts without any size restriction. This change introduces a limit to prevent excessively large payloads and align validation behavior with the existing `storyContext` protection.

### Changes made

* Added `.max(500)` validation to `selectedChoice`
* Added a clear validation error message
* Prevented unbounded input from reaching downstream AI processing

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

## Related issue

Closes #1812

## Screenshot

N/A — backend validation change, no UI modifications.

## Checklist

* [x] I have added screenshots or noted N/A.
* [x] I have filled in the related issue number.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.
