### PR TITLE
fix: replace hardcoded .limit(2) with configurable limit in getPostsByTag

### DIFF
--- a/backend/src/app/modules/post/post.controller.ts
+++ b/backend/src/app/modules/post/post.controller.ts
@@ -101,7 +101,8 @@ const getSinglePost = catchAsync(async (req: Request, res: Response) => {
 const getPostsByTag = catchAsync(async (req: Request, res: Response) => {
   const tag = routeParam(req.params.tag);
   const excludeId = req.query.excludeId as string | undefined;
-  const result = await PostService.getPostsByTag(tag, excludeId);
+  const limit = req.query.limit ? Math.min(Number(req.query.limit), 50) : 10;
+  const result = await PostService.getPostsByTag(tag, excludeId, limit);
   sendResponse(res, {
     statusCode: httpStatus.OK,
     success: true,

--- a/backend/src/app/modules/post/post.service.ts
+++ b/backend/src/app/modules/post/post.service.ts
@@ -372,7 +372,7 @@ const getSinglePost = async (id: string) => {
   return postById;
 };
 
-const getPostsByTag = async (tag: string, excludeId?: string) => {
+const getPostsByTag = async (tag: string, excludeId?: string, limit: number = 10) => {
   if (!tag) {
     return [];
   }
@@ -381,8 +381,10 @@ const getPostsByTag = async (tag: string, excludeId?: string) => {
   if (excludeId) {
     query._id = { $ne: excludeId };
   }
+  // limit was previously hardcoded as 2 — now accepts a caller-supplied
+  // value (default 10, max 50) so the route handler can expose it as a query param
   const result = await Post.find(query)
-    .limit(2)
+    .limit(Math.min(limit, 50))
     .populate("author", "name email createdAt")
     .populate({
       path: "reactions",


### PR DESCRIPTION
## What this PR does
`getPostsByTag` in `post.service.ts` hardcoded `.limit(2)` with no way for callers to request more results:

```ts
const result = await Post.find(query)
  .limit(2)  // always capped at 2 regardless of available matches
```

Related posts were always capped at 2 regardless of how many matching posts existed for that tag. There was no query parameter to request more results and no way to override the limit at the call site.

Changes made:
- Added optional `limit` parameter to `getPostsByTag` service function with a default of `10` and a hard cap of `50` via `Math.min(limit, 50)` to prevent unbounded queries
- Updated `getPostsByTag` controller to read `limit` from `req.query.limit` (default `10`, max `50`) and pass it to the service
- Added a comment explaining the previous hardcoded value and the new behaviour

## Type of change
- [x] Bug fix

## Related issue
Fixes #2430

## More screenshots (optional)
N/A — backend service change with no UI.

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.