### PR TITLE
fix: use correct Comment model field names in getCommentsByPostId

### DIFF
--- a/backend/src/app/modules/comment/comment.service.ts
+++ b/backend/src/app/modules/comment/comment.service.ts
@@ -43,7 +43,7 @@ const createComment = async (
 };
 
 const getCommentsByPostId = async (postId: string) => {
-  return await Comment.find({ post: postId }).populate("author", "name profile.avatar").sort({ createdAt: -1 });
+  return await Comment.find({ postId }).populate("userId", "name profile.avatar").sort({ createdAt: -1 });
 };
 
 const toggleCommentLike = async (commentId: string, token: ITokenPayload) => {


### PR DESCRIPTION
## What this PR does

* Fixed the `getCommentsByPostId()` query to use the correct field names defined in the `Comment` model.
* Updated the comment retrieval logic so comments associated with a post are returned correctly.
* Ensured user information is populated using the appropriate relationship field from the schema.
* Kept the change minimal and limited to the comment retrieval functionality without modifying unrelated files or behavior.

---

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

---

## Related issue

Closes #2378

---

## More screenshots (optional)

N/A – No UI changes.

---

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.
