### PR TITLE
fix: resolve UI overlap between Scroll-to-Top and AI Help widget

### DIFF
--- a/frontend/src/components/Scrolltotopandscrolltobottom.tsx
+++ b/frontend/src/components/Scrolltotopandscrolltobottom.tsx
@@ -43,7 +43,7 @@ export default function DualScrollButton() {
       aria-label={isBottomMode ? "Scroll to bottom" : "Scroll to top"}
       title={isBottomMode ? "Scroll to bottom" : "Scroll to top"}
       className={`
-        fixed bottom-40 right-6 z-50 lg:bottom-6
+       fixed bottom-28 right-6 z-50
         flex items-center justify-center
         w-14 h-14 rounded-full
         text-white


### PR DESCRIPTION
This PR addresses a layout conflict where the floating "Scroll to Top" button overlapped with the AI Help widget. By adjusting the bottom offset, both UI elements are now properly spaced and accessible on all screen sizes.

Changes:

Modified DualScrollButton component in Scrolltotopandscrolltobottom.tsx.

Increased bottom spacing to 28 units (bottom-28) for consistent vertical clearance.

Removed the lg:bottom-6 override to ensure the fix persists on desktop views.

After fixing:
<img width="215" height="237" alt="sar" src="https://github.com/user-attachments/assets/e73a9086-c318-4500-b539-ff650effc72d" />

closes #2030 
