### PR TITLE
fix(error-page): preserve active auth session on Reset Cache & Reload

### DIFF
--- a/frontend/src/components/ErrorPage.tsx
+++ b/frontend/src/components/ErrorPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { AUTH_KEY } from "../constants/storage-key";
 
 const ErrorPage = () => {
   const [isReloading, setIsReloading] = useState(false);
@@ -13,17 +14,15 @@ const ErrorPage = () => {
   const handleResetCache = () => {
     setIsReloading(true);
     try {
-      // Preserve auth tokens
-      const authToken = localStorage.getItem("authToken");
-      const userPrefs = localStorage.getItem("userPreferences");
-      
+      // Preserve the active auth session so the user stays logged in
+      const accessToken = localStorage.getItem(AUTH_KEY);
+
       localStorage.clear();
       sessionStorage.clear();
-      
-      // Restore critical data
-      if (authToken) localStorage.setItem("authToken", authToken);
-      if (userPrefs) localStorage.setItem("userPreferences", userPrefs);
-      
+
+      // Restore the auth token after clearing cache
+      if (accessToken) localStorage.setItem(AUTH_KEY, accessToken);
+
       setTimeout(() => {
         window.location.reload();
       }, 300);

--- a/frontend/src/components/ErrorPage.tsx
+++ b/frontend/src/components/ErrorPage.tsx
@@ -15,13 +15,13 @@ const ErrorPage = () => {
     setIsReloading(true);
     try {
       // Preserve the active auth session so the user stays logged in
-      const accessToken = localStorage.getItem(AUTH_KEY);
+      const authToken = localStorage.getItem(AUTH_KEY);
 
       localStorage.clear();
       sessionStorage.clear();
 
       // Restore the auth token after clearing cache
-      if (accessToken) localStorage.setItem(AUTH_KEY, accessToken);
+      if (authToken) localStorage.setItem(AUTH_KEY, authToken);
 
       setTimeout(() => {
         window.location.reload();


### PR DESCRIPTION
## Screenshot (when helpful)

N/A — logic-only fix; no UI change. The button label and layout are unchanged. The auth session now survives the cache reset, which can be verified by logging in, triggering an error boundary, clicking **Reset Cache & Reload**, and confirming you land back on the dashboard rather than the login page.

## What this PR does

`handleResetCache` in `ErrorPage.tsx` was saving and restoring the auth token under the hardcoded key `"authToken"`, but the app stores the access token under the key exported as `AUTH_KEY` from `constants/storage-key.ts` (value: `"accessToken"`). Because the keys didn't match, the token was never actually preserved — `localStorage.clear()` wiped it and the user was silently logged out on every cache reset.

**Fix:** import `AUTH_KEY` and use it consistently for both the read and the write. Also removed the `userPreferences` preservation block — that key is never written anywhere in the codebase, so preserving it was dead code.

## Type of change

- [x] Bug fix

## Related issue

Fixes #2408

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.