### PR TITLE
fix: resolve setup-blocking bugs preventing local development

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -3,8 +3,9 @@
   "version": "1.0.0",
   "description": "Story Spark AI API (Express + MongoDB)",
   "main": "dist/server.js",
+  "type": "commonjs",
   "scripts": {
-    "dev": "ts-node-dev --respawn --transpile-only src/server.ts",
+    "dev": "npx tsx watch src/server.ts",
     "build": "tsc",
     "start": "node dist/server.js",
     "test": "jest --runInBand"
@@ -52,6 +53,7 @@
     "ts-jest": "^29.4.11",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
+    "tsx": "^4.22.4",
     "typescript": "^5.7.2"
   }
 }

--- a/backend/src/utils/generation_timeout.ts
+++ b/backend/src/utils/generation_timeout.ts
@@ -4,14 +4,12 @@ export class GenerationTimeoutError extends Error {
     this.name = "GenerationTimeoutError";
   }
 }
-
 export class GenerationAbortedError extends Error {
   constructor(message = "Generation aborted") {
     super(message);
     this.name = "GenerationAbortedError";
   }
 }
-
 /**
  * Races generation against a timeout; aborts via AbortSignal when time expires or after completion.
  */
@@ -20,33 +18,13 @@ export const raceGenerationWithTimeout = async <T>(
   timeLimitMs: number
 ): Promise<T> => {
   const controller = new AbortController();
-
-  return new Promise<T>((resolve, reject) => {
-    const timeoutId = setTimeout(() => {
-      controller.abort();
-      reject(new GenerationTimeoutError());
-    }, timeLimitMs);
-
-    operation(controller.signal)
-      .then((result) => {
-        clearTimeout(timeoutId);
-        controller.abort();
-        resolve(result);
-      })
-     export const raceGenerationWithTimeout = async <T>(
-  operation: (signal: AbortSignal) => Promise<T>,
-  timeLimitMs: number
-): Promise<T> => {
-  const controller = new AbortController();
   let timedOut = false;
-
   return new Promise<T>((resolve, reject) => {
     const timeoutId = setTimeout(() => {
       timedOut = true;
       controller.abort();
       reject(new GenerationTimeoutError());
     }, timeLimitMs);
-
     operation(controller.signal)
       .then((result) => {
         clearTimeout(timeoutId);
@@ -54,15 +32,11 @@ export const raceGenerationWithTimeout = async <T>(
       })
       .catch((error) => {
         clearTimeout(timeoutId);
-
         if (timedOut) {
           reject(new GenerationTimeoutError());
           return;
         }
-
         reject(error);
-              });
-          });
-        };
+      });
   });
 };

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -45,7 +45,6 @@ import PublishedStoriesComponent from "./components/dashboard/posts/published_st
 import ReportBug from "./components/report-bug/ReportBug";
 import ResourceDetailComponent from "./components/community/resource_detail.component";
 import ResourcesListComponent from "./components/community/resources_list.component";
-import ScrollToTop from "./components/ScrollToTop";
 import SettingComponent from "./components/dashboard/settings/settings.component";
 import SignUpComponent from "./components/signup/signup.component";
 import Terms from "./components/footer/terms.tsx";

--- a/frontend/src/components/signup/signup.component.tsx
+++ b/frontend/src/components/signup/signup.component.tsx
@@ -511,6 +511,7 @@ const SignUpComponent = () => {
             </>
           )}
         </div>
+        </div>
       </div>
 
       <Toaster position="top-right" reverseOrder={false} />


### PR DESCRIPTION
Description:
Summary
This PR fixes multiple bugs that completely block new contributors from running the project locally. All three bugs were reproducible on a clean clone following the README setup steps.

closes #2387

Changes
1. frontend/src/App.tsx — Duplicate ScrollToTop import
ScrollToTop was imported twice (lines 3 and 48), causing Vite to throw:
Identifier 'ScrollToTop' has already been declared.
Fix: Removed the duplicate import at line 48.

2. frontend/src/components/signup/signup.component.tsx — Missing closing </div>
The <div className="flex justify-center items-center gap-40"> wrapper (line 248) was never closed, causing Vite to throw:
Unterminated JSX contents. (517:10)
Fix: Added the missing </div> after the right panel closing tag.

3. backend/src/utils/generation_timeout.ts — Duplicate function merged incorrectly
Two versions of raceGenerationWithTimeout were merged together, with the second version pasted inside the first one's .then() block, causing:
SyntaxError: Unexpected token 'export'
Fix: Removed the malformed first version, kept the complete second version with the timedOut flag.

4. backend/package.json — ESM/CJS conflict crashes backend
The frontend's "type": "module" bleeds into the backend through npm workspaces, forcing ESM mode on the CommonJS backend. Also replaced ts-node-dev with tsx which handles this correctly.
Fix: Added "type": "commonjs" and replaced dev script with tsx watch.

How to reproduce (before this fix)

Clone the repo
npm install
Configure .env files per README
npm run dev
→ Frontend crashes with JSX errors, backend crashes with SyntaxError

How to verify (after this fix)

Apply these changes
npm install
npm run dev
→ Both frontend and backend start successfully


Type of change: bug fix
Tested on: Ubuntu 24, Node.js v20.20.2, npm 10.8.2