### PR TITLE
fix(auth.css): add missing .auth-form-card and .input-icon-wrapper st…

### DIFF
--- a/auth.css
+++ b/auth.css
@@ -240,6 +240,19 @@ input:focus {
     width: 100%;
 }
 
+/* ── Auth Form Card: width-constrained inner panel ── */
+.auth-form-card {
+    width: 100%;
+    max-width: var(--ds-card-max-width);
+    box-sizing: border-box;
+}
+
+/* ── Input Icon Wrapper: positioning context for icon + input ── */
+.input-icon-wrapper {
+    position: relative;
+    width: 100%;
+}
+
 /* ── Mobile Layout Media Queries ── */
 @media (max-width: 767px) {
     .auth-container {


### PR DESCRIPTION
Colse #2426 

## Bug Summary

On the login page (`login.html`), the email and password input fields were overflowing outside the boundaries of the authentication card container. Instead of sitting neatly inside the card panel, the inputs stretched beyond its edges, breaking the layout.

## Root Cause Analysis

The layout broke due to two missing CSS class definitions in `auth.css` that the HTML markup relies on:

1. **`.auth-form-card`**: Lacked a width constraint. The card expanded to fill the entire right pane, causing `w-full` inputs to inherit an unbounded width.
2. **`.input-icon-wrapper`**: Lacked a positioning context. Without `position: relative`, absolutely-positioned icons escaped the wrapper, and child inputs rendered without a properly constrained width.

## Changes Made

Added the missing structural classes to `auth.css` under the Panel Constraints section:

* **Added `.auth-form-card**`: Constrains the auth panel width (`max-width: var(--ds-card-max-width)` resolving to `420px`) and ensures padding is calculated safely via `box-sizing: border-box`.
* **Added `.input-icon-wrapper**`: Introduced `position: relative` to correctly anchor absolute children (icons/toggles) and set `width: 100%` so inputs size correctly against the card budget.

## Verification Checklist

Reviewers, please confirm the following:

* [x] Email, Password, and Full Name (sign-up mode) input fields are fully contained within the card boundaries.
* [x] The envelope/lock icons are correctly positioned inside the inputs on the left.
* [x] The password visibility toggle button appears correctly at the right edge of the password input.
* [x] No horizontal scrollbar appears on the page.
* [x] Card layout responds correctly on mobile (≤ 767px) by using full available width.
* [x] Card layout is correctly capped at 420px on desktop viewports (≥ 768px).
* [x] Switching between "LOG IN" and "CREATE ACCOUNT" tabs does not break the layout.
* [x] Input focus rings render correctly within the card.