### PR TITLE
fix: align login textbox within login container box

### DIFF
--- a/frontend/src/components/login/auth.css
+++ b/frontend/src/components/login/auth.css
@@ -509,3 +509,19 @@ button:disabled {
     }
     .ds-spinner { animation: none !important; }
 }
+/* ── Fix: Login textbox alignment within container ── */
+.auth-form-card .ds-input-group,
+.auth-form-card .input-icon-wrapper,
+.auth-form-card input[type="text"],
+.auth-form-card input[type="email"],
+.auth-form-card input[type="password"] {
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+.auth-form-card {
+  padding: 0 1rem;
+  box-sizing: border-box;
+  overflow: hidden;
+}


### PR DESCRIPTION
Fixes #2271 — Login textbox was overflowing outside the login box container.

## Changes made
- Added `box-sizing: border-box` and `max-width: 100%` constraints to all input wrappers inside `.auth-form-card` in `auth.css`
- Added `overflow: hidden` and padding to `.auth-form-card` to prevent inputs from breaking out of the card

## Type of change
- [x] Bug fix (UI alignment)

## Contributing under
GSSoC'26