### PR TITLE
fix: add missing aria-labels to icon-only buttons

### DIFF
--- a/frontend/src/components/BookmarkButton.tsx
+++ b/frontend/src/components/BookmarkButton.tsx
@@ -58,6 +58,7 @@ const BookmarkButton: React.FC<BookmarkButtonProps> = ({
       onClick={handleBookmark}
       disabled={isLoading}
       title={isCurrentlyBookmarked ? "Remove bookmark" : "Save story"}
+      aria-label={isCurrentlyBookmarked ? "Remove bookmark" : "Save story"}
       className={`!rounded-button cursor-pointer transition-all duration-300 border px-3 py-1 flex items-center justify-center hover:scale-105 active:scale-95 ${
         isCurrentlyBookmarked
           ? "text-purple-400 border-purple-500/50 bg-purple-500/10 hover:bg-purple-500/20 hover:text-purple-300"

--- a/frontend/src/components/chat/Chat.tsx
+++ b/frontend/src/components/chat/Chat.tsx
@@ -102,12 +102,14 @@ const ChatComponent: React.FC = () => {
               <div className="flex items-center gap-2">
                 <button
                   onClick={() => setIsMinimized(!isMinimized)}
+                  aria-label="Minimize chat"
                   className="p-1 hover:bg-white/10 rounded-lg transition-colors"
                 >
                   <Minus size={18} />
                 </button>
                 <button
                   onClick={() => setIsOpen(false)}
+                  aria-label="Close chat"
                   className="p-1 hover:bg-white/10 rounded-lg transition-colors"
                 >
                   <X size={18} />
@@ -185,6 +187,7 @@ const ChatComponent: React.FC = () => {
                     <button
                       type="button"
                       onClick={clearChat}
+                      aria-label="Clear chat history"
                       className="p-2 text-slate-400 hover:text-red-500 transition-colors"
                       title="Clear chat"
                     >
@@ -200,6 +203,7 @@ const ChatComponent: React.FC = () => {
                     <button
                       type="submit"
                       disabled={!message.trim() || isLoading}
+                      aria-label="Send message"
                       className="p-2 bg-indigo-600 text-white rounded-xl hover:bg-indigo-700 disabled:opacity-50 disabled:hover:bg-indigo-600 transition-all"
                     >
                       <Send size={20} />
@@ -218,6 +222,7 @@ const ChatComponent: React.FC = () => {
           setIsOpen(!isOpen);
           setIsMinimized(false);
         }}
+        aria-label={isOpen ? "Close chat" : "Open chat"}
         className={`w-14 h-14 rounded-full flex items-center justify-center shadow-lg transition-all duration-300 hover:scale-110 active:scale-95 ${
           isOpen
             ? "bg-slate-800 text-white rotate-90"

--- a/frontend/src/components/dashboard/dashboard_layout.component.tsx
+++ b/frontend/src/components/dashboard/dashboard_layout.component.tsx
@@ -228,7 +228,7 @@ const DashboardLayout: React.FC = () => {
       <header className="px-6 py-4 bg-gray-50 border-b border-gray-200 flex items-center justify-between dark:bg-[#0a1020] dark:border-white/[0.06]">
         <div className="flex items-center gap-4">
           <Link to="/">
-            <button className="w-9 h-9 rounded-lg bg-white/[0.7] hover:bg-white transition text-slate-900 dark:bg-white/[0.05] dark:hover:bg-white/[0.1] dark:text-white">
+            <button aria-label="Go back to home" className="w-9 h-9 rounded-lg bg-white/[0.7] hover:bg-white transition text-slate-900 dark:bg-white/[0.05] dark:hover:bg-white/[0.1] dark:text-white">
               <i className="fas fa-arrow-left"></i>
             </button>
           </Link>
@@ -239,7 +239,7 @@ const DashboardLayout: React.FC = () => {
         </div>
 
         <div className="flex items-center gap-4 text-slate-900 dark:text-white">
-          <button className="relative">
+          <button aria-label="Notifications" className="relative">
             <i className="fas fa-bell text-lg"></i>
             <span className="absolute -top-1 -right-2 bg-red-500 text-[10px] px-1 rounded-full">
               5

--- a/frontend/src/components/layout/floating_nav.component.tsx
+++ b/frontend/src/components/layout/floating_nav.component.tsx
@@ -106,6 +106,7 @@ const FloatingNavComponent: React.FC = () => {
                   <ThemeToggle />
                   <button
                     onClick={() => setIsMoreOpen(false)}
+                    aria-label="Close menu"
                     className="w-8 h-8 rounded-full bg-slate-100 dark:bg-white/10 flex items-center justify-center text-slate-500 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-white/20 hover:text-slate-950 dark:hover:text-white transition-all cursor-pointer"
                   >
                     <X size={16} />

--- a/frontend/src/components/notification/notification.component.tsx
+++ b/frontend/src/components/notification/notification.component.tsx
@@ -32,6 +32,7 @@ const NotificationComponent: React.FC<INotificationComponentProps> = ({
         <button
           className="rounded-full p-2 text-slate-400 transition-colors hover:bg-white/5 hover:text-white"
           onClick={() => setShowNotification(false)}
+          aria-label="Close notifications"
         >
           <i className="fas fa-times text-sm"></i>
         </button>

--- a/frontend/src/components/stories/RecentPromptsPanel.tsx
+++ b/frontend/src/components/stories/RecentPromptsPanel.tsx
@@ -94,6 +94,7 @@ const RecentPromptsPanel: React.FC<RecentPromptsPanelProps> = ({
             <button
               type="button"
               onClick={onToggle}
+              aria-label="Close recent prompts"
               className="text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-colors cursor-pointer"
               title={text.close}
             >

--- a/frontend/src/components/top_header/top_header.component.tsx
+++ b/frontend/src/components/top_header/top_header.component.tsx
@@ -36,6 +36,7 @@ const TopHeaderComponent = () => {
             <div className="hidden sm:ml-6 sm:flex sm:items-center">
               <button
                 type="button"
+                aria-label="Search"
                 className="!rounded-button p-2 text-gray-400 hover:text-gray-500"
               >
                 <i className="fas fa-search"></i>
@@ -44,6 +45,7 @@ const TopHeaderComponent = () => {
                 <div>
                   <button
                     type="button"
+                    aria-label="Notifications"
                     className="!rounded-button p-1 rounded-full text-gray-400 hover:text-gray-500 focus:outline-none cursor-pointer"
                     onClick={() => setShowNotification(true)}
                   >
@@ -55,6 +57,7 @@ const TopHeaderComponent = () => {
                 <div>
                   <button
                     type="button"
+                    aria-label="User profile"
                     className="!rounded-button bg-white flex text-sm rounded-full focus:outline-none"
                   >
                     <img

--- a/frontend/src/components/ui-component/floating-chat/floating_chat.component.tsx
+++ b/frontend/src/components/ui-component/floating-chat/floating_chat.component.tsx
@@ -208,6 +208,7 @@ export const FloatingChatWidget: React.FC = () => {
               <button
                 onClick={handleClearChat}
                 title="Clear conversation history"
+                aria-label="Clear conversation history"
                 className="text-slate-400 hover:text-rose-500 p-1.5 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800/60 transition-colors cursor-pointer"
               >
                 <i className="fa-solid fa-trash-can text-xs"></i>
@@ -215,6 +216,7 @@ export const FloatingChatWidget: React.FC = () => {
               <button
                 onClick={toggleWidget}
                 title="Collapse Assistant"
+                aria-label="Collapse assistant"
                 className="text-slate-400 hover:text-slate-700 dark:hover:text-white p-1.5 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800/60 transition-colors cursor-pointer"
               >
                 <i className="fa-solid fa-xmark text-sm"></i>


### PR DESCRIPTION
## What this PR does

Adds missing `aria-label` attributes to icon-only buttons across the frontend to improve accessibility.

These labels provide meaningful descriptions for screen readers and other assistive technologies, ensuring users can understand the purpose of icon-only controls without relying on visual context.

The changes are intentionally minimal and limited to accessibility improvements. No styling, functionality, or unrelated code was modified.

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

## Related issue

Fixes #2434

## More screenshots (optional)

N/A – No visual changes were introduced.

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.
