### PR TITLE
fix(backend): use aiFreeStoryContinuation in collab socket to prevent…

### DIFF
--- a/backend/src/socket/collab.socket.ts
+++ b/backend/src/socket/collab.socket.ts
@@ -221,14 +221,12 @@ socket.on("collab:ai_continue", async ({ roomId }) => {
         ? `Continue the following story naturally and creatively in 2-3 sentences based on the context. Return ONLY the continuation text, do not add any quotes, titles, JSON, formatting, or labels:\n\nStory Context:\n${storyContext}\n\nContinuation:`
         : "Start a collaborative story naturally and creatively in 2-3 sentences. Return ONLY the story text, do not add any quotes, titles, JSON, formatting, or labels.";
 
-      const result = await AiModelService.aiFreeModelGenerate({
+      const result = await AiModelService.aiFreeStoryContinuation({
         prompt,
-        wordLength: 120,
-        numStories: 1,
         language: "English",
       });
 
-      const continuationText = result?.[0]?.content?.trim();
+      const continuationText = result?.continuation?.trim();
 
       if (!continuationText) {
         throw new Error("Empty response from AI");


### PR DESCRIPTION
… collab socket to prevent prompt conflicts

## Before you open this PR

## What this PR does

This PR resolves a prompt conflict and generation mismatch in the real-time AI collaboration handler:
1. **Changes AI Service Invocation**: Modifies the `collab:ai_continue` socket event handler inside `collab.socket.ts` to call `AiModelService.aiFreeStoryContinuation` instead of `AiModelService.aiFreeModelGenerate`.
2. **Prevents Prompt Interference**: The `aiFreeModelGenerate` method is designed for structured post generation and wraps prompt inputs with formatting instructions (requesting titles, tag, emotions, etc. in JSON format). This directly conflicted with the collab continuation request (to output *only* 2-3 sentences of natural continuation), confusing the AI.
3. **Corrects Output Extract**: Updates extraction from `result?.[0]?.content?.trim()` to `result?.continuation?.trim()`, matching the exact format of the returned continuation payload.


## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #2175


## More screenshots (optional)

<!-- Extra before/after images, flows, or recordings for reviewers. -->



## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason. (N/A: Backend-only socket changes)
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
