### PR TITLE
Validate and sanitize input in remixStory and translateStory

### DIFF
--- a/backend/src/app/modules/post/post.service.ts
+++ b/backend/src/app/modules/post/post.service.ts
@@ -517,6 +517,13 @@ const deletePost = async (postId: string, token: ITokenPayload) => {
 };
 
 const remixStory = async (postId: string, prompt: string, token: ITokenPayload) => {
+  if (!prompt || typeof prompt !== "string") {
+    throw new ApiError(httpStatus.BAD_REQUEST, "Prompt is required and must be a string");
+  }
+  const safePrompt = prompt.slice(0, 500).replace(/[\n\r\t"]/g, " ").trim();
+  if (!safePrompt) {
+    throw new ApiError(httpStatus.BAD_REQUEST, "Prompt cannot be empty or whitespace");
+  }
   const user = await User.findOne({ email: token.email });
   if (!user) {
     throw new ApiError(httpStatus.BAD_REQUEST, "User not found!");
@@ -527,7 +534,7 @@ const remixStory = async (postId: string, prompt: string, token: ITokenPayload) 
     throw new ApiError(httpStatus.NOT_FOUND, "Original story post not found!");
   }
 
-  const remixedContent = `[AI Remixed Version based on prompt: "${prompt}"]\n\n${originalPost.content}`;
+  const remixedContent = `[AI Remixed Version based on prompt: "${safePrompt}"]\n\n${originalPost.content}`;
 
   const res = await Post.create({
     title: `Remix of ${originalPost.title}`,
@@ -546,6 +553,13 @@ const remixStory = async (postId: string, prompt: string, token: ITokenPayload) 
 };
 
 const translateStory = async (postId: string, language: string, token: ITokenPayload) => {
+  if (!language || typeof language !== "string") {
+    throw new ApiError(httpStatus.BAD_REQUEST, "Language is required and must be a string");
+  }
+  const safeLanguage = language.slice(0, 50).replace(/[\n\r\t"]/g, " ").trim();
+  if (!safeLanguage) {
+    throw new ApiError(httpStatus.BAD_REQUEST, "Language cannot be empty or whitespace");
+  }
   const user = await User.findOne({ email: token.email });
   if (!user) {
     throw new ApiError(httpStatus.BAD_REQUEST, "User not found!");
@@ -556,7 +570,7 @@ const translateStory = async (postId: string, language: string, token: ITokenPay
     throw new ApiError(httpStatus.NOT_FOUND, "Original story post not found!");
   }
 
-  const translatedContent = `[Translated to ${language}]\n\n${originalPost.content}`;
+  const translatedContent = `[Translated to ${safeLanguage}]\n\n${originalPost.content}`;
 
   const res = await Post.create({
     title: `${originalPost.title} (${language})`,


### PR DESCRIPTION
Adds input validation and sanitization for `prompt` in `remixStory` and `language` in `translateStory` functions in `post.service.ts`.

Previously, both functions accepted user input without any validation — allowing undefined values, unlimited length strings, and special characters like newlines and quotes that could cause content injection and storage issues.

**Changes made:**
- Added type check: throws 400 error if input is not a string
- Added length cap: `prompt` limited to 500 chars, `language` limited to 50 chars
- Sanitized special characters (newlines, tabs, quotes) using `.replace()`
- Added empty-after-sanitize check to catch whitespace-only inputs
- Replaced raw `${prompt}` and `${language}` with sanitized `${safePrompt}` and `${safeLanguage}` in template strings

## Type of change

- [x] Bug fix

## Related issue

Fixes #2446

## Screenshot

N/A — backend service logic change with no UI impact.

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.