### PR TITLE
fix: remove write-on-read anti-pattern in getProfileInfo (#2197)

### DIFF
--- a/backend/src/app/modules/user/user.service.ts
+++ b/backend/src/app/modules/user/user.service.ts
@@ -172,17 +172,9 @@ const getProfileInfo = async (token: ITokenPayload) => {
     throw new ApiError(httpStatus.BAD_REQUEST, "User not found!");
   }
 
-  const publishedPostsCount = await Post.countDocuments({
-    author: user._id,
-    isPublished: true,
-    isDeleted: { $ne: true },
-  });
-
-  if (user.postsCount !== publishedPostsCount) {
-    user.postsCount = publishedPostsCount;
-    await user.save();
-  }
-
+  // postsCount is kept in sync via event-driven increments in createPost and
+  // decrements in deletePost. We do NOT repair it here to keep this GET
+  // endpoint side-effect-free and idempotent (fixes write-on-read anti-pattern).
   return user;
 };
 


### PR DESCRIPTION
Closes #2197

## Changes
- Removed `Post.countDocuments()` + `user.save()` from `getProfileInfo` in `user.service.ts`
- Profile GET is now a pure read with no side effects
- `postsCount` sync is already handled in `createPost` and `deletePost`

## Why
Every profile page load was triggering a DB write via `user.save()`, which:
- Violates REST idempotency (GET should not mutate state)
- Triggers the bcrypt `pre('save')` hook unnecessarily
- Causes write contention under concurrent load

Contributing under GSSoC'26 🎯
