### PR TITLE
fix: replace hardcoded FontAwesome icon with SVG (#2366)

### DIFF
--- a/frontend/src/components/back_home/back.home.component.tsx
+++ b/frontend/src/components/back_home/back.home.component.tsx
@@ -1,7 +1,8 @@
+import { ArrowLeft } from "lucide-react";
 const BackHomeComponent = () => {
   return (
     <div className="bg-gradient-to-r from-slate-800 via-blue-500/10 to-slate-800 rounded-lg p-2 hover:from-slate-800 hover:via-blue-500/30 hover:to-slate-800 transition text-blue-600">
-      <i className="fa-solid fa-backward"></i> Back
+      <ArrowLeft size={16} className="inline mr-1" /> Back
     </div>
   );
 };


### PR DESCRIPTION
## What this PR does

* Replaced the hardcoded FontAwesome icon (`fa-solid fa-backward`) in `BackHomeComponent`
* Switched to the project's existing `lucide-react` icon system using `ArrowLeft`
* Removed dependency on external FontAwesome CSS for this component

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

## Related issue

Fixes #2366

## Screenshots

N/A

## Checklist

* [x] Code follows the project style
* [x] Changes are limited to the issue scope
* [x] No unrelated files were modified
