### PR TITLE
fix: resolve confirm password validation error appearing on OTP screen

### DIFF
--- a/backend/src/app/modules/user/user.validation.ts
+++ b/backend/src/app/modules/user/user.validation.ts
@@ -15,13 +15,9 @@ const register = z.object({
       .string({ required_error: "Name is required" })
       .min(3, "Name must be at least 3 characters long"),
     password: passwordSchema,
-    confirmPassword: z.string({ required_error: "Confirm password is required" }),
     verificationToken: z
       .string({ required_error: "Verification token is required" })
       .min(1, "Verification token is required"),
-  }).refine((data) => data.password === data.confirmPassword, {
-    message: "Passwords do not match",
-    path: ["confirmPassword"],
   }),
 });
 

--- a/frontend/src/components/signup/signup.component.tsx
+++ b/frontend/src/components/signup/signup.component.tsx
@@ -92,6 +92,7 @@ const SignUpComponent = () => {
     handleSubmit,
     watch,
     setValue,
+    unregister,
     formState: { errors },
   } = useForm<Inputs>({ mode: "onChange" });
   const [isBusy, setIsBusy] = useState<boolean>(false);
@@ -154,6 +155,10 @@ const SignUpComponent = () => {
           setExpiredAt(new Date(expiresAt).getTime());
           toast.success("OTP sent to your email");
           setRegisterInfo(user);
+          unregister("confirmPassword");
+          unregister("password");
+          unregister("name");
+          unregister("email");
           setShowOtpField(true);
           setCooldown(60);
         }


### PR DESCRIPTION
- Remove confirmPassword from backend Zod register validation
- Unregister signup form fields before OTP screen transition

Fixes #1908

## Before you open this PR

- **Issue:** Fixes #1908
- **Description:** Filled below
- **Screenshots:** N/A (No UI changes)

## Screenshot (when helpful)

N/A – This fix addresses form validation and state management during the signup → OTP transition. No UI changes were introduced.

## What this PR does

Fixes an issue in the signup → OTP verification flow where users would see a **"Confirm password is required"** validation error immediately after reaching the OTP screen, despite having filled all signup fields correctly.

### Root Cause

The signup form uses React Hook Form with `mode: "onChange"`.

After a successful signup request, the UI transitions from the registration form to the OTP verification screen. However, the signup fields (`name`, `email`, `password`, and `confirmPassword`) remained registered in the form state even after being unmounted.

As a result, React Hook Form continued validating hidden fields, causing the `confirmPassword` validation error to be triggered on the OTP screen.

### Changes Made

- Removed `confirmPassword` validation from the backend registration Zod schema.
- Removed the password-confirmation refinement logic from the backend schema.
- Unregistered signup form fields before transitioning to the OTP verification screen:
  - `name`
  - `email`
  - `password`
  - `confirmPassword`
- Prevented hidden form fields from participating in OTP-stage validation.

### Result

Users can now transition to the OTP verification screen without encountering misleading validation errors after a successful signup request.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Fixes #1908

## More screenshots (optional)

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.