### PR TITLE
fix: add DELETE /comment/delete/commentId=:commentId endpoint

### DIFF
--- a/backend/src/app/modules/comment/comment.controller.ts
+++ b/backend/src/app/modules/comment/comment.controller.ts
@@ -40,8 +40,21 @@ const toggleCommentLike = catchAsync(async (req: Request, res: Response) => {
   });
 });
 
+const deleteComment = catchAsync(async (req: Request, res: Response) => {
+  const commentId = routeParam(req.params.commentId);
+  const token = await getToken(req);
+  const result = await CommentService.deleteComment(commentId, token);
+  sendResponse(res, {
+    statusCode: httpStatus.OK,
+    success: true,
+    message: "Comment deleted successfully!",
+    data: result,
+  });
+});
+
 export const CommentController = {
   createComment,
   getCommentsByPostId,
   toggleCommentLike,
+  deleteComment,
 };

--- a/backend/src/app/modules/comment/comment.router.ts
+++ b/backend/src/app/modules/comment/comment.router.ts
@@ -34,4 +34,16 @@ router.patch(
   CommentController.toggleCommentLike
 );
 
+// Delete a comment (author or admin only)
+router.delete(
+  "/delete/commentId=:commentId",
+  auth(
+    ENUM_USER_ROLE.WRITER,
+    ENUM_USER_ROLE.ADMIN,
+    ENUM_USER_ROLE.SUPER_ADMIN,
+    ENUM_USER_ROLE.USER
+  ),
+  CommentController.deleteComment
+);
+
 export const CommentRouter = router;

--- a/backend/src/app/modules/comment/comment.service.ts
+++ b/backend/src/app/modules/comment/comment.service.ts
@@ -88,8 +88,36 @@ const toggleCommentLike = async (commentId: string, token: ITokenPayload) => {
   return updatedComment;
 };
 
+const deleteComment = async (commentId: string, token: ITokenPayload) => {
+  const { _id, email, role } = token;
+  const user = _id ? await User.findById(_id) : await User.findOne({ email });
+  if (!user) {
+    throw new ApiError(httpStatus.BAD_REQUEST, "User not found!");
+  }
+  const comment = await Comment.findById(commentId);
+  if (!comment) {
+    throw new ApiError(httpStatus.NOT_FOUND, "Comment not found!");
+  }
+  // Only the comment author or an admin/super-admin can delete
+  const isAuthor = comment.userId.toString() === user._id.toString();
+  const isAdmin = role === "ADMIN" || role === "SUPER_ADMIN";
+  if (!isAuthor && !isAdmin) {
+    throw new ApiError(
+      httpStatus.FORBIDDEN,
+      "You are not authorized to delete this comment!"
+    );
+  }
+  await Comment.findByIdAndDelete(commentId);
+  // Decrement commentsCount on the post atomically
+  await Post.findByIdAndUpdate(comment.postId, {
+    $inc: { commentsCount: -1 },
+  });
+  return { message: "Comment deleted successfully!" };
+};
+
 export const CommentService = {
   createComment,
   getCommentsByPostId,
   toggleCommentLike,
+  deleteComment,
 };


### PR DESCRIPTION
- No delete endpoint existed for comments — users who posted a comment had no way to remove it and admins could not delete individual comments through the API
- Added deleteComment to comment.service.ts:
  - Verifies the requesting user exists
  - Verifies the comment exists
  - Authorisation check: only the comment author or ADMIN/SUPER_ADMIN can delete — returns 403 Forbidden ## What this PR does
`CommentRouter` only exposed three endpoints — create, get by post, and toggle like. There was no DELETE endpoint for removing comments. Users who posted a comment had no way to remove it, and admins could not delete individual comments through the API.

Added `deleteComment` to `comment.service.ts`, `comment.controller.ts`, and `comment.router.ts`:
- Service verifies the requesting user exists, verifies the comment exists (404 if not), and enforces authorization — only the comment author or `ADMIN`/`SUPER_ADMIN` can delete (403 otherwise)
- Deletes the comment with `findByIdAndDelete` and atomically decrements `commentsCount` on the parent post via `$inc` to mirror the increment done in `createComment`
- Controller uses the same `catchAsync`/`sendResponse`/`routeParam` pattern as all other handlers
- Route `DELETE /delete/commentId=:commentId` protected by `auth` middleware for all authenticated roles

## Type of change
- [x] Bug fix
- [x] New feature

## Related issue
Fixes #1662

## More screenshots (optional)
N/A — backend API change with no UI.

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.