### PR TITLE
fix: make cors origins configurable

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -27,12 +27,10 @@ const limiter = rateLimit({
 });
 app.use(limiter as unknown as RequestHandler);
 
-const defaultCorsOrigins = [
-  "http://localhost:4001",
-  "http://localhost:4002",
-  "https://storysparkai-five.vercel.app",
-  "https://storysparkai.vercel.app",
-];
+const defaultCorsOrigins =
+  process.env.NODE_ENV === "development"
+  ? ["http://localhost:4001", "http://localhost:4002"]
+  : [];
 
 const corsOrigins =
   config.cors_origins && config.cors_origins.length > 0

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -32,13 +32,21 @@ async function main() {
     });
 
     const httpServer = http.createServer(app);
+    const defaultCorsOrigins =
+      process.env.NODE_ENV === "development"
+      ? ["http://localhost:4001", "http://localhost:4002"]
+      : [];
+
+    const socketCorsOrigins =
+      config.cors_origins && config.cors_origins.length > 0
+      ? config.cors_origins
+      : defaultCorsOrigins;
+
     const io = new Server(httpServer, {
-      cors: {
-        origin: config.cors_origins?.length
-          ? config.cors_origins
-          : ["http://localhost:4001", "https://storysparkai-five.vercel.app"],
-        credentials: true,
-      },
+        cors: {
+          origin: socketCorsOrigins,
+          credentials: true,
+        },
     });
 
     const [{ setNotificationSocket }, { setupCollabSocket }] = await Promise.all([


### PR DESCRIPTION

## Screenshot (when helpful)
N/A – Configuration-only change. No UI changes involved.
## What this PR does
This PR makes CORS origins configurable instead of relying on hardcoded localhost ports.

**Changes made:**

- Added environment-based default CORS origins for development:
- http://localhost:4001
- http://localhost:4002
- Production environments no longer use hardcoded localhost origins by default.
- Uses CORS_ORIGINS when provided through environment variables.
- Applied the same configurable CORS logic to both Express CORS middleware and Socket.IO CORS configuration.

This improves deployment flexibility across development, staging, and production environments.
## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue
Closes #2160 
## More screenshots (optional)
N/A
## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.

## Build Status

The typecheck workflow is currently failing due to existing syntax errors in:

- src/app/modules/post/post.service.ts
- src/app/modules/reaction/reaction.service.ts

These files were not modified as part of this PR. This PR only updates the CORS configuration in app.ts and server.ts.
