### PR TITLE
fix: conditionally mount GoogleOAuthProvider (#2497)

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -13,7 +13,6 @@ const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID;
 
 const googleClientId = import.meta.env.VITE_GOOGLE_CLIENT_ID || "";
 
-
 if (!GOOGLE_CLIENT_ID) {
   console.warn("VITE_GOOGLE_CLIENT_ID is missing. Google Login will not function.");
 }
@@ -26,12 +25,20 @@ if (!container) {
 
 createRoot(container).render(
   <StrictMode>
-    <GoogleOAuthProvider clientId={GOOGLE_CLIENT_ID || ""}>
+    {GOOGLE_CLIENT_ID ? (
+      <GoogleOAuthProvider clientId={GOOGLE_CLIENT_ID}>
+        <Provider store={store}>
+          <ThemeProvider>
+            <App />
+          </ThemeProvider>
+        </Provider>
+      </GoogleOAuthProvider>
+    ) : (
       <Provider store={store}>
         <ThemeProvider>
           <App />
         </ThemeProvider>
       </Provider>
-    </GoogleOAuthProvider>
+    )}
   </StrictMode>
 );


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Fixes #2497
- **Description:** Conditionally mounts `GoogleOAuthProvider` only when `VITE_GOOGLE_CLIENT_ID` is present to prevent mounting with an empty string.
- **Screenshots:** N/A (Logic update, no UI changes).

## Screenshot (when helpful)

N/A - This is a logic fix to prevent an empty string from being passed to the provider.

## What this PR does

This PR solves issue #2497. Previously, `GoogleOAuthProvider` was rendering even if `VITE_GOOGLE_CLIENT_ID` was missing from the `.env` file, passing an empty string as the client ID. I have updated `frontend/src/main.tsx` to conditionally wrap the app with `GoogleOAuthProvider` only if a valid `GOOGLE_CLIENT_ID` exists. If it's missing, the app renders normally without the provider.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Fixes #2497

## More screenshots (optional)

<!-- Extra before/after images, flows, or recordings for reviewers. -->

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.