### PR TITLE
fix: resolve storyboard scene limit and fix OpenAI image generation model

### DIFF
--- a/backend/src/app/modules/story_visualizer/story_visualizer.service.ts
+++ b/backend/src/app/modules/story_visualizer/story_visualizer.service.ts
@@ -13,7 +13,6 @@ import {
 import { generateStoryboardImage } from "../../../utils/storyboard_image_generation";
 
 const STORY_VISUALIZER_TIMEOUT_MS = 90000;
-const MAX_IMAGES_PER_STORYBOARD = 2;
 
 const mapStoryVisualizerError = (error: unknown): never => {
   if (error instanceof ApiError) {
@@ -52,38 +51,26 @@ const attachSceneImages = async (
   scenes: IStoryboardScene[],
   styleGuide: string
 ): Promise<IStoryboardScene[]> => {
-  const scenesWithImages: IStoryboardScene[] = [];
-
-  for (let index = 0; index < scenes.length; index += 1) {
-    const scene = scenes[index];
-
-    if (index >= MAX_IMAGES_PER_STORYBOARD) {
-      scenesWithImages.push({
-        ...scene,
-        imageStatus: "pending",
-      });
-      continue;
-    }
-
+  const promises = scenes.map(async (scene) => {
     try {
       const imageUrl = await generateStoryboardImage(
         buildStoryboardImagePrompt(styleGuide, scene.imagePrompt)
       );
 
-      scenesWithImages.push({
+      return {
         ...scene,
         ...(imageUrl ? { imageUrl } : {}),
-        imageStatus: imageUrl ? "generated" : "failed",
-      });
+        imageStatus: imageUrl ? ("generated" as const) : ("failed" as const),
+      };
     } catch (error) {
-      scenesWithImages.push({
+      return {
         ...scene,
-        imageStatus: "failed",
-      });
+        imageStatus: "failed" as const,
+      };
     }
-  }
+  });
 
-  return scenesWithImages;
+  return Promise.all(promises);
 };
 
 const generateStoryboard = async (

--- a/backend/src/utils/storyboard_image_generation.ts
+++ b/backend/src/utils/storyboard_image_generation.ts
@@ -41,7 +41,7 @@ const generateWithOpenAI = async (prompt: string): Promise<string | null> => {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      model: "gpt-image-1",
+      model: "dall-e-3",
       prompt,
       size: "1024x1024",
       quality: "low",


### PR DESCRIPTION

- **Description:** Fixed storyboard scene image limit and OpenAI model parameters in the backend.

## Screenshot (when helpful)

N/A - Back-end changes affecting API payload variables and concurrency logic.

## What this PR does

Fixes issue #2151 

This PR resolves two key issues related to storyboard generation in the backend:
1. **Storyboard Scene Limit & Stuck "Pending" State:** Removed the hardcoded `MAX_IMAGES_PER_STORYBOARD = 2` limitation in `story_visualizer.service.ts`. Refactored `attachSceneImages` to run all image generations concurrently using `Promise.all` instead of sequentially. This prevents scenes from being skipped and permanently stuck in a `"pending"` status.
2. **Invalid OpenAI Model Name:** Fixed a bug in `storyboard_image_generation.ts` where the model name was incorrectly configured as `"gpt-image-1"`. It has been updated to the valid OpenAI image generation model `"dall-e-3"` to ensure API requests succeed.

## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [x] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Documentation update

## Related issue
Nine

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.