### PR TITLE
fix(#1683): reorder routes to prevent /:id from shadowing /tag/:tag

### DIFF
--- a/backend/src/app/modules/post/post.router.ts
+++ b/backend/src/app/modules/post/post.router.ts
@@ -22,8 +22,13 @@ router.post(
 );
 
 router.get(
-  "/",
-  PostController.getPosts
+  "/tag/:tag",
+  PostController.getPostsByTag
+);
+
+router.get(
+  "/:id",
+  PostController.getSinglePost
 );
 
 router.get(


### PR DESCRIPTION
Moves GET /tag/:tag above GET /:id so Express routes requests for /tag/science to the correct handler instead of matching the wildcard /:id route.

Fixes #1683