### PR TITLE
fix(hooks): reset retry state after retry completion

### DIFF
--- a/frontend/src/hooks/useRetry.ts
+++ b/frontend/src/hooks/useRetry.ts
@@ -13,7 +13,7 @@ export interface UseRetryReturn {
   countdown: number;       // seconds remaining before next retry allowed
   MAX_RETRIES: number;
   setIsTimeout: (v: boolean) => void;
-  handleRetry: (triggerFn: () => void) => void;
+  handleRetry: (triggerFn: () => void | Promise<void>) => void;
   resetRetry: () => void;
 }
 
@@ -46,7 +46,7 @@ export function useRetry({
   );
 
   const handleRetry = useCallback(
-    (triggerFn: () => void) => {
+    (triggerFn: () => void | Promise<void>) => {
       // Prevent multiple simultaneous retries (issue requirement #4)
       if (isRetrying || countdown > 0) return;
       if (retryCount >= maxRetries) return;
@@ -58,15 +58,23 @@ export function useRetry({
       // Exponential backoff delay: 0s, 2s, 4s for retries 1, 2, 3
       const delaySeconds = baseDelay > 0 ? baseDelay * nextCount : 0;
 
+      const executeTrigger = async () => {
+        try {
+          await triggerFn();
+        } finally {
+          setIsRetrying(false);
+        }
+      };
+
       if (delaySeconds > 0) {
         setIsRetrying(false); // not retrying yet, counting down
         startCountdown(delaySeconds, () => {
           setIsRetrying(true);
-          triggerFn();
+          executeTrigger();
         });
       } else {
         setIsRetrying(true);
-        triggerFn();
+        executeTrigger();
       }
     },
     [isRetrying, countdown, retryCount, maxRetries, baseDelay, startCountdown]


### PR DESCRIPTION
## What this PR does

This PR fixes a bug in the `useRetry` hook where retry operations become permanently blocked after the first retry attempt.

### Problem

The hook sets `isRetrying` to `true` when a retry begins, but never resets it after the retry operation finishes.

Because the retry guard checks:

```ts
if (isRetrying || countdown > 0) return;
```

all future retries are blocked after the first execution.

### Solution

Updated `handleRetry` to support both synchronous and asynchronous retry functions:

```ts
(triggerFn: () => void | Promise<void>)
```

Introduced an internal execution wrapper that:

* Executes the retry callback.
* Waits for async operations to complete.
* Resets `isRetrying` inside a `finally` block.

This guarantees cleanup regardless of success or failure.

### Benefits

* Restores multi-attempt retry behavior.
* Prevents retry lockups.
* Supports async retry handlers safely.
* Ensures retry state is always cleaned up.

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

## Related issue

Fixes #2268 

## More screenshots (optional)

N/A

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.
