### PR TITLE
perf: migrate global post feed queries to cursor pagination (#1595)

### DIFF
--- a/backend/src/app/modules/post/post.service.ts
+++ b/backend/src/app/modules/post/post.service.ts
@@ -12,8 +12,79 @@ import {
 } from "../../../interfaces/pagination";
 import paginationHelper from "../../../utils/pagination_helper";
 import { postSearchFields } from "./post.constant";
-import { SortOrder } from "mongoose";
+import { SortOrder, Types } from "mongoose";
 import { GamificationService } from "../gamification/gamification.service";
+
+interface ICursorPayload {
+  value: string;
+  id: string;
+}
+
+const encodeCursor = (item: IPost, sortBy: string) => {
+  const rawValue = item[sortBy as keyof IPost];
+  const value = rawValue instanceof Date ? rawValue.toISOString() : String(rawValue ?? "");
+  return Buffer.from(JSON.stringify({ value, id: item._id?.toString() })).toString("base64");
+};
+
+const decodeCursor = (cursor?: string): ICursorPayload | null => {
+  if (!cursor) {
+    return null;
+  }
+
+  try {
+    const decoded = Buffer.from(cursor, "base64").toString("utf-8");
+    const parsed = JSON.parse(decoded);
+    if (!parsed?.id || parsed.value === undefined) {
+      return null;
+    }
+    return parsed as ICursorPayload;
+  } catch {
+    return null;
+  }
+};
+
+const getCursorCondition = (
+  sortBy: string,
+  orderBy: SortOrder,
+  cursor?: string,
+) => {
+  const parsed = decodeCursor(cursor);
+  if (!parsed) {
+    return null;
+  }
+
+  const { value: rawValue, id } = parsed;
+  let value: string | number | Date = rawValue;
+
+  if (sortBy === "createdAt" || sortBy === "publishedAt") {
+    value = new Date(rawValue);
+  } else if (
+    ["likesCount", "commentsCount", "viewsCount", "bookmarksCount"].includes(
+      sortBy,
+    )
+  ) {
+    value = Number(rawValue);
+  }
+
+  const compareOperator = orderBy === "asc" ? "$gt" : "$lt";
+  const objectId = Types.ObjectId.isValid(id) ? new Types.ObjectId(id) : id;
+
+  return {
+    $or: [
+      {
+        [sortBy]: {
+          [compareOperator]: value,
+        },
+      },
+      {
+        [sortBy]: value,
+        _id: {
+          [compareOperator]: objectId,
+        },
+      },
+    ],
+  };
+};
 
 const createPost = async (payload: IPostPayload, token: ITokenPayload) => {
   const { email, role } = token;
@@ -54,7 +125,9 @@ const getPosts = async (
   filters: IPostSearchFields,
   pagination: IPaginationOptions
 ): Promise<IGenericResponse<IPost[]>> => {
-  const { page, limit, skip, sortBy, orderBy } = paginationHelper(pagination);
+  const { page, limit, cursor, sortBy, orderBy } = paginationHelper(
+    pagination,
+  );
   const { searchTerm, trendingTopic, sortFilter, genres, ...filterData } =
     filters;
   const andCondition: Record<string, unknown>[] = [
@@ -120,7 +193,7 @@ const getPosts = async (
     });
   }
 
-  const whereCondition = andCondition.length > 0 ? { $and: andCondition } : {};
+  const countCondition = andCondition.length > 0 ? { $and: andCondition } : {};
 
   // sort condition
   const sortCondition: { [key: string]: SortOrder } = {};
@@ -131,10 +204,17 @@ const getPosts = async (
   if (sortBy && orderBy) {
     sortCondition[sortBy] = orderBy === "asc" ? 1 : -1;
   }
+  sortCondition._id = orderBy === "asc" ? 1 : -1;
+
+  const cursorCondition = getCursorCondition(sortBy, orderBy, cursor);
+  if (cursorCondition) {
+    andCondition.push(cursorCondition);
+  }
+
+  const whereCondition = andCondition.length > 0 ? { $and: andCondition } : {};
 
   const result = await Post.find(whereCondition)
     .sort(sortCondition)
-    .skip(skip)
     .limit(limit)
     .populate("author", "name email createdAt")
     .populate({
@@ -142,12 +222,16 @@ const getPosts = async (
       populate: { path: "userId", select: "email" },
     })
     .populate("bookmarks", "email");
-  const total = await Post.countDocuments(whereCondition);
+  const total = await Post.countDocuments(countCondition);
+  const nextCursor = result.length === limit ? encodeCursor(result[result.length - 1], sortBy) : undefined;
+
   return {
     meta: {
       page,
       limit,
       total,
+      nextCursor,
+      hasMore: Boolean(nextCursor),
     },
     data: result,
   };

--- a/backend/src/constants/pagination.ts
+++ b/backend/src/constants/pagination.ts
@@ -1,1 +1,1 @@
-export const paginationFields = ["page", "limit", "sortBy", "orderBy","sortOrder"];
+export const paginationFields = ["page", "limit", "cursor", "sortBy", "orderBy", "sortOrder"];

--- a/backend/src/interfaces/pagination.ts
+++ b/backend/src/interfaces/pagination.ts
@@ -3,6 +3,7 @@ import { SortOrder } from "mongoose";
 export interface IPaginationOptions {
   page?: number;
   limit?: number;
+  cursor?: string;
   sortBy?: string;
   orderBy?: SortOrder;
 }
@@ -12,6 +13,8 @@ export interface IGenericResponse<T> {
     page: number;
     limit: number;
     total: number;
+    nextCursor?: string;
+    hasMore?: boolean;
   };
   data: T;
 }

--- a/backend/src/utils/pagination_helper.ts
+++ b/backend/src/utils/pagination_helper.ts
@@ -3,6 +3,7 @@ import { SortOrder } from "mongoose";
 interface IOptions {
   page?: number;
   limit?: number;
+  cursor?: string;
   sortBy?: string;
   orderBy?: SortOrder;
   sortOrder?: SortOrder;
@@ -12,6 +13,7 @@ interface PGOptions {
   page: number;
   limit: number;
   skip: number;
+  cursor?: string;
   sortBy: string;
   orderBy: SortOrder;
 }
@@ -26,6 +28,7 @@ const paginationHelper = (option: IOptions): PGOptions => {
     page,
     limit,
     skip,
+    cursor: typeof option.cursor === "string" ? option.cursor : undefined,
     sortBy,
     orderBy,
   };

--- a/frontend/src/components/post/post.component.tsx
+++ b/frontend/src/components/post/post.component.tsx
@@ -1,69 +1,143 @@
-import React, { useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import ExploreViewListComponent from "./post.view.list.component";
 import ExploreFeatureComponent from "./post.feature.component";
 import { Link } from "react-router-dom";
 import { useGetPostListsQuery, useGetGenresQuery } from "../../redux/apis/post.api";
 import type { Post } from "../../models/post";
 import { useDebounced } from "../../hooks/global";
-import PaginationComponent from "../pagination/pagination.component";
 
 const ExploreComponent = () => {
   const [sortBy, setSortBy] = useState<string>("createdAt");
   const [sortOrder, setSortOrder] = useState<string>("desc");
   const [searchTerm, setSearchTerm] = useState<string>("");
   const [size, setSize] = useState<number>(10);
-  const [page, setPage] = useState<number>(1);
+  const [cursor, setCursor] = useState<string | undefined>(undefined);
+  const [posts, setPosts] = useState<Post[]>([]);
   const [featuredPost, setFeaturedPost] = useState<boolean>(false);
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
-
-  const query: Record<string, string | number> = {
-    page,
-    limit: size,
-    sortBy,
-    sortOrder,
-  };
 
   const debounceTerm = useDebounced({
     searchQuery: searchTerm,
     daley: 600,
   });
 
-  if (debounceTerm?.trim()) {
-  query["searchTerm"] = debounceTerm;
-}
+  const normalizedSearchTerm = debounceTerm?.trim() ?? "";
+  const genresParam = selectedTags.length > 0 ? selectedTags.join(",") : undefined;
 
-  if (selectedTags.length > 0) {
-    query["genres"] = selectedTags.join(",");
-  }
+  const queryArgs = useMemo<Record<string, string | number>>(() => {
+    const args: Record<string, string | number> = {
+      limit: size,
+      sortBy,
+      sortOrder,
+    };
 
-  const { data, isLoading } = useGetPostListsQuery({ ...query });
+    if (normalizedSearchTerm) {
+      args.searchTerm = normalizedSearchTerm;
+    }
+
+    if (genresParam) {
+      args.genres = genresParam;
+    }
+
+    if (cursor) {
+      args.cursor = cursor;
+    }
+
+    return args;
+  }, [size, sortBy, sortOrder, normalizedSearchTerm, genresParam, cursor]);
+
+  const { data, isLoading, isFetching } = useGetPostListsQuery(queryArgs);
   const { data: genres } = useGetGenresQuery();
 
-  const filteredPosts = data?.posts || [];
+  const loadMoreTriggerRef = useRef<HTMLDivElement | null>(null);
+  const querySignature = useMemo(
+    () =>
+      JSON.stringify({
+        size,
+        sortBy,
+        sortOrder,
+        normalizedSearchTerm,
+        genresParam,
+      }),
+    [size, sortBy, sortOrder, normalizedSearchTerm, genresParam],
+  );
+  const previousQuerySignature = useRef<string>(querySignature);
+
+  useEffect(() => {
+    if (previousQuerySignature.current !== querySignature) {
+      previousQuerySignature.current = querySignature;
+      setCursor(undefined);
+      setPosts([]);
+    }
+  }, [querySignature]);
+
+  useEffect(() => {
+    if (!data?.posts) {
+      return;
+    }
+
+    if (!cursor) {
+      setPosts(data.posts);
+      return;
+    }
+
+    if (data.posts.length > 0) {
+      setPosts((prevPosts) => [...prevPosts, ...data.posts]);
+    }
+  }, [data?.posts, cursor]);
+
+  useEffect(() => {
+    const trigger = loadMoreTriggerRef.current;
+    if (!trigger) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (
+          entry?.isIntersecting &&
+          data?.meta?.hasMore &&
+          data.meta.nextCursor &&
+          !isLoading &&
+          !isFetching &&
+          data.meta.nextCursor !== cursor
+        ) {
+          setCursor(data.meta.nextCursor);
+        }
+      },
+      {
+        rootMargin: "200px",
+      },
+    );
+
+    observer.observe(trigger);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [cursor, data?.meta?.hasMore, data?.meta?.nextCursor, isFetching, isLoading]);
+
+  const filteredPosts = posts;
 
   const resetAllStates = () => {
     setSortBy("createdAt");
     setSortOrder("desc");
     setSearchTerm("");
     setSelectedTags([]);
-    setPage(1);
-  };
-
-  const onPaginationChange = (page: number, pageSize: number) => {
-    setPage(page);
-    setSize(pageSize);
+    setCursor(undefined);
+    setPosts([]);
   };
 
   const handleTagClick = (tag: string) => {
     setSelectedTags((prev) =>
       prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag],
     );
-    setPage(1);
   };
 
   const availableTags = Array.from(
     new Set(
-      (data?.posts || [])
+      posts
         .map((post: Post) => post.tag)
         .filter(Boolean)
         .map((tag: string) => `#${tag.toLowerCase().trim()}`),
@@ -95,14 +169,7 @@ const ExploreComponent = () => {
                 value={searchTerm}
                 onChange={(e) => {
                   setSearchTerm(e.target.value);
-                  setPage(1);
-                }}
-              />
 
-              <i className="fas fa-search absolute left-4 top-1/2 transform -translate-y-1/2 text-slate-400"></i>
-            </div>
-          </div>
-        </div>
 
         {/* Main Layout */}
         <div className="flex flex-col md:flex-row gap-8">
@@ -177,12 +244,11 @@ const ExploreComponent = () => {
                     value={sortBy}
                     onChange={(e) => {
                       setSortBy(e.target.value);
-                      setPage(1);
                     }}
                     className="w-full border border-gray-200 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-gray-100 text-slate-900 p-2.5 outline-none transition-all cursor-pointer appearance-none dark:border-slate-600 dark:bg-slate-700/50 dark:text-slate-200"
                   >
                     <option value="createdAt">Latest</option>
-                    <option value="views">Most Popular</option>
+                    <option value="viewsCount">Most Popular</option>
                     <option value="commentsCount">Most Discussed</option>
                     <option value="likesCount">Most Liked</option>
                   </select>
@@ -196,7 +262,6 @@ const ExploreComponent = () => {
                     value={sortOrder}
                     onChange={(e) => {
                       setSortOrder(e.target.value);
-                      setPage(1);
                     }}
                     className="w-full border border-gray-200 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-gray-100 text-slate-900 p-2.5 outline-none transition-all cursor-pointer appearance-none dark:border-slate-600 dark:bg-slate-700/50 dark:text-slate-200"
                   >
@@ -243,7 +308,6 @@ const ExploreComponent = () => {
                     value={size}
                     onChange={(e) => {
                       setSize(Number(e.target.value));
-                      setPage(1);
                     }}
                   >
                     <option value={10}>10</option>
@@ -292,17 +356,21 @@ const ExploreComponent = () => {
               )}
             </div>
 
-            {!featuredPost && data?.meta && (
-
-              <div className="sticky bottom-0 bg-white/90 backdrop-blur-xl border-t border-gray-200 z-20 mt-8 shadow-[0_-10px_40px_-10px_rgba(15,23,42,0.12)] transition-colors duration-300 dark:bg-[#0b1329]/80 dark:border-slate-800 dark:shadow-[0_-10px_40px_-10px_rgba(0,0,0,0.5)]">
-                <div className="max-w-8xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
-                  <PaginationComponent
-                    current={page}
-                    pageSize={size}
-                    total={data.meta.total}
-                    onChange={onPaginationChange}
-                  />
+            {!featuredPost && (
+              <div className="mt-8">
+                <div className="max-w-8xl mx-auto px-4 sm:px-6 lg:px-8 py-3 text-center">
+                  {isFetching && !isLoading && (
+                    <p className="text-sm text-slate-600 dark:text-slate-300">
+                      Loading more stories...
+                    </p>
+                  )}
+                  {!isFetching && !data?.meta?.hasMore && posts.length > 0 && (
+                    <p className="text-sm text-slate-600 dark:text-slate-300">
+                      You have reached the end of the feed.
+                    </p>
+                  )}
                 </div>
+                <div ref={loadMoreTriggerRef} className="h-6" />
               </div>
             )}
           </div>

--- a/frontend/src/types/common.ts
+++ b/frontend/src/types/common.ts
@@ -4,6 +4,8 @@ export interface IMeta {
   limit: number;
   page: number;
   total: number;
+  nextCursor?: string;
+  hasMore?: boolean;
 }
 
 export interface ResponseSuccessType<T = unknown> {


### PR DESCRIPTION
## Screenshot

N/A — backend/frontend pagination behavior only; no visual design changes beyond existing feed list.

## What this PR does

- Migrates the global story feed from offset-based pagination to cursor-based pagination.
- Updates backend `/posts/lists` to accept `cursor` and return `meta.nextCursor` / `meta.hasMore`.
- Removes `.skip()` from the post query and replaces it with stable cursor filtering using `[sortBy, _id]`.
- Updates frontend `ExploreComponent` to fetch the feed using `cursor` and load additional posts with an `IntersectionObserver` instead of page controls.
- Preserves existing filters, sort options, and page size behavior while avoiding duplicate/missed posts during scrolling.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

#1597 

## More screenshots

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.