### PR TITLE
Improve: Add reproducible random seed support for ML model training

### DIFF
--- a/backend/ml/train_scorer.py
+++ b/backend/ml/train_scorer.py
@@ -24,8 +24,6 @@ random.seed(SEED)
 np.random.seed(SEED)
 tf.random.set_seed(SEED)
 
-
-
 from tensorflow.keras.preprocessing.text import Tokenizer
 from tensorflow.keras.preprocessing.sequence import pad_sequences
 from scorer import build_model, MAX_VOCAB, MAX_LEN, SAVE_DIR

--- a/backend/ml/train_scorer.py
+++ b/backend/ml/train_scorer.py
@@ -12,6 +12,14 @@ Place at: backend/ml/train_scorer.py
 import os, random, string
 import numpy as np
 import joblib
+import tensorflow as tf
+
+# Set random seeds for reproducible training results
+SEED = 42
+
+random.seed(SEED)
+np.random.seed(SEED)
+tf.random.set_seed(SEED)
 
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
 

--- a/backend/ml/train_scorer.py
+++ b/backend/ml/train_scorer.py
@@ -12,6 +12,9 @@ Place at: backend/ml/train_scorer.py
 import os, random, string
 import numpy as np
 import joblib
+
+os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
+
 import tensorflow as tf
 
 # Set random seeds for reproducible training results
@@ -21,7 +24,7 @@ random.seed(SEED)
 np.random.seed(SEED)
 tf.random.set_seed(SEED)
 
-os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
+
 
 from tensorflow.keras.preprocessing.text import Tokenizer
 from tensorflow.keras.preprocessing.sequence import pad_sequences


### PR DESCRIPTION
## Summary

This PR improves the reproducibility of the ML training pipeline by adding a fixed random seed configuration.

## Changes Made

* Added `import tensorflow as tf`
* Added a fixed seed value (`SEED = 42`)
* Added `random.seed(SEED)`
* Added `np.random.seed(SEED)`
* Added `tf.random.set_seed(SEED)`
* Added comments explaining the purpose of the seed configuration

## Why This Change?

The training script relies on random dataset generation and model initialization. Without a fixed random seed, training results may vary between runs, making debugging and model performance comparisons difficult.

This change helps ensure more consistent and reproducible training outcomes.

## Related Issue

Closes #2370