### PR TITLE
fix: allow admins and super admins to delete posts

### DIFF
--- a/backend/src/app/modules/post/__tests__/post.service.test.ts
+++ b/backend/src/app/modules/post/__tests__/post.service.test.ts
@@ -1,9 +1,12 @@
 import { Post } from "../post.model";
+import { User } from "../../user/user.model";
 import { PostService } from "../post.service";
+import { Bookmark } from "../../bookmark/bookmark.model";
 
 jest.mock("../post.model", () => ({
   Post: {
     find: jest.fn().mockReturnThis(),
+    findOne: jest.fn(),
     sort: jest.fn().mockReturnThis(),
     limit: jest.fn().mockReturnThis(),
     populate: jest.fn().mockReturnThis(),
@@ -11,7 +14,20 @@ jest.mock("../post.model", () => ({
   },
 }));
 
+jest.mock("../../user/user.model", () => ({
+  User: {
+    findOne: jest.fn(),
+  },
+}));
+
+jest.mock("../../bookmark/bookmark.model", () => ({
+  Bookmark: {
+    deleteMany: jest.fn().mockResolvedValue({}),
+  },
+}));
+
 const mockedPost = Post as jest.Mocked<typeof Post>;
+const mockedUser = User as jest.Mocked<typeof User>;
 
 describe("PostService", () => {
   beforeEach(() => {
@@ -34,6 +50,65 @@ describe("PostService", () => {
       expect(mockedPost.find).toHaveBeenCalledWith({
         isDeleted: { $ne: true },
         isPublished: true,
+      });
+    });
+  });
+
+  describe("deletePost — authorization", () => {
+    const postId = "post123";
+    const authorId = { toString: () => "user1" };
+
+    const makeUser = (id: string, role: string) => ({
+      _id: { toString: () => id },
+      role,
+      postsCount: 1,
+      save: jest.fn().mockResolvedValue(undefined),
+    });
+
+    const makePost = (authorStr: string) => ({
+      author: { toString: () => authorStr },
+      isPublished: true,
+      isDeleted: false,
+      deletedAt: null,
+      deletedBy: null,
+      save: jest.fn().mockResolvedValue(undefined),
+    });
+
+    it("should allow the post author to delete their own post", async () => {
+      const user = makeUser("user1", "user");
+      const post = makePost("user1");
+      mockedUser.findOne.mockResolvedValue(user as any);
+      mockedPost.findOne.mockResolvedValue(post as any);
+
+      await expect(PostService.deletePost(postId, { email: "a@a.com" } as any)).resolves.not.toThrow();
+    });
+
+    it("should allow admin to delete any post", async () => {
+      const user = makeUser("admin1", "admin");
+      const post = makePost("user1");
+      mockedUser.findOne.mockResolvedValue(user as any);
+      mockedPost.findOne.mockResolvedValue(post as any);
+
+      await expect(PostService.deletePost(postId, { email: "admin@a.com" } as any)).resolves.not.toThrow();
+    });
+
+    it("should allow super_admin to delete any post", async () => {
+      const user = makeUser("sa1", "super_admin");
+      const post = makePost("user1");
+      mockedUser.findOne.mockResolvedValue(user as any);
+      mockedPost.findOne.mockResolvedValue(post as any);
+
+      await expect(PostService.deletePost(postId, { email: "sa@a.com" } as any)).resolves.not.toThrow();
+    });
+
+    it("should forbid a non-author user from deleting another user's post", async () => {
+      const user = makeUser("user2", "user");
+      const post = makePost("user1");
+      mockedUser.findOne.mockResolvedValue(user as any);
+      mockedPost.findOne.mockResolvedValue(post as any);
+
+      await expect(PostService.deletePost(postId, { email: "b@b.com" } as any)).rejects.toMatchObject({
+        statusCode: 403,
       });
     });
   });

--- a/backend/src/app/modules/post/post.service.ts
+++ b/backend/src/app/modules/post/post.service.ts
@@ -486,7 +486,11 @@ const deletePost = async (postId: string, token: ITokenPayload) => {
     throw new ApiError(httpStatus.NOT_FOUND, "Post not found!");
   }
 
-  if (!post.author || post.author.toString() !== user._id.toString()) {
+  if (
+    post.author.toString() !== user._id.toString() &&
+    user.role !== "admin" &&
+    user.role !== "super_admin"
+  ) {
     throw new ApiError(
       httpStatus.FORBIDDEN,
       "You can only delete your own story!"


### PR DESCRIPTION
## What this PR does

Fixes the authorization logic in `deletePost()` to allow users with `admin` and `super_admin` roles to delete posts they do not own for moderation purposes.

Previously, only the original post author could delete a post. This prevented administrators from removing harmful, abusive, or policy-violating content.

The authorization check now follows the same pattern used in `updatePost()`, allowing:

* Post authors to delete their own posts.
* Admins to delete any post.
* Super admins to delete any post.

No other post deletion logic was modified.

---

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

---

## Related issue

Closes #2379

---

## More screenshots (optional)

N/A

---

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.
