### PR TITLE
Fix/gamification addxp race condition

### DIFF
--- a/backend/src/app/modules/gamification/gamification.service.ts
+++ b/backend/src/app/modules/gamification/gamification.service.ts
@@ -97,24 +97,26 @@ const updateDailyStreak = async (userId: string) => {
 
 const addXp = async (userId: string, amount: number, reason: string) => {
   try {
-    const updatedUser = await User.findByIdAndUpdate(
-      userId,
-      {
-        $inc: { "gamification.xp": amount },
-      },
-      { new: true }
+    await User.updateOne(
+      { _id: userId },
+      [
+        {
+          $set: {
+            "gamification.xp": { $add: [{ $ifNull: ["$gamification.xp", 0] }, amount] }
+          }
+        },
+        {
+          $set: {
+            "gamification.level": {
+              $max: [
+                { $ifNull: ["$gamification.level", 1] },
+                { $add: [{ $floor: { $sqrt: { $divide: ["$gamification.xp", 100] } } }, 1] }
+              ]
+            }
+          }
+        }
+      ]
     );
-
-    if (!updatedUser?.gamification) return;
-
-    const newXp = updatedUser.gamification.xp || 0;
-    const newLevel = calculateLevel(newXp);
-
-    if (newLevel > (updatedUser.gamification.level || 1)) {
-      await User.findByIdAndUpdate(userId, {
-        $max: { "gamification.level": newLevel },
-      });
-    }
   } catch (error) {
     console.error(`Error adding XP for ${reason}:`, error);
   }

--- a/backend/src/app/modules/newsletter/newsletter.controller.ts
+++ b/backend/src/app/modules/newsletter/newsletter.controller.ts
@@ -58,8 +58,6 @@ export const unsubscribeByToken = async (req: Request, res: Response) => {
     const safeToken = Array.isArray(token) ? token[0] : token;
 
     const result = await newsletterService.unsubscribeByToken(safeToken);
-    const token = req.params.token as string;
-    const result = await newsletterService.unsubscribeByToken(token);
     res.status(200).json(result);
   } catch (err: any) {
     res.status(400).json({ message: err.message });

--- a/backend/src/app/modules/post/post.service.ts
+++ b/backend/src/app/modules/post/post.service.ts
@@ -409,11 +409,6 @@ const toggleBookmark = async (postId: string, token: ITokenPayload) => {
 
   const postExists = await Post.exists({ _id: postId, isDeleted: { $ne: true } });
   if (!postExists) {
-
-  const post = await Post.findOne({ _id: postId, isDeleted: { $ne: true } });
-
-  if (!post) {
-
     throw new ApiError(httpStatus.BAD_REQUEST, "Post not found!");
   }
 

--- a/backend/src/app/modules/post/post.service.ts
+++ b/backend/src/app/modules/post/post.service.ts
@@ -16,12 +16,9 @@ import { SortOrder, Types } from "mongoose";
 import { GamificationService } from "../gamification/gamification.service";
 
 const MAX_SEARCH_TERM_LENGTH = 100;
-const escapeRegex = (text: string) => text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
-
 const escapeRegex = (text: string): string => {
   return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
 };
-const MAX_SEARCH_TERM_LENGTH = 100;
 
 interface ICursorPayload {
   value: string;

--- a/backend/src/app/modules/reaction/reaction.service.ts
+++ b/backend/src/app/modules/reaction/reaction.service.ts
@@ -16,7 +16,6 @@ const toggleReaction = async (
   const { email } = token;
 
   const user = await User.findOne({ email });
-  const user = await User.findOne({ email }).select("_id").lean();
 
   if (!user) {
     throw new ApiError(httpStatus.BAD_REQUEST, "User not found!");
@@ -26,7 +25,6 @@ const toggleReaction = async (
     _id: postId,
     isDeleted: { $ne: true },
   });
-  }).select("likesCount reactions");
 
   if (!post) {
     throw new ApiError(httpStatus.BAD_REQUEST, "Post not found!");

--- a/backend/src/config/razorpay.ts
+++ b/backend/src/config/razorpay.ts
@@ -1,9 +1,9 @@
 // Initializes and exports the Razorpay instance using credentials from environment variables
 const Razorpay = require("razorpay");
 
-let razorpayInstance: Razorpay | null = null;
+let razorpayInstance: typeof Razorpay | null = null;
 
-export function getRazorpay(): Razorpay {
+export function getRazorpay(): typeof Razorpay {
   if (!razorpayInstance) {
     if (!process.env.RAZORPAY_KEY_ID || !process.env.RAZORPAY_KEY_SECRET) {
       throw new Error("Razorpay credentials are missing in environment variables");


### PR DESCRIPTION
Closes #2309

## Changes
- Refactored `addXp` in `gamification.service.ts` to use a single atomic `updateOne` with an aggregation pipeline.
- XP increment and Level calculation (using `$sqrt` and `$floor`) now happen atomically inside the MongoDB engine.
- Removed the separate `findByIdAndUpdate` calls that were creating a race window under concurrent load.

## Why
Under heavy concurrent load (e.g. rapid fire XP events), doing sequential DB reads and writes causes missed increments and dropped XP. By pushing the calculation entirely into the database transaction layer via aggregation pipeline, we guarantee absolute consistency.

Contributing under GSSoC'26 🎯
