### PR TITLE
feat: add soft delete functionality for comments

### DIFF
--- a/backend/src/app/modules/comment/comment.interface.ts
+++ b/backend/src/app/modules/comment/comment.interface.ts
@@ -6,6 +6,8 @@ export interface IComment {
   comment: string;
   parentCommentId?: Types.ObjectId;
   likes?: Types.ObjectId[];
+  isDeleted?: boolean;
+  deletedAt?: Date | null;
 }
 
 export type CommentModel = Model<IComment, object>;

--- a/backend/src/app/modules/comment/comment.model.ts
+++ b/backend/src/app/modules/comment/comment.model.ts
@@ -11,13 +11,23 @@ const CommentSchema: Schema<IComment> = new Schema<IComment, CommentModel>(
       ref: "Comment",
       default: null,
     },
-    likes: [
-      {
-        type: Schema.Types.ObjectId,
-        ref: "User",
-        default: [],
-      },
-    ],
+   likes: [
+  {
+    type: Schema.Types.ObjectId,
+    ref: "User",
+    default: [],
+  },
+],
+
+isDeleted: {
+  type: Boolean,
+  default: false,
+},
+
+deletedAt: {
+  type: Date,
+  default: null,
+},
   },
   { timestamps: true }
 );

--- a/backend/src/app/modules/comment/comment.service.ts
+++ b/backend/src/app/modules/comment/comment.service.ts
@@ -107,11 +107,11 @@ const deleteComment = async (commentId: string, token: ITokenPayload) => {
       "You are not authorized to delete this comment!"
     );
   }
-  await Comment.findByIdAndDelete(commentId);
-  // Decrement commentsCount on the post atomically
-  await Post.findByIdAndUpdate(comment.postId, {
-    $inc: { commentsCount: -1 },
-  });
+  await Comment.findByIdAndUpdate(commentId, {
+  isDeleted: true,
+  deletedAt: new Date(),
+  comment: "This comment was deleted",
+});
   return { message: "Comment deleted successfully!" };
 };
 

--- a/frontend/src/components/post/post.comment.component.tsx
+++ b/frontend/src/components/post/post.comment.component.tsx
@@ -4,6 +4,7 @@ import {
   useCreateCommentMutation,
   useGetCommentsListQuery,
   useToggleCommentLikeMutation,
+  useDeleteCommentMutation,
 } from "../../redux/apis/comment";
 import { isLoggedIn, getUserInfo } from "../../services/auth.service";
 import toast, { Toaster } from "react-hot-toast";
@@ -32,7 +33,7 @@ const PostCommentComponent: React.FC<IPostCommentComponentProps> = ({
   const { data: commentList } = useGetCommentsListQuery(postId);
   const [createComment] = useCreateCommentMutation();
   const [toggleCommentLike] = useToggleCommentLikeMutation();
-
+  const [deleteComment] = useDeleteCommentMutation();
   const onSubmit: SubmitHandler<Inputs> = async (data) => {
     if (!isLogin) {
       toast.error("Please login to post a comment.");
@@ -107,7 +108,20 @@ const PostCommentComponent: React.FC<IPostCommentComponentProps> = ({
       toast.error(getErrorMessage(err));
     }
   };
+  const handleDeleteComment = async (commentId: string) => {
+  const confirmed = window.confirm(
+    "Are you sure you want to delete this comment?"
+  );
 
+  if (!confirmed) return;
+
+  try {
+    await deleteComment(commentId).unwrap();
+    toast.success("Comment deleted successfully!");
+  } catch (err: unknown) {
+    toast.error(getErrorMessage(err));
+  }
+};
   return (
     <div>
       <form className="mb-8" onSubmit={handleSubmit(onSubmit)}>
@@ -161,8 +175,17 @@ const PostCommentComponent: React.FC<IPostCommentComponentProps> = ({
                     onClick={() => setReplyingTo(replyingTo === comment._id ? null : comment._id)}
                     className="hover:text-blue-400 transition-colors"
                   >
+                  
                     <i className="far fa-comment mr-1"></i> Reply
                   </button>
+                  {currentUser?.userId === comment?.userId?._id && (
+                  <button
+                  onClick={() => handleDeleteComment(comment._id)}
+                  className="hover:text-red-500 transition-colors"
+                  >
+    <i className="far fa-trash-alt mr-1"></i> Delete
+  </button>
+)}
                 </div>
 
                 {replyingTo === comment._id && (

--- a/frontend/src/redux/apis/comment.ts
+++ b/frontend/src/redux/apis/comment.ts
@@ -13,6 +13,7 @@ const commentApi = baseApi.injectEndpoints({
       }),
       invalidatesTags: [tagTypes.post, tagTypes.comment],
     }),
+
     getCommentsList: build.query({
       query: (postId: string) => ({
         url: `/${COMMENT_URL}/get-comments/postId=${postId}`,
@@ -24,6 +25,7 @@ const commentApi = baseApi.injectEndpoints({
       }) => response.data,
       providesTags: [tagTypes.post, tagTypes.comment],
     }),
+
     toggleCommentLike: build.mutation({
       query: (commentId: string) => ({
         url: `/${COMMENT_URL}/toggle-like/commentId=${commentId}`,
@@ -31,7 +33,20 @@ const commentApi = baseApi.injectEndpoints({
       }),
       invalidatesTags: [tagTypes.post, tagTypes.comment],
     }),
+
+    deleteComment: build.mutation({
+      query: (commentId: string) => ({
+        url: `/${COMMENT_URL}/delete/commentId=${commentId}`,
+        method: "DELETE",
+      }),
+      invalidatesTags: [tagTypes.post, tagTypes.comment],
+    }),
   }),
 });
 
-export const { useCreateCommentMutation, useGetCommentsListQuery, useToggleCommentLikeMutation } = commentApi;
+export const {
+  useCreateCommentMutation,
+  useGetCommentsListQuery,
+  useToggleCommentLikeMutation,
+  useDeleteCommentMutation,
+} = commentApi;


### PR DESCRIPTION
## Related issue

Closes #548

## What this PR does

- Added `isDeleted` and `deletedAt` fields to the comment model
- Replaced hard delete functionality with soft delete
- Added delete comment API endpoint integration
- Added delete comment option in the frontend for comment owners
- Preserved comment thread structure by replacing deleted comments with:
  `"This comment was deleted"`

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #548

## More screenshots (optional)

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.