### PR TITLE
Add password reset tests and fix forgot link

### DIFF
--- a/backend/src/__tests__/passwordReset.test.ts
+++ b/backend/src/__tests__/passwordReset.test.ts
@@ -1,0 +1,103 @@
+import mongoose from "mongoose";
+import httpStatus from "http-status";
+import { AuthService } from "../app/modules/auth/auth.service";
+import { User } from "../app/modules/user/user.model";
+import { OTPModel } from "../app/modules/verify_email/verify_email.model";
+import ApiError from "../errors/api_error";
+import { ENUM_USER_ROLE } from "../../enums/user";
+
+jest.mock("../app/modules/verify_email/verify_email.service", () => ({
+  VerifyEmailService: {
+    VerifyEmail: jest.fn().mockResolvedValue(true),
+    VerifyOtp: jest.fn().mockResolvedValue({ verified: true, verificationToken: "validToken" }),
+  },
+}));
+
+describe("Password Reset Flow", () => {
+  const mockEmail = "testuser@example.com";
+  
+  beforeAll(async () => {
+    // Setup in-memory db or mock mongoose methods if necessary
+    // Here we will mock since we do not have a real connection in this lightweight suite
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("AuthService.resetPassword", () => {
+    it("Reset succeeds with valid OTP + token", async () => {
+      jest.spyOn(User, "findOne").mockResolvedValue({
+        _id: new mongoose.Types.ObjectId(),
+        email: mockEmail,
+        password: "oldpassword",
+        tokenVersion: 1,
+        save: jest.fn().mockResolvedValue(true),
+      } as any);
+
+      jest.spyOn(OTPModel, "findOne").mockResolvedValue({
+        email: mockEmail,
+        isVerified: true,
+        verificationToken: "valid-token",
+        verificationTokenExpires: new Date(Date.now() + 1000 * 60),
+      } as any);
+
+      jest.spyOn(OTPModel, "deleteOne").mockResolvedValue({} as any);
+
+      const res = await AuthService.resetPassword({
+        email: mockEmail,
+        password: "NewPassword123!",
+        confirmPassword: "NewPassword123!",
+        verificationToken: "valid-token"
+      });
+
+      expect(res.accessToken).toBeDefined();
+      expect(res.refreshToken).toBeDefined();
+      expect(OTPModel.deleteOne).toHaveBeenCalledWith({ email: mockEmail });
+    });
+
+    it("Expired verification token returns 401", async () => {
+      jest.spyOn(User, "findOne").mockResolvedValue({ email: mockEmail } as any);
+      jest.spyOn(OTPModel, "findOne").mockResolvedValue({
+        email: mockEmail,
+        isVerified: true,
+        verificationToken: "expired-token",
+        verificationTokenExpires: new Date(Date.now() - 1000 * 60),
+      } as any);
+
+      await expect(
+        AuthService.resetPassword({
+          email: mockEmail,
+          password: "NewPassword123!",
+          confirmPassword: "NewPassword123!",
+          verificationToken: "expired-token"
+        })
+      ).rejects.toThrowError(new ApiError(httpStatus.UNAUTHORIZED, "Verification token has expired. Please verify your email again."));
+    });
+
+    it("Invalid token returns 401", async () => {
+      jest.spyOn(User, "findOne").mockResolvedValue({ email: mockEmail } as any);
+      jest.spyOn(OTPModel, "findOne").mockResolvedValue(null as any); // simulate token not found
+
+      await expect(
+        AuthService.resetPassword({
+          email: mockEmail,
+          password: "NewPassword123!",
+          confirmPassword: "NewPassword123!",
+          verificationToken: "invalid-token"
+        })
+      ).rejects.toThrowError(new ApiError(httpStatus.UNAUTHORIZED, "Invalid or expired verification token. Please verify your email again."));
+    });
+
+    it("Weak password rejected", async () => {
+      await expect(
+        AuthService.resetPassword({
+          email: mockEmail,
+          password: "weak",
+          confirmPassword: "weak",
+          verificationToken: "valid-token"
+        })
+      ).rejects.toThrowError(new ApiError(httpStatus.BAD_REQUEST, "Password must be at least 8 characters long"));
+    });
+  });
+});

--- a/login.html
+++ b/login.html
@@ -156,7 +156,7 @@
                 <div>
                     <div class="flex justify-between mb-1.5">
                         <label class="field-label" for="password-field">Password</label>
-                        <a class="text-[12px] text-primary hover:text-secondary transition-colors font-semibold cursor-pointer" id="forgot-password-link">Forgot Password?</a>
+                        <a class="text-[12px] text-primary hover:text-secondary transition-colors font-semibold cursor-pointer" id="forgot-password-link" href="/forgot-password">Forgot Password?</a>
                     </div>
                     <div class="input-icon-wrapper">
                         <i class="fi fi-rr-lock input-icon text-[16px] absolute left-4 top-1/2 -translate-y-1/2 text-on-surface-variant/80"></i>


### PR DESCRIPTION
Add comprehensive password reset unit tests (backend/src/__tests__/passwordReset.test.ts) covering successful reset, expired token, invalid token, and weak-password scenarios; mocks VerifyEmailService and OTP/User model interactions. Also update login.html to add href="/forgot-password" on the Forgot Password link so it navigates to the forgot-password page.

## Before you open this PR

- **Issue:** Open or link a related issue when there is one (`Closes #123`, `Fixes #45`, or write **None** under Related issue below).
- **Description:** Fill in **What this PR does** so a reviewer can understand the change without your local context.
- **Screenshots:** Add screenshots or a short recording when they help (UI changes, confusing flows, or non-code proof). If not needed, say so in the checklist.

## Screenshot (when helpful)

<!-- Drag & drop or paste. For non-UI work, you can use tests output, logs, or API responses. Write “N/A” in the checklist if you skip this section. -->



## What this PR does

<!-- Short summary: what problem does this solve, and how? -->




## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

<!-- Example: Closes #123 or Fixes #45. Use “None” if there is no issue. -->



## More screenshots (optional)

<!-- Extra before/after images, flows, or recordings for reviewers. -->



## Checklist

- [ ] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [ ] I have filled in the related issue number when there is one.
- [ ] I have tested my changes.
- [ ] I have done a self-review of the code.
