### PR TITLE
fix(ui): center and balance Share Review button padding in ReviewForm

### DIFF
--- a/frontend/src/components/home/writer_feedback/ReviewForm.tsx
+++ b/frontend/src/components/home/writer_feedback/ReviewForm.tsx
@@ -201,9 +201,9 @@ const ReviewForm = () => {
               type="button"
               onClick={handleSubmit}
               disabled={isLoading}
-              className="w-full py-2.5 px-4 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white font-semibold rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-offset-slate-900 mt-2"
+              className="w-full py-3 px-6 flex items-center justify-center gap-2 bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed text-white font-semibold rounded-xl transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-offset-slate-900 mt-4"
             >
-              {isLoading ? "Submitting..." : "Submit Review"}
+              {isLoading ? "Submitting..." : "Share Review ✨"}
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Screenshot 
<img width="968" height="198" alt="Screenshot 2026-06-06 112110" src="https://github.com/user-attachments/assets/263c9fe1-e668-4f85-8af7-a6b897c1a8f3" />


## What this PR does

The "Share Review ✨" button in the ReviewForm modal had asymmetric padding (`py-2.5 px-4`) and no explicit flex centering, causing it to appear visually unbalanced within the modal card.

Changes made to `frontend/src/components/home/writer_feedback/ReviewForm.tsx`:
- Added `flex items-center justify-center gap-2` for explicit centering (root fix)
- Balanced padding from `py-2.5 px-4` to `py-3 px-6`
- Applied gradient background (`from-blue-600 to-indigo-600`) consistent with modal design
- Updated `rounded-lg` to `rounded-xl` to match the card's rounded style
- Added `disabled:cursor-not-allowed` for better UX when loading
- Updated button text to "Share Review ✨" to match the deployed UI

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #2356

## More screenshots (optional)

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.