### PR TITLE
feat(auth): Implement server-side JWT revocation/blacklisting mechanism on user logout

### DIFF
--- a/backend/src/app/middleware/auth.middleware.ts
+++ b/backend/src/app/middleware/auth.middleware.ts
@@ -28,7 +28,7 @@ const auth =
       const isBlacklisted = await TokenBlacklist.findOne({ token });
       if (isBlacklisted) {
         return res.status(401).json({
-          message: "Token has been revoked. Please log in again.",
+          message: "Token is invalidated/logged out",
         });
       }
 

--- a/backend/src/app/modules/auth/auth.controller.ts
+++ b/backend/src/app/modules/auth/auth.controller.ts
@@ -68,14 +68,8 @@ const logout = catchAsync(async (req: Request, res: Response) => {
 
   if (activeToken) {
     try {
-      const decoded = jwt.decode(activeToken) as jwt.JwtPayload | null;
-      const expiresAt = decoded && decoded.exp 
-        ? new Date(decoded.exp * 1000) 
-        : new Date(Date.now() + 24 * 60 * 60 * 1000); // fallback if no exp is present
-
       await TokenBlacklist.create({
         token: activeToken,
-        expiresAt,
       });
     } catch (err) {
       console.error("Error blacklisting token on logout:", err);

--- a/backend/src/app/modules/auth/tokenBlacklist.model.ts
+++ b/backend/src/app/modules/auth/tokenBlacklist.model.ts
@@ -2,21 +2,15 @@ import { Schema, model } from "mongoose";
 
 export interface ITokenBlacklist {
   token: string;
-  expiresAt: Date;
+  createdAt?: Date;
 }
 
 const tokenBlacklistSchema = new Schema<ITokenBlacklist>(
   {
     token: { type: String, required: true, unique: true, index: true },
-    expiresAt: { type: Date, required: true },
-  },
-  {
-    timestamps: true,
+    createdAt: { type: Date, default: Date.now, expires: '1d' },
   }
 );
-
-// Native MongoDB TTL index: documents automatically self-delete upon expiration.
-tokenBlacklistSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
 
 export const TokenBlacklist = model<ITokenBlacklist>(
   "TokenBlacklist",


### PR DESCRIPTION
### 🔍 Description
This PR resolves the security loophole where JWT tokens remained valid on the server side even after a user logs out. It implements a robust, automated server-side token revocation and blacklisting workflow.

### 🛠️ Changes Made
- **TokenBlacklist Model:** Created `tokenBlacklist.model.ts` with a native MongoDB TTL index set to `1d` for automated database cleanup.
- **Logout Controller:** Updated `auth.controller.ts` to intercept the bearer token upon logout and save it to the blacklist collection.
- **Auth Middleware:** Refactored `auth.middleware.ts` to query the blacklist database first; requests with revoked tokens are immediately blocked with a strict `401 Unauthorized` status ("Token is invalidated/logged out").

### 📌 GSSoC '26 Info
- **GSSoC '26 Contributor**
- **Closes:** #2288