### PR TITLE
fix: wire storyQueue to branching controller to enforce AI concurrenc…

### DIFF
--- a/backend/src/controllers/storyBranchingController.ts
+++ b/backend/src/controllers/storyBranchingController.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from "express";
 import { generateStory } from "../services/ai.service";
 import sendResponse from "../shared/send_response";
+import { storyQueue } from "../services/storyRequestQueue";
 
 const sanitizeJsonText = (rawText: string): string => {
   const trimmed = rawText.trim();
@@ -53,7 +54,7 @@ Task:
 }
 `;
 
-      const result = await generateStory(prompt);
+      const result = await storyQueue.enqueue(() => generateStory(prompt));
 
       let parsed: { storySegment: string; choices: string[] };
       try {


### PR DESCRIPTION
## Screenshot (when helpful)

N/A — This is a purely backend logic fix for API concurrency. 

## What this PR does

`storyRequestQueue.ts` was originally added to cap concurrent AI generation calls and prevent API overload, but it was never wired into the branching controller. 

This PR connects the two files by importing `storyQueue` and wrapping the `generateStory` call with `storyQueue.enqueue()`, effectively enforcing the `AI_CONCURRENCY` cap.

**File modified:** `backend/src/controllers/storyBranchingController.ts`

**Code Before:**
```ts
const result = await generateStory(prompt);
```

**Code After:**
```ts
import { storyQueue } from "../services/storyRequestQueue";

// ... existing code ...

const result = await storyQueue.enqueue(() => generateStory(prompt));
```

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Fixes #2200

## More screenshots (optional)

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason (N/A — backend concurrency logic).
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.