### PR TITLE
fix(protected-route): reject expired and invalid tokens on story routes

### DIFF
--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,6 +1,5 @@
 import { Navigate } from 'react-router-dom';
-import { getFromLocalStorage } from '../utils/local-storage';
-import { AUTH_KEY } from '../constants/storage-key';
+import { isLoggedIn } from '../services/auth.service';
 
 interface ProtectedRouteProps {
   children: React.ReactNode;
@@ -8,20 +7,16 @@ interface ProtectedRouteProps {
 
 /**
  * SimpleProtectedRoute Component
- * Synchronously checks if user has valid auth token, Immediately redirects if no token (no loading state)
+ * Guards a route by verifying the stored token is present, structurally valid,
+ * and not expired. Redirects to /login immediately when any check fails.
  */
 const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
-  // Get token from localStorage SYNCHRONOUSLY (no useState needed)
-  const token = getFromLocalStorage(AUTH_KEY);
-  
-  // If NO token found → immediately redirect to login
-  if (!token) {
-    console.log("No token found, redirecting to login");
+  // isLoggedIn decodes the JWT and checks the `exp` claim, so expired or
+  // malformed tokens are treated the same as a missing token.
+  if (!isLoggedIn()) {
     return <Navigate to="/login" replace />;
   }
-  
-  // If token exists → show protected content
-  console.log("Token found, showing protected content");
+
   return <>{children}</>;
 };
 

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -7,12 +7,14 @@ interface ProtectedRouteProps {
 
 /**
  * SimpleProtectedRoute Component
- * Guards a route by verifying the stored token is present, structurally valid,
- * and not expired. Redirects to /login immediately when any check fails.
+ * Guards a route by verifying the stored token is present, decodable,
+ * and not past its `exp` claim. Redirects to /login immediately when
+ * any check fails.
  */
 const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
-  // isLoggedIn decodes the JWT and checks the `exp` claim, so expired or
-  // malformed tokens are treated the same as a missing token.
+  // isLoggedIn reads the token from localStorage, decodes it with
+  // jwtDecode, and returns false if the token is missing, malformed,
+  // or if Date.now() is past the `exp` claim.
   if (!isLoggedIn()) {
     return <Navigate to="/login" replace />;
   }


### PR DESCRIPTION
## Screenshot (when helpful)

N/A — auth/redirect logic only; no visual change. Reproducible manually: log in, wait for (or manually set) an expired token in localStorage, navigate to \`/story-workspace\` — before this fix the page renders, after it redirects to \`/login\`.

## What this PR does

`ProtectedRoute` (used to guard story routes in `App.tsx` as `SimpleProtectedRoute`) was checking only whether a token **string exists** in localStorage:

```ts
// before
const token = getFromLocalStorage(AUTH_KEY);
if (!token) return <Navigate to="/login" replace />;
```

A user with an **expired** or **structurally invalid** JWT would pass this check and see the protected page, because the string is still present in localStorage — it just isn't valid anymore.

**Fix:** replace the raw string check with `isLoggedIn()` from `auth.service`, which:
1. Reads the token from localStorage
2. Decodes the JWT with `jwtDecode`
3. Compares the `exp` claim against `Date.now()` — if expired, removes the token and returns `false`
4. Catches malformed tokens in a `try/catch` — also removes the token and returns `false`

Also removes two `console.log` calls that were leaking auth state to the browser console in production.

## Type of change

- [x] Bug fix

## Related issue

Fixes #2409

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.