### PR TITLE
fix: harden token refresh logic and ensure Bearer prefix

### DIFF
--- a/frontend/src/helpers/axios/axiosInstance.ts
+++ b/frontend/src/helpers/axios/axiosInstance.ts
@@ -67,12 +67,20 @@ export const setupAxiosInterceptors = () => {
 
           if (newAccessToken) {
             setToLocalStorage(AUTH_KEY, newAccessToken);
-            originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+            if (originalRequest.headers.set) {
+              originalRequest.headers.set("Authorization", `Bearer ${newAccessToken}`);
+            } else {
+              originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+            }
             return instance(originalRequest);
+          } else {
+            throw new Error("No access token returned");
           }
-        } catch {
+        } catch (error) {
           removeFromLocalStorage(AUTH_KEY);
-          window.location.href = "/login";
+          if (typeof window !== "undefined") {
+            window.location.href = "/login";
+          }
           return Promise.reject(error);
         }
       }


### PR DESCRIPTION
## ✦ Description
Harden the token refresh logic in the Axios interceptor to ensure the `Bearer ` prefix is always correctly applied and handle edge cases where the refresh request might succeed but return no token. This prevents potential logout loops caused by malformed Authorization headers during retries.

Fixes #1936

---

## ⟡ Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (non-breaking change to docs)
- [ ] Code styling/formatting (prettier, eslint, spacing)

---

## ✦ Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings or console errors.

---

## Description

### Root Cause
The token refresh retry logic previously had potential for setting the `Authorization` header incorrectly and did not handle cases where the refresh endpoint returned success but no token, leading to unresolved requests and silent logout loops.

### Changes Made
- Updated `frontend/src/helpers/axios/axiosInstance.ts` to ensure the `Bearer ` prefix is consistently applied using idiomatic Axios 1.x methods.
- Added explicit error handling for missing tokens in successful refresh responses.
- Added environment safety checks (window object) to the interceptor logic.

### Testing Performed
Verified logic flow and header assignment consistency.

### Result
More resilient authentication state management and token recovery.

---

## Additional Notes
- Branch pushed: Pcmhacker-piro/story-spark-ai:fix/token-refresh-robustness
- Compare URL: https://github.com/ronisarkarexe/story-spark-ai/compare/main...Pcmhacker-piro:fix/token-refresh-robustness