### PR TITLE
fix(post): correct escapeRegex replacement string to actually escape metacharacters

### DIFF
--- a/backend/src/app/modules/post/post.service.ts
+++ b/backend/src/app/modules/post/post.service.ts
@@ -17,7 +17,7 @@ import { GamificationService } from "../gamification/gamification.service";
 const MAX_SEARCH_TERM_LENGTH = 100;
 
 const escapeRegex = (text: string): string => {
-  return text.replace(/[-[\]{}()*+?.,\^$|#\s]/g, "\$&");
+  return text.replace(/[-[\]{}()*+?.,\^$|#\s]/g, "\\$&");
 };
 
 interface ICursorPayload {


### PR DESCRIPTION
## Screenshot (when helpful)

N/A — backend-only one-line fix, no UI changes. See PoC output below demonstrating the bug and the fix.

## What this PR does

Fixes a broken regex escaping function in `backend/src/app/modules/post/post.service.ts` that silently fails to escape any metacharacters, leaving `getPosts()` and `getPublishedPostsByAuthor()` vulnerable to regex injection via user-supplied `searchTerm`.

The `escapeRegex` function on `main` currently reads:

```typescript
const escapeRegex = (text: string): string => {
  return text.replace(/[-[\]{}()*+?.,\^$|#\s]/g, "\$&");
};
```

The replacement string `"\$&"` is intended to produce the literal string `\$&` (backslash followed by the `$&` back-reference). However, in JavaScript, `\$` is **not** a recognized escape sequence — so the backslash is silently dropped at parse time. The runtime replacement string becomes just `"$&"`, which is the `String.replace()` special pattern meaning "the matched substring." Every matched metacharacter is replaced with itself — the function is a complete no-op.

This is a follow-up to PR #2407, which removed a duplicate raw `searchTerm` push in `getPosts()`. That fixed the bypass path, but `escapeRegex` itself remained broken, so both call sites (`getPosts` at line 144 and `getPublishedPostsByAuthor` at line 256) are still passing unsanitized input into MongoDB `$regex`.

### Fix

Change the replacement string from `"\$&"` to `"\\$&"`. In JavaScript, `\\` is the escape sequence for a literal backslash, so the runtime string becomes `\$&` — a literal backslash followed by the `$&` back-reference. This correctly prepends a backslash before every matched regex metacharacter.

The diff is a single character change on one line:

```diff
- return text.replace(/[-[\]{}()*+?.,\^$|#\s]/g, "\$&");
+ return text.replace(/[-[\]{}()*+?.,\^$|#\s]/g, "\\$&");
```

### Vulnerability details

**CWE-943** — Improper Neutralization of Special Elements in Data Query Logic

**Affected functions:** `escapeRegex()` (line 19), called by `getPosts()` (line 144) and `getPublishedPostsByAuthor()` (line 256) in `backend/src/app/modules/post/post.service.ts`.

**Impact — ReDoS:** Because `escapeRegex` is a no-op, attacker-supplied regex metacharacters pass through directly into MongoDB's `$regex` operator. A pattern like `(a+)+$` causes catastrophic backtracking in the regex engine, hanging the query and consuming server CPU. The `searchTerm` is trimmed and capped at 100 characters (`MAX_SEARCH_TERM_LENGTH`), but 100 characters is more than enough to construct a ReDoS payload — catastrophic backtracking in `(a+)+$` is achievable with as few as 25 characters.

**Impact — Regex injection:** An attacker can also inject `.*` to match all posts, or use targeted patterns to enumerate content beyond normal search results.

**Note on routing:** The `GET /` route for `getPosts` was removed by a recent refactor (PR #2098 reordered routes and dropped the `GET /` handler). Currently `getPosts` is exported from the service but has no HTTP route in `post.router.ts`. Similarly, `getPublishedPostsByAuthor` is exported but not mounted on any route. However, fixing the escape function is the correct defense-in-depth measure — any future route that calls these functions would immediately inherit the vulnerability if left unfixed.

## Type of change

- [x] Bug fix

## Related issue

Follows up on #2407 (merged), which removed the duplicate raw `searchTerm` regex bypass but did not fix the underlying broken `escapeRegex`.

## Proof of Concept

Run this in Node.js to confirm `escapeRegex` is a no-op on `main`:

```javascript
// Current main code — "\$&" resolves to "$&" at runtime
const escapeRegex_broken = (text) => text.replace(/[-[\]{}()*+?.,\^$|#\s]/g, "\$&");

// Fixed code — "\\$&" resolves to "\$&" at runtime
const escapeRegex_fixed = (text) => text.replace(/[-[\]{}()*+?.,\^$|#\s]/g, "\\$&");

const input = "(a+)+$";

console.log("Broken output:", escapeRegex_broken(input));
// => "(a+)+$"  — identical to input, no escaping happened

console.log("Fixed output:", escapeRegex_fixed(input));
// => "\(a\+\)\+\$"  — metacharacters properly escaped

console.log("Broken is no-op:", escapeRegex_broken(input) === input);
// => true
```

To verify the ReDoS impact, the unescaped pattern would be passed directly into MongoDB's `$regex`:

```javascript
// This is what MongoDB receives when escapeRegex is a no-op:
const regex = new RegExp("(a+)+$", "i");
// Catastrophic backtracking on input like "aaaaaaaaaaaaaaaaaaaaaaaa!"
const start = Date.now();
regex.test("aaaaaaaaaaaaaaaaaaaaaaaa!");
console.log("Regex took:", Date.now() - start, "ms");
// Will hang for seconds/minutes depending on input length
```

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.

## Adversarial review

Before submitting, we verified this isn't already mitigated. The `MAX_SEARCH_TERM_LENGTH` cap (100 chars) limits input size but does not prevent exploitation — ReDoS patterns like `(a+)+$` are well under 100 characters, and regex injection patterns like `.*` are trivially short. The previous PR (#2407) removed one bypass path (the duplicate raw `searchTerm` push), but the root cause — `escapeRegex` being a no-op — remains on `main`. We also confirmed that no middleware or framework-level sanitization exists between the Express route handler and the MongoDB query that would strip regex metacharacters.