### PR TITLE
fix: resolve text contrast visibility on Writing Templates page

### DIFF
--- a/frontend/src/components/templates/templates.component.tsx
+++ b/frontend/src/components/templates/templates.component.tsx
@@ -28,10 +28,10 @@ const TemplateCard: React.FC<TemplateCardProps> = ({
   };
 
   return (
-    <div className="group relative bg-white/[0.02] backdrop-blur-xl border border-white/10 rounded-2xl overflow-hidden shadow-lg hover:shadow-indigo-500/20 hover:border-indigo-500/50 transition-all duration-500 flex flex-col h-full transform hover:-translate-y-1">
+    <div className="group relative bg-white dark:bg-white/[0.02] backdrop-blur-xl border border-slate-200 dark:border-white/10 rounded-2xl overflow-hidden shadow-lg hover:shadow-indigo-500/20 hover:border-indigo-500/50 dark:hover:border-indigo-500/50 transition-all duration-500 flex flex-col h-full transform hover:-translate-y-1">
       {/* Banner Image with Zoom Effect */}
-      <div className="relative h-48 overflow-hidden w-full shrink-0 bg-[#0B0F19]">
-        <div className="absolute inset-0 bg-gradient-to-t from-[#0B0F19] via-[#0B0F19]/40 to-transparent z-10 pointer-events-none"></div>
+      <div className="relative h-48 overflow-hidden w-full shrink-0 bg-slate-100 dark:bg-[#0B0F19]">
+        <div className="absolute inset-0 bg-gradient-to-t from-white via-white/40 dark:from-[#0B0F19] dark:via-[#0B0F19]/40 to-transparent z-10 pointer-events-none"></div>
         <ImageFallback
           src={image}
           alt={title}
@@ -45,19 +45,19 @@ const TemplateCard: React.FC<TemplateCardProps> = ({
 
       <div className="p-6 flex flex-col flex-grow relative z-20 -mt-10">
         {/* Icon overlay */}
-        <div className={`w-12 h-12 rounded-xl flex items-center justify-center shadow-lg backdrop-blur-md border border-white/20 mb-4 ${color} relative z-30 ring-4 ring-[#0B0F19]`}>
+        <div className={`w-12 h-12 rounded-xl flex items-center justify-center shadow-lg backdrop-blur-md border border-white/50 dark:border-white/20 mb-4 ${color} relative z-30 ring-4 ring-white dark:ring-[#0B0F19]`}>
           <i className={`${icon} text-xl text-white`}></i>
         </div>
         
-        <h3 className="text-xl font-bold text-gray-100 mb-3 group-hover:text-indigo-400 transition-colors duration-300">
+        <h3 className="text-xl font-bold text-slate-900 dark:text-gray-100 mb-3 group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors duration-300">
           {title}
         </h3>
-        <p className="text-gray-400 mb-6 flex-grow leading-relaxed text-sm">
+        <p className="text-slate-600 dark:text-gray-400 mb-6 flex-grow leading-relaxed text-sm">
           {description}
         </p>
         <button
           onClick={handleUseTemplate}
-          className="mt-auto w-full py-3.5 rounded-xl bg-indigo-500/10 hover:bg-indigo-500/20 border border-indigo-500/30 hover:border-indigo-500/50 text-indigo-300 hover:text-indigo-200 font-semibold transition-all duration-300 flex items-center justify-center gap-2 group/btn"
+          className="mt-auto w-full py-3.5 rounded-xl bg-indigo-50 dark:bg-indigo-500/10 hover:bg-indigo-100 dark:hover:bg-indigo-500/20 border border-indigo-200 dark:border-indigo-500/30 hover:border-indigo-300 dark:hover:border-indigo-500/50 text-indigo-600 dark:text-indigo-300 hover:text-indigo-700 dark:hover:text-indigo-200 font-semibold transition-all duration-300 flex items-center justify-center gap-2 group/btn"
         >
           <span>Use Template</span>
           <i className="fas fa-arrow-right text-sm transform group-hover/btn:translate-x-1 transition-transform"></i>
@@ -206,7 +206,7 @@ const TemplatesComponent = () => {
   ];
 
   return (
-    <div className="bg-gradient-to-br animate-gradient-slow min-h-screen pb-24 relative overflow-hidden">
+    <div className="bg-gradient-to-br animate-gradient-slow min-h-screen pb-24 relative overflow-hidden dark:bg-transparent">
       {/* Background decorations */}
       <div className="absolute top-[-200px] right-[-100px] w-[600px] h-[600px] bg-blue-500/10 rounded-full blur-3xl -z-10 pointer-events-none"></div>
       <div className="absolute bottom-[20%] left-[-150px] w-[500px] h-[500px] bg-indigo-500/10 rounded-full blur-3xl -z-10 pointer-events-none"></div>
@@ -217,7 +217,7 @@ const TemplatesComponent = () => {
         <div className="mb-4">
           <button 
             onClick={() => navigate('/')}
-            className="group inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-white/5 border border-white/10 text-gray-400 hover:text-white hover:bg-white/10 hover:border-indigo-500/30 transition-all duration-300 shadow-[0_0_15px_rgba(0,0,0,0)] hover:shadow-[0_0_15px_rgba(99,102,241,0.2)]"
+            className="group inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-slate-100 dark:bg-white/5 border border-slate-200 dark:border-white/10 text-slate-600 dark:text-gray-400 hover:text-slate-900 dark:hover:text-white hover:bg-slate-200 dark:hover:bg-white/10 hover:border-indigo-300 dark:hover:border-indigo-500/30 transition-all duration-300 shadow-[0_0_15px_rgba(0,0,0,0)] hover:shadow-[0_0_15px_rgba(99,102,241,0.2)]"
           >
             <i className="fas fa-arrow-left text-sm transform group-hover:-translate-x-1 transition-transform"></i>
             <span className="text-sm font-semibold tracking-wide">Back to Home</span>
@@ -225,19 +225,19 @@ const TemplatesComponent = () => {
         </div>
         {/* Hero Section */}
         <div className="text-center mb-24 relative mt-4">
-          <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[800px] h-[400px] bg-indigo-600/20 rounded-[100%] blur-[120px] -z-10 pointer-events-none"></div>
+          <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[800px] h-[400px] bg-indigo-600/10 dark:bg-indigo-600/20 rounded-[100%] blur-[120px] -z-10 pointer-events-none"></div>
           
-          <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-indigo-500/30 bg-indigo-500/10 text-indigo-300 text-xs font-semibold tracking-widest uppercase mb-8 backdrop-blur-sm shadow-[0_0_20px_rgba(99,102,241,0.2)]">
+          <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-indigo-200 dark:border-indigo-500/30 bg-indigo-50 dark:bg-indigo-500/10 text-indigo-700 dark:text-indigo-300 text-xs font-semibold tracking-widest uppercase mb-8 backdrop-blur-sm shadow-[0_0_20px_rgba(99,102,241,0.1)] dark:shadow-[0_0_20px_rgba(99,102,241,0.2)]">
             <span className="relative flex h-2 w-2">
               <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-indigo-400 opacity-75"></span>
               <span className="relative inline-flex rounded-full h-2 w-2 bg-indigo-500"></span>
             </span>
             Professional Writing Templates
           </div>
-          <h1 className="text-5xl md:text-7xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-white via-blue-100 to-indigo-300 mb-8 tracking-tight drop-shadow-2xl">
+          <h1 className="text-5xl md:text-7xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-slate-900 via-indigo-800 to-indigo-600 dark:from-white dark:via-blue-100 dark:to-indigo-300 mb-8 tracking-tight drop-shadow-sm dark:drop-shadow-2xl">
             Writing Templates
           </h1>
-          <p className="text-xl text-gray-400 max-w-xl mx-auto mb-10 leading-relaxed font-light">
+          <p className="text-xl text-slate-600 dark:text-gray-400 max-w-xl mx-auto mb-10 leading-relaxed font-light">
             Skip the blank page. Choose from beautifully crafted templates for stories, poems, characters, and creative inspiration.
           </p>
           <div className="flex flex-col sm:flex-row items-center justify-center gap-5">
@@ -262,7 +262,7 @@ const TemplatesComponent = () => {
               <div className="w-10 h-10 rounded-lg bg-emerald-500/20 flex items-center justify-center border border-emerald-500/30 text-emerald-400">
                 <i className="fas fa-book-open"></i>
               </div>
-              <h2 className="text-3xl font-bold text-gray-100">Story Writing</h2>
+              <h2 className="text-3xl font-bold text-slate-900 dark:text-gray-100">Story Writing</h2>
               <div className="h-px bg-gradient-to-r from-emerald-500/50 to-transparent flex-grow ml-4"></div>
             </div>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
@@ -278,7 +278,7 @@ const TemplatesComponent = () => {
               <div className="w-10 h-10 rounded-lg bg-purple-500/20 flex items-center justify-center border border-purple-500/30 text-purple-400">
                 <i className="fas fa-pen-nib"></i>
               </div>
-              <h2 className="text-3xl font-bold text-gray-100">Creative Writing</h2>
+              <h2 className="text-3xl font-bold text-slate-900 dark:text-gray-100">Creative Writing</h2>
               <div className="h-px bg-gradient-to-r from-purple-500/50 to-transparent flex-grow ml-4"></div>
             </div>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
@@ -294,7 +294,7 @@ const TemplatesComponent = () => {
               <div className="w-10 h-10 rounded-lg bg-pink-500/20 flex items-center justify-center border border-pink-500/30 text-pink-400">
                 <i className="fas fa-lightbulb"></i>
               </div>
-              <h2 className="text-3xl font-bold text-gray-100">Writing Inspiration</h2>
+              <h2 className="text-3xl font-bold text-slate-900 dark:text-gray-100">Writing Inspiration</h2>
               <div className="h-px bg-gradient-to-r from-pink-500/50 to-transparent flex-grow ml-4"></div>
             </div>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
@@ -309,20 +309,20 @@ const TemplatesComponent = () => {
         {/* CTA Section */}
         <div className="mt-32 mb-10 relative rounded-3xl p-[1px] bg-gradient-to-b from-indigo-500/40 via-indigo-500/10 to-transparent overflow-hidden group">
           <div className="absolute inset-0 bg-indigo-500/10 blur-2xl group-hover:bg-indigo-500/20 transition-all duration-700"></div>
-          <div className="relative bg-gradient-to-b from-[#0f1423]/90 to-[#0B0F19]/90 backdrop-blur-xl rounded-3xl p-12 md:p-20 border border-white/5 text-center overflow-hidden h-full w-full shadow-2xl">
+          <div className="relative bg-gradient-to-b from-white to-slate-50 dark:from-[#0f1423]/90 dark:to-[#0B0F19]/90 backdrop-blur-xl rounded-3xl p-12 md:p-20 border border-slate-200 dark:border-white/5 text-center overflow-hidden h-full w-full shadow-xl dark:shadow-2xl">
             <div className="absolute -top-32 right-0 w-96 h-96 bg-blue-500/20 rounded-full blur-[100px] -z-10 pointer-events-none transition-all duration-700 group-hover:bg-blue-500/30"></div>
             <div className="absolute -bottom-32 left-0 w-96 h-96 bg-indigo-500/20 rounded-full blur-[100px] -z-10 pointer-events-none transition-all duration-700 group-hover:bg-indigo-500/30"></div>
             
             <div className="relative z-10 flex flex-col items-center">
-              <h2 className="text-4xl md:text-5xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-white via-indigo-100 to-indigo-300 mb-6 tracking-tight drop-shadow-xl">
+              <h2 className="text-4xl md:text-5xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-slate-900 via-indigo-800 to-indigo-600 dark:from-white dark:via-indigo-100 dark:to-indigo-300 mb-6 tracking-tight drop-shadow-sm dark:drop-shadow-xl">
                 Your next great story starts here ✨
               </h2>
-              <p className="text-xl text-gray-400 mb-12 max-w-2xl mx-auto font-light leading-relaxed">
+              <p className="text-xl text-slate-600 dark:text-gray-400 mb-12 max-w-2xl mx-auto font-light leading-relaxed">
                 Choose a template, spark an idea, and let Story Spark AI turn your imagination into something unforgettable.
               </p>
               <button 
                 onClick={() => navigate('/stories')}
-                className="group/btn px-10 py-4 rounded-full bg-gradient-to-r from-blue-600 to-indigo-600 text-white font-bold text-lg shadow-[0_0_30px_rgba(79,70,229,0.4)] hover:shadow-[0_0_50px_rgba(79,70,229,0.6)] hover:scale-105 transition-all duration-300 flex items-center justify-center gap-3 mx-auto border border-white/10"
+                className="group/btn px-10 py-4 rounded-full bg-gradient-to-r from-blue-600 to-indigo-600 text-white font-bold text-lg shadow-[0_0_30px_rgba(79,70,229,0.4)] hover:shadow-[0_0_50px_rgba(79,70,229,0.6)] hover:scale-105 transition-all duration-300 flex items-center justify-center gap-3 mx-auto border border-slate-200 dark:border-white/10"
               >
                 <span>Start Creating</span>
                 <i className="fas fa-arrow-right transform group-hover/btn:translate-x-1 transition-transform"></i>


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Open or link a related issue when there is one (`Closes #123`, `Fixes #45`, or write **None** under Related issue below).
- **Description:** Fill in **What this PR does** so a reviewer can understand the change without your local context.
- **Screenshots:** Add screenshots or a short recording when they help (UI changes, confusing flows, or non-code proof). If not needed, say so in the checklist.

## Screenshot (when helpful)
N/A


## What this PR does

This PR resolves a severe text contrast and visibility issue on the "Writing Templates" page. Previously, the primary hero heading ("Writing Templates") and section headers (e.g., "Story Writing", "Creative Writing") were illegible in light mode due to using light-colored text on a light background. 

**Changes made:**
- Implemented proper responsive light and dark mode utility classes across the `templates.component.tsx`.
- Updated base text colors to `text-slate-900` and `text-slate-600` for excellent contrast in light mode.
- Preserved the existing bright text aesthetics for dark mode using the `dark:` prefix (e.g., `dark:text-white`, `dark:text-gray-100`).
- Adjusted background gradients, badges, and the CTA card to complement both light and dark themes beautifully.




## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [X] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

closes #2141 



## More screenshots (optional)


BEFORE

<img width="1872" height="818" alt="Screenshot 2026-06-03 221228" src="https://github.com/user-attachments/assets/a1fdd046-bd80-4d04-8b50-e64da5c53c1e" />

AFTER

<img width="1907" height="900" alt="Screenshot 2026-06-04 132057" src="https://github.com/user-attachments/assets/aeca5be5-d1d6-4e9a-a27a-3ff0544e56b7" />



## Checklist

- [X] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [X] I have filled in the related issue number when there is one.
- [X] I have tested my changes.
- [X] I have done a self-review of the code.
