### PR TITLE
fix: add missing roles and pro subscription tier to JWT validation

### DIFF
--- a/frontend/src/utils/jwt.ts
+++ b/frontend/src/utils/jwt.ts
@@ -59,7 +59,7 @@ export const decodedToken = (token: string): CustomJwtPayload => {
     throw new Error("Token is missing a valid 'role' claim.");
   }
 
-  const validRoles = ["user", "admin", "guest"];
+  const validRoles = ["user", "admin", "super_admin", "writer", "guest"];
   if (!validRoles.includes(decoded.role)) {
     throw new Error(`Token 'role' claim must be one of: ${validRoles.join(", ")}`);
   }
@@ -69,7 +69,7 @@ export const decodedToken = (token: string): CustomJwtPayload => {
     throw new Error("Token is missing a valid 'subscriptionType' claim.");
   }
 
-  const validSubscriptions = ["free", "premium"];
+  const validSubscriptions = ["free", "pro", "premium"];
   if (!validSubscriptions.includes(decoded.subscriptionType)) {
     throw new Error(`Token 'subscriptionType' claim must be one of: ${validSubscriptions.join(", ")}`);
   }


### PR DESCRIPTION
## Screenshot (when helpful)

N/A (Frontend JWT claim validation update)

## What this PR does

This PR updates the client-side JWT claims validation to align with valid user roles and subscription tiers defined in the backend configuration.
- Added `writer` and `super_admin` to the whitelist of `validRoles` inside the frontend `jwt.ts` utility.
- Added `pro` to the whitelist of `validSubscriptions` in `jwt.ts`.
- Prevents immediate logouts for authenticated users with writer/super_admin roles or pro subscription plans due to token verification schema mismatches.

## Type of change

- [x] Bug fix

## Related issue

Fixes #2127

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
