### PR TITLE
feat: add clear prompt button

### DIFF
--- a/frontend/src/components/story-inspiration-page/StoryInspirationPage.tsx
+++ b/frontend/src/components/story-inspiration-page/StoryInspirationPage.tsx
@@ -37,13 +37,29 @@ const StoryInspirationPage: React.FC = () => {
         value={intro}
         onChange={e => setIntro(e.target.value)}
       />
-      <button
-        className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
-        onClick={fetchIdeas}
-        disabled={loading || !intro.trim()}
-      >
-        {loading ? 'Generating...' : 'Get Ideas'}
-      </button>
+    <div className="flex gap-2">
+  <button
+    className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+    onClick={fetchIdeas}
+    disabled={loading || !intro.trim()}
+  >
+    {loading ? 'Generating...' : 'Get Ideas'}
+  </button>
+
+  {intro.trim() && (
+    <button
+      type="button"
+      onClick={() => {
+        setIntro('');
+        setIdeas([]);
+        setError('');
+      }}
+      className="bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600"
+    >
+      Clear Prompt
+    </button>
+  )}
+</div>
       {error && <div className="text-red-600 mt-4">{error}</div>}
       {ideas.length > 0 && (
         <div className="mt-6">


### PR DESCRIPTION
## Description

Fixes #2065

Added a Clear Prompt button to the Story Inspiration page.

### Changes Made

- Added a "Clear Prompt" button beside the "Get Ideas" button.
- Button only appears when the prompt textarea contains text.
- Clicking the button clears:
  - Story prompt input
  - Generated story ideas
  - Error messages
- Maintained existing UI styling and functionality.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

### Before
- Users had to manually delete the entire prompt text.
- No quick way to reset the input field.

### After
- Clear Prompt button appears when text is entered.
- One click clears the prompt, generated ideas, and errors.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (repository contains existing unrelated lint errors).
- [ ] I have run `npm run test` and all tests pass locally.
- [ ] I have run `npm run test:coverage` and branch coverage is at or above 70%.
- [x] My commits follow the Conventional Commits format.
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The changes maintain the existing UI quality and responsiveness standards.
- [ ] (Recommended) I joined the project Discord server.