### PR TITLE
fix: sanitize support email fields to prevent HTML injection

### DIFF
--- a/backend/src/utils/email.util.ts
+++ b/backend/src/utils/email.util.ts
@@ -1,6 +1,15 @@
 import nodemailer from "nodemailer";
 import config from "../config";
 
+const escapeHtml = (unsafe: string): string => {
+  return unsafe
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+};
+
 export const sendVerificationEmail = async (
   to: string,
   token: string,
@@ -84,22 +93,26 @@ export const sendContactEmail = async (data: {
 
   const displayName = data.fullname?.trim() || "Anonymous user";
   const displayEmail = data.email?.trim() || "Not provided";
+  const safeDisplayName = escapeHtml(displayName);
+  const safeDisplayEmail = escapeHtml(displayEmail);
+  const safeSubject = escapeHtml(data.subject);
+  const safeMessage = escapeHtml(data.message);
 
   const mailOptions = {
     from: `"Story Spark AI Support" <${config.verify_email}>`,
     replyTo: data.email?.trim() || undefined,
     to: config.verify_email,
-    subject: `Support Form [${feedbackTypeLabel}]: ${data.subject}`,
+    subject: `Support Form [${feedbackTypeLabel}]: ${safeSubject}`,
     html: `
       <div style="font-family: Arial, sans-serif; padding: 20px; color: #333;">
         <h2>New Support / Feedback Submission</h2>
         <p><strong>Type:</strong> ${feedbackTypeLabel}</p>
-        <p><strong>Name:</strong> ${displayName}</p>
-        <p><strong>Email:</strong> ${displayEmail}</p>
-        <p><strong>Subject:</strong> ${data.subject}</p>
+        <p><strong>Name:</strong> ${safeDisplayName}</p>
+        <p><strong>Email:</strong> ${safeDisplayEmail}</p>
+        <p><strong>Subject:</strong> ${safeSubject}</p>
         <hr style="border: none; border-top: 1px solid #eaeaea; margin: 20px 0;" />
         <p><strong>Message:</strong></p>
-        <p style="white-space: pre-wrap;">${data.message}</p>
+        <p style="white-space: pre-wrap;">${safeMessage}</p>
         <hr style="border: none; border-top: 1px solid #eaeaea; margin: 20px 0;" />
         <p style="color: #888; font-size: 12px;">This email was sent from the Story Spark AI support form.</p>
       </div>


### PR DESCRIPTION
## Issue Fix
Fixes #2266 

## What this PR does

Fixes the support email template by sanitizing user-provided input before rendering it in HTML emails.

### Changes

* Added an `escapeHtml` helper function
* Sanitized user-provided name, email, subject, and message fields
* Replaced raw values in the email template with escaped values

### Why

Previously, user input was rendered directly into the HTML email template. This could allow HTML content to be injected into support emails. Escaping user-provided values ensures the content is displayed as plain text and improves security.

## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

Not tested locally due to environment/build configuration issues. Change was verified through code review and is limited to input sanitization.

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [ ] I have tested my changes.
- [x] I have done a self-review of the code.
