### PR TITLE
fix(report-bug): remove invalid ellipsis from icon import

### DIFF
--- a/frontend/src/components/report-bug/ReportBug.tsx
+++ b/frontend/src/components/report-bug/ReportBug.tsx
@@ -2,7 +2,6 @@ import { useState, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "react-hot-toast";
 import { useSubmitBugReportMutation } from "../../redux/apis/bugReport.api";
-import { ..., Image as ImageIcon, X } from "lucide-react";
 import { 
   Bug, 
   Send, 
@@ -15,7 +14,9 @@ import {
   MessageSquare,
   ClipboardList,
   Target,
-  FileWarning
+  FileWarning,
+  Image as ImageIcon,
+  X
 } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 


### PR DESCRIPTION
## What this PR does

This PR fixes a TypeScript compilation error caused by an invalid placeholder inside a lucide-react import declaration.

Changes made:

- Removed invalid ellipsis (`...`).
- Restored valid import syntax.
- Verified successful compilation.

---

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

---

## Related issue

Closes #2478

---

## Checklist

- [x] Verified build success.
- [x] Completed self-review.