### PR TITLE
fix: remove duplicate search condition in getPosts

### DIFF
--- a/backend/src/app/modules/post/post.service.ts
+++ b/backend/src/app/modules/post/post.service.ts
@@ -158,14 +158,6 @@ const getPosts = async (
         })),
       });
     }
-    andCondition.push({
-      $or: postSearchFields.map((field) => ({
-        [field]: {
-          $regex: searchTerm,
-          $options: "i",
-        },
-      })),
-    });
   }
 
   if (trendingTopic) {


### PR DESCRIPTION
## Screenshot (when helpful)

N/A (Backend query logic fix)

## What this PR does

This PR resolves a query filtering bug in the backend post service.
- Removed the redundant, unescaped `searchTerm` condition push in the `getPosts` method within `backend/src/app/modules/post/post.service.ts`.
- Ensures only the sanitized `safeSearchTerm` regex query is executed, resolving potential ReDoS vulnerabilities and fixing search filter restrictions.

## Type of change

- [x] Bug fix

## Related issue

Closes #2133

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
