### PR TITLE
fix(signup): fix typo in terms agreement label on signup page

### DIFF
--- a/signup.html
+++ b/signup.html
@@ -236,7 +236,7 @@
             </form>
 
             <p class="text-center mt-4 text-[13px] text-on-surface-variant">
-                By continuing, you agreeeee to our
+                By continuing, you agree to our
                 <a class="underline hover:text-primary transition-colors cursor-pointer" onclick="openLegalModal('terms')">Terms of Service</a> and
                 <a class="underline hover:text-primary transition-colors cursor-pointer" onclick="openLegalModal('privacy')">Privacy Policy</a>.
             </p>


### PR DESCRIPTION
Resolves #2070

This PR implements the fix proposed in the issue.