### PR TITLE
fix: add mark-all-read and delete-all endpoints to NotificationRouter

### DIFF
--- a/backend/src/app/modules/notification/notification.controller.ts
+++ b/backend/src/app/modules/notification/notification.controller.ts
@@ -39,7 +39,31 @@ const markNotificationAsRead = catchAsync(
   }
 );
 
+const markAllNotificationsAsRead = catchAsync(async (req: Request, res: Response) => {
+  const token = req.user as ITokenPayload;
+  const result = await NotificationService.markAllNotificationsAsRead(token);
+  sendResponse(res, {
+    statusCode: httpStatus.OK,
+    success: true,
+    message: "All notifications marked as read successfully!",
+    data: result,
+  });
+});
+
+const deleteAllNotifications = catchAsync(async (req: Request, res: Response) => {
+  const token = req.user as ITokenPayload;
+  const result = await NotificationService.deleteAllNotifications(token);
+  sendResponse(res, {
+    statusCode: httpStatus.OK,
+    success: true,
+    message: "All notifications cleared successfully!",
+    data: result,
+  });
+});
+
 export const NotificationController = {
   getUserNotifications,
   markNotificationAsRead,
+  markAllNotificationsAsRead,
+  deleteAllNotifications,
 };

--- a/backend/src/app/modules/notification/notification.router.ts
+++ b/backend/src/app/modules/notification/notification.router.ts
@@ -27,4 +27,26 @@ router.patch(
   NotificationController.markNotificationAsRead
 );
 
+router.patch(
+  "/mark-all-read",
+  auth(
+    ENUM_USER_ROLE.ADMIN,
+    ENUM_USER_ROLE.SUPER_ADMIN,
+    ENUM_USER_ROLE.WRITER,
+    ENUM_USER_ROLE.USER
+  ),
+  NotificationController.markAllNotificationsAsRead
+);
+
+router.delete(
+  "/",
+  auth(
+    ENUM_USER_ROLE.ADMIN,
+    ENUM_USER_ROLE.SUPER_ADMIN,
+    ENUM_USER_ROLE.WRITER,
+    ENUM_USER_ROLE.USER
+  ),
+  NotificationController.deleteAllNotifications
+);
+
 export const NotificationRouter = router;

--- a/backend/src/app/modules/notification/notification.service.ts
+++ b/backend/src/app/modules/notification/notification.service.ts
@@ -76,9 +76,25 @@ const markNotificationAsRead = async (
   return notification;
 };
 
+const markAllNotificationsAsRead = async (token: ITokenPayload) => {
+  const userId = await resolveUserId(token);
+  await Notification.updateMany({ userId, isRead: false }, { isRead: true });
+  emitNotificationStateToUser(userId, "notification:all-read", {});
+  return { message: "All notifications marked as read!" };
+};
+
+const deleteAllNotifications = async (token: ITokenPayload) => {
+  const userId = await resolveUserId(token);
+  await Notification.deleteMany({ userId });
+  emitNotificationStateToUser(userId, "notification:all-cleared", {});
+  return { message: "All notifications cleared!" };
+};
+
 export const NotificationService = {
   createNotification,
   getUserNotifications,
   markNotificationAsRead,
+  markAllNotificationsAsRead,
+  deleteAllNotifications,
   resolveUserId,
 };


### PR DESCRIPTION
## What this PR does
`NotificationRouter` only had a single-item mark-as-read endpoint (`PATCH /:id/read`) with no bulk operations. Users with many unread notifications had to mark each one individually with separate API calls — there was no way to bulk acknowledge or clear all notifications at once.

Added two new endpoints:
- `PATCH /mark-all-read` — marks all unread notifications for the authenticated user as read using an atomic `updateMany` and emits a `notification:all-read` socket event
- `DELETE /` — deletes all notifications for the authenticated user using `deleteMany` and emits a `notification:all-cleared` socket event

Both endpoints use the existing `resolveUserId` helper, follow the `catchAsync`/`sendResponse` pattern, and are protected by `auth` middleware for all authenticated roles.

## Type of change
- [x] Bug fix
- [x] New feature

## Related issue
Fixes #2429

## More screenshots (optional)
N/A — backend API change with no UI.

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.