### PR TITLE
feat: Implement graceful fallback and client disconnect streaming recovery (#2569, #2571)

### DIFF
--- a/backend/src/app/modules/ai_model/ai_model.controller.ts
+++ b/backend/src/app/modules/ai_model/ai_model.controller.ts
@@ -24,8 +24,11 @@ const aiModelGenerate = catchAsync(async (req: Request, res: Response) => {
     );
   }
 
+  const controller = new AbortController();
+  req.on("close", () => controller.abort());
+
   await runWithQuotaCleanup(guard, async () => {
-    const result = await AiModelService.aiModelGenerate(prompt);
+    const result = await AiModelService.aiModelGenerate(prompt, undefined, controller.signal);
     sendResponse(res, {
       statusCode: httpStatus.OK,
       success: true,
@@ -44,10 +47,13 @@ const aiFreeModelGenerate = catchAsync(async (req: Request, res: Response) => {
     setGuestUserIdCookie(res, userId);
   }
 
+  const controller = new AbortController();
+  req.on("close", () => controller.abort());
+
   const guard = createGuestQuotaGuard(userId);
   await runWithQuotaCleanup(guard, async () => {
     await reserveGuestQuota(userId);
-    const result = await AiModelService.aiFreeModelGenerate(prompt);
+    const result = await AiModelService.aiFreeModelGenerate(prompt, controller.signal);
     sendResponse(res, {
       statusCode: httpStatus.OK,
       success: true,
@@ -68,8 +74,11 @@ const aiModelAlternateEndings = catchAsync(async (req: Request, res: Response) =
     );
   }
 
+  const controller = new AbortController();
+  req.on("close", () => controller.abort());
+
   await runWithQuotaCleanup(guard, async () => {
-    const result = await AiModelService.aiModelAlternateEndings(payload);
+    const result = await AiModelService.aiModelAlternateEndings(payload, undefined, controller.signal);
     sendResponse(res, {
       statusCode: httpStatus.OK,
       success: true,
@@ -89,10 +98,13 @@ const aiFreeModelAlternateEndings = catchAsync(
       setGuestUserIdCookie(res, userId);
     }
 
+    const controller = new AbortController();
+    req.on("close", () => controller.abort());
+
     const guard = createGuestQuotaGuard(userId);
     await runWithQuotaCleanup(guard, async () => {
       await reserveGuestQuota(userId);
-      const result = await AiModelService.aiFreeModelAlternateEndings(payload);
+      const result = await AiModelService.aiFreeModelAlternateEndings(payload, controller.signal);
       sendResponse(res, {
         statusCode: httpStatus.OK,
         success: true,
@@ -130,16 +142,25 @@ await runWithQuotaCleanup(guard, async () => {
       wordLength ?? 250,
       numStories ?? 2,
       (chunk: string) => {
-        res.write(`data: ${JSON.stringify({ chunk })}\n\n`);
+        if (!res.writableEnded) res.write(`data: ${JSON.stringify({ chunk })}\n\n`);
       },
       controller.signal
     );
-    res.write(`data: ${JSON.stringify({ done: true })}\n\n`);
-    res.end();
-    } catch (error: unknown) {
+    if (!res.writableEnded) {
+      res.write(`data: ${JSON.stringify({ done: true })}\n\n`);
+      res.end();
+    }
+  } catch (error: unknown) {
+    if (controller.signal.aborted) {
+      // Client disconnected, do nothing else to avoid crashing
+      if (!res.writableEnded) res.end();
+      return;
+    }
     const errorMsg = error instanceof Error ? error.message : String(error);
-    res.write(`data: ${JSON.stringify({ error: errorMsg })}\n\n`);
-    res.end();
+    if (!res.writableEnded) {
+      res.write(`data: ${JSON.stringify({ error: errorMsg })}\n\n`);
+      res.end();
+    }
     throw error;
   }
 });
@@ -155,8 +176,11 @@ const aiModelRemix = catchAsync(async (req: Request, res: Response) => {
     );
   }
 
+  const controller = new AbortController();
+  req.on("close", () => controller.abort());
+
   await runWithQuotaCleanup(guard, async () => {
-    const result = await AiModelService.aiModelRemix(payload);
+    const result = await AiModelService.aiModelRemix(payload, undefined, controller.signal);
     sendResponse(res, {
       statusCode: httpStatus.OK,
       success: true,
@@ -175,10 +199,13 @@ const aiFreeModelRemix = catchAsync(async (req: Request, res: Response) => {
     setGuestUserIdCookie(res, userId);
   }
 
+  const controller = new AbortController();
+  req.on("close", () => controller.abort());
+
   const guard = createGuestQuotaGuard(userId);
   await runWithQuotaCleanup(guard, async () => {
     await reserveGuestQuota(userId);
-    const result = await AiModelService.aiFreeModelRemix(payload);
+    const result = await AiModelService.aiFreeModelRemix(payload, controller.signal);
     sendResponse(res, {
       statusCode: httpStatus.OK,
       success: true,
@@ -199,8 +226,11 @@ const aiModelTranslate = catchAsync(async (req: Request, res: Response) => {
     );
   }
 
+  const controller = new AbortController();
+  req.on("close", () => controller.abort());
+
   await runWithQuotaCleanup(guard, async () => {
-    const result = await AiModelService.aiModelTranslate(payload);
+    const result = await AiModelService.aiModelTranslate(payload, undefined, controller.signal);
     sendResponse(res, {
       statusCode: httpStatus.OK,
       success: true,
@@ -219,10 +249,13 @@ const aiFreeModelTranslate = catchAsync(async (req: Request, res: Response) => {
     setGuestUserIdCookie(res, userId);
   }
 
+  const controller = new AbortController();
+  req.on("close", () => controller.abort());
+
   const guard = createGuestQuotaGuard(userId);
   await runWithQuotaCleanup(guard, async () => {
     await reserveGuestQuota(userId);
-    const result = await AiModelService.aiFreeModelTranslate(payload);
+    const result = await AiModelService.aiFreeModelTranslate(payload, controller.signal);
     sendResponse(res, {
       statusCode: httpStatus.OK,
       success: true,
@@ -243,8 +276,11 @@ const aiModelChat = catchAsync(async (req: Request, res: Response) => {
     );
   }
 
+  const controller = new AbortController();
+  req.on("close", () => controller.abort());
+
   await runWithQuotaCleanup(guard, async () => {
-    const result = await AiModelService.aiModelChat(payload);
+    const result = await AiModelService.aiModelChat(payload, undefined, controller.signal);
     sendResponse(res, {
       statusCode: httpStatus.OK,
       success: true,
@@ -263,10 +299,13 @@ const aiFreeModelChat = catchAsync(async (req: Request, res: Response) => {
     setGuestUserIdCookie(res, userId);
   }
 
+  const controller = new AbortController();
+  req.on("close", () => controller.abort());
+
   const guard = createGuestQuotaGuard(userId);
   await runWithQuotaCleanup(guard, async () => {
     await reserveGuestQuota(userId);
-    const result = await AiModelService.aiFreeModelChat(payload);
+    const result = await AiModelService.aiFreeModelChat(payload, controller.signal);
     sendResponse(res, {
       statusCode: httpStatus.OK,
       success: true,
@@ -287,8 +326,11 @@ const aiStoryContinuation = catchAsync(async (req: Request, res: Response) => {
     );
   }
 
+  const controller = new AbortController();
+  req.on("close", () => controller.abort());
+
   await runWithQuotaCleanup(guard, async () => {
-    const result = await AiModelService.aiModelStoryContinuation(payload);
+    const result = await AiModelService.aiModelStoryContinuation(payload, undefined, controller.signal);
     sendResponse(res, {
       statusCode: httpStatus.OK,
       success: true,
@@ -307,10 +349,13 @@ const aiFreeStoryContinuation = catchAsync(async (req: Request, res: Response) =
     setGuestUserIdCookie(res, userId);
   }
 
+  const controller = new AbortController();
+  req.on("close", () => controller.abort());
+
   const guard = createGuestQuotaGuard(userId);
   await runWithQuotaCleanup(guard, async () => {
     await reserveGuestQuota(userId);
-    const result = await AiModelService.aiFreeStoryContinuation(payload);
+    const result = await AiModelService.aiFreeStoryContinuation(payload, controller.signal);
     sendResponse(res, {
       statusCode: httpStatus.OK,
       success: true,

--- a/backend/src/app/modules/ai_model/ai_model.service.ts
+++ b/backend/src/app/modules/ai_model/ai_model.service.ts
@@ -62,7 +62,7 @@ const mapGenerationError = (error: unknown, message: string): never => {
 
 // Bug fix 1: quota.lifecycle owns rollback — no manual User.updateOne needed.
 // Bug fix 2: _token kept as unused param (quota handled upstream by middleware).
-const aiModelGenerate = async (payload: IAIModel, _token?: ITokenPayload) => {
+const aiModelGenerate = async (payload: IAIModel, _token?: ITokenPayload, signal?: AbortSignal) => {
   const { prompt, wordLength, numStories, language, tone, genre, characters } =
     normalizeStoryPayload(payload);
 
@@ -79,7 +79,8 @@ const aiModelGenerate = async (payload: IAIModel, _token?: ITokenPayload) => {
           genre,
           characters,
         ),
-      AUTHENTICATED_GENERATION_TIMEOUT_MS
+      AUTHENTICATED_GENERATION_TIMEOUT_MS,
+      signal
     );
     assertSuccessfulGeneration(result, GENERATION_FAILED_MESSAGE);
     return result;
@@ -88,7 +89,7 @@ const aiModelGenerate = async (payload: IAIModel, _token?: ITokenPayload) => {
   }
 };
 
-const aiFreeModelGenerate = async (payload: IAIModel) => {
+const aiFreeModelGenerate = async (payload: IAIModel, signal?: AbortSignal) => {
   const { prompt, wordLength, numStories, language, tone, genre, characters } =
     normalizeStoryPayload(payload);
 
@@ -105,7 +106,8 @@ const aiFreeModelGenerate = async (payload: IAIModel) => {
           genre,
           characters,
         ),
-      FREE_GENERATION_TIMEOUT_MS
+      FREE_GENERATION_TIMEOUT_MS,
+      signal
     );
     assertSuccessfulGeneration(result, FREE_GENERATION_FAILED_MESSAGE);
     return result;
@@ -118,14 +120,16 @@ const aiFreeModelGenerate = async (payload: IAIModel) => {
 // consistent with aiModelGenerate and all other authenticated functions.
 const aiModelAlternateEndings = async (
   payload: IAlternateEndingPayload,
-  _token?: ITokenPayload
+  _token?: ITokenPayload,
+  signal?: AbortSignal
 ) => {
   const { title, content, tag, language = "English" } = payload;
 
   try {
     const result = await raceGenerationWithTimeout(
-      () => generateAlternateEndingsWithGemini(title, content, tag, language),
-      AUTHENTICATED_GENERATION_TIMEOUT_MS
+      (s) => generateAlternateEndingsWithGemini(title, content, tag, language, s),
+      AUTHENTICATED_GENERATION_TIMEOUT_MS,
+      signal
     );
     assertSuccessfulGeneration(result, ALTERNATE_ENDING_FAILED_MESSAGE);
     return result;
@@ -134,13 +138,14 @@ const aiModelAlternateEndings = async (
   }
 };
 
-const aiFreeModelAlternateEndings = async (payload: IAlternateEndingPayload) => {
+const aiFreeModelAlternateEndings = async (payload: IAlternateEndingPayload, signal?: AbortSignal) => {
   const { title, content, tag, language = "English" } = payload;
 
   try {
     const result = await raceGenerationWithTimeout(
-      () => generateAlternateEndingsWithGemini(title, content, tag, language),
-      FREE_GENERATION_TIMEOUT_MS
+      (s) => generateAlternateEndingsWithGemini(title, content, tag, language, s),
+      FREE_GENERATION_TIMEOUT_MS,
+      signal
     );
     assertSuccessfulGeneration(result, FREE_ALTERNATE_ENDING_FAILED_MESSAGE);
     return result;
@@ -149,12 +154,13 @@ const aiFreeModelAlternateEndings = async (payload: IAlternateEndingPayload) => 
   }
 };
 
-const aiModelRemix = async (payload: IRemixPayload, _token?: ITokenPayload) => {
+const aiModelRemix = async (payload: IRemixPayload, _token?: ITokenPayload, signal?: AbortSignal) => {
   const { title, content, tag, remixType, remixOption = "", language = "English" } = payload;
   try {
     const result = await raceGenerationWithTimeout(
-      () => generateRemixWithGemini(title, content, tag, remixType, remixOption, language),
-      AUTHENTICATED_GENERATION_TIMEOUT_MS
+      (s) => generateRemixWithGemini(title, content, tag, remixType, remixOption, language, s),
+      AUTHENTICATED_GENERATION_TIMEOUT_MS,
+      signal
     );
     return result;
   } catch (error) {
@@ -162,12 +168,13 @@ const aiModelRemix = async (payload: IRemixPayload, _token?: ITokenPayload) => {
   }
 };
 
-const aiFreeModelRemix = async (payload: IRemixPayload) => {
+const aiFreeModelRemix = async (payload: IRemixPayload, signal?: AbortSignal) => {
   const { title, content, tag, remixType, remixOption = "", language = "English" } = payload;
   try {
     const result = await raceGenerationWithTimeout(
-      () => generateRemixWithGemini(title, content, tag, remixType, remixOption, language),
-      FREE_GENERATION_TIMEOUT_MS
+      (s) => generateRemixWithGemini(title, content, tag, remixType, remixOption, language, s),
+      FREE_GENERATION_TIMEOUT_MS,
+      signal
     );
     return result;
   } catch (error) {
@@ -175,12 +182,13 @@ const aiFreeModelRemix = async (payload: IRemixPayload) => {
   }
 };
 
-const aiModelTranslate = async (payload: ITranslatePayload, _token?: ITokenPayload) => {
+const aiModelTranslate = async (payload: ITranslatePayload, _token?: ITokenPayload, signal?: AbortSignal) => {
   const { title, content, targetLanguage } = payload;
   try {
     const result = await raceGenerationWithTimeout(
-      () => translateStoryWithGemini(title, content, targetLanguage),
-      AUTHENTICATED_GENERATION_TIMEOUT_MS
+      (s) => translateStoryWithGemini(title, content, targetLanguage, s),
+      AUTHENTICATED_GENERATION_TIMEOUT_MS,
+      signal
     );
     return result;
   } catch (error) {
@@ -188,12 +196,13 @@ const aiModelTranslate = async (payload: ITranslatePayload, _token?: ITokenPaylo
   }
 };
 
-const aiFreeModelTranslate = async (payload: ITranslatePayload) => {
+const aiFreeModelTranslate = async (payload: ITranslatePayload, signal?: AbortSignal) => {
   const { title, content, targetLanguage } = payload;
   try {
     const result = await raceGenerationWithTimeout(
-      () => translateStoryWithGemini(title, content, targetLanguage),
-      FREE_GENERATION_TIMEOUT_MS
+      (s) => translateStoryWithGemini(title, content, targetLanguage, s),
+      FREE_GENERATION_TIMEOUT_MS,
+      signal
     );
     return result;
   } catch (error) {
@@ -203,14 +212,16 @@ const aiFreeModelTranslate = async (payload: ITranslatePayload) => {
 
 const aiModelStoryContinuation = async (
   payload: { prompt: string; language?: string },
-  _token?: ITokenPayload
+  _token?: ITokenPayload,
+  signal?: AbortSignal
 ) => {
   const { prompt, language = "English" } = payload;
 
   try {
     const result = await raceGenerationWithTimeout(
-      (signal) => generateStoryContinuationWithGemini(prompt, language, signal),
-      AUTHENTICATED_GENERATION_TIMEOUT_MS
+      (s) => generateStoryContinuationWithGemini(prompt, language, s),
+      AUTHENTICATED_GENERATION_TIMEOUT_MS,
+      signal
     );
     return result;
   } catch (error) {
@@ -218,13 +229,14 @@ const aiModelStoryContinuation = async (
   }
 };
 
-const aiFreeStoryContinuation = async (payload: { prompt: string; language?: string }) => {
+const aiFreeStoryContinuation = async (payload: { prompt: string; language?: string }, signal?: AbortSignal) => {
   const { prompt, language = "English" } = payload;
 
   try {
     const result = await raceGenerationWithTimeout(
-      (signal) => generateStoryContinuationWithGemini(prompt, language, signal),
-      FREE_GENERATION_TIMEOUT_MS
+      (s) => generateStoryContinuationWithGemini(prompt, language, s),
+      FREE_GENERATION_TIMEOUT_MS,
+      signal
     );
     return result;
   } catch (error) {
@@ -232,7 +244,7 @@ const aiFreeStoryContinuation = async (payload: { prompt: string; language?: str
   }
 };
 
-const aiModelChat = async (payload: IChatPayload, _token?: ITokenPayload) => {
+const aiModelChat = async (payload: IChatPayload, _token?: ITokenPayload, signal?: AbortSignal) => {
   const { message, history = [] } = payload;
 
   try {
@@ -242,8 +254,9 @@ const aiModelChat = async (payload: IChatPayload, _token?: ITokenPayload) => {
     }));
 
     const result = await raceGenerationWithTimeout(
-      () => chatWithGemini(message, formattedHistory),
-      AUTHENTICATED_GENERATION_TIMEOUT_MS
+      (s) => chatWithGemini(message, formattedHistory, s),
+      AUTHENTICATED_GENERATION_TIMEOUT_MS,
+      signal
     );
     return result;
   } catch (error) {
@@ -251,7 +264,7 @@ const aiModelChat = async (payload: IChatPayload, _token?: ITokenPayload) => {
   }
 };
 
-const aiFreeModelChat = async (payload: IChatPayload) => {
+const aiFreeModelChat = async (payload: IChatPayload, signal?: AbortSignal) => {
   const { message, history = [] } = payload;
 
   try {
@@ -261,8 +274,9 @@ const aiFreeModelChat = async (payload: IChatPayload) => {
     }));
 
     const result = await raceGenerationWithTimeout(
-      () => chatWithGemini(message, formattedHistory),
-      FREE_GENERATION_TIMEOUT_MS
+      (s) => chatWithGemini(message, formattedHistory, s),
+      FREE_GENERATION_TIMEOUT_MS,
+      signal
     );
     return result;
   } catch (error) {

--- a/backend/src/app/modules/ai_model/ai_model.utils.ts
+++ b/backend/src/app/modules/ai_model/ai_model.utils.ts
@@ -25,6 +25,10 @@ const model = genAI.getGenerativeModel({
   model: "gemini-2.5-flash",
 });
 
+const fallbackModel = genAI.getGenerativeModel({
+  model: "gemini-2.5-flash-8b",
+});
+
 const generationConfig = {
   temperature: 1,
   topP: 0.95,
@@ -135,6 +139,48 @@ const buildCharactersInstruction = (characters?: ICharacter[]): string => {
   return `Cast of Characters (You MUST incorporate these characters into all generated stories and maintain their roles, relationship dynamics, and traits consistently):\n${charsString}\n\n`;
 };
 
+import { GenerativeModel } from "@google/generative-ai";
+
+const executeWithRetryAndFallback = async <T>(
+  operation: (activeModel: GenerativeModel) => Promise<T>,
+  signal?: AbortSignal
+): Promise<T> => {
+  const maxRetries = 2;
+  const baseDelayMs = 1000;
+
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      throwIfAborted(signal);
+      return await operation(model);
+    } catch (error: any) {
+      if (signal?.aborted || error instanceof GenerationAbortedError || error?.name === 'AbortError') {
+        throw new GenerationAbortedError();
+      }
+      
+      const status = error?.status || error?.response?.status;
+      const isRetryable = status >= 500 || status === 429 || error?.message?.includes("fetch failed");
+      
+      if (!isRetryable || attempt === maxRetries) {
+        break; // Break to try fallback
+      }
+      
+      const delay = baseDelayMs * Math.pow(2, attempt - 1);
+      await new Promise(res => setTimeout(res, delay));
+    }
+  }
+  
+  // Fallback to the smaller model
+  try {
+    throwIfAborted(signal);
+    return await operation(fallbackModel);
+  } catch (fallbackError: any) {
+    if (signal?.aborted || fallbackError instanceof GenerationAbortedError || fallbackError?.name === 'AbortError') {
+      throw new GenerationAbortedError();
+    }
+    throw fallbackError;
+  }
+};
+
 export async function generateWithGeminiStories(
   prompt: string,
   wordLength: number = 250,
@@ -150,28 +196,25 @@ export async function generateWithGeminiStories(
   assertGeminiApiKeyConfigured();
 
   try {
-    const chatSession = model.startChat({
-      generationConfig,
-      safetySettings,
-      history: [],
-    });
+    const response = await executeWithRetryAndFallback(async (activeModel) => {
+      const chatSession = activeModel.startChat({
+        generationConfig,
+        safetySettings,
+        history: [],
+      });
 
-    // NEW: Prepend the tone instruction block to the Gemini prompt when a tone is selected.
-    const toneInstruction = buildToneInstruction(tone);
-    const genreInstruction = buildGenreInstruction(genre);
-    const charactersInstruction = buildCharactersInstruction(characters);
-
-    const response = await chatSession.sendMessage(
-      `${genreInstruction}${toneInstruction}${charactersInstruction}You are an expert storyteller and emotion analyst. The user provided the following base prompt: "${prompt}".
-      First, enhance this prompt to be more emotionally engaging and context-sensitive (e.g., add suspense, joy, or mystery).
-      Then, generate ${numStories} different short stories based on this ENHANCED prompt.
-      The stories MUST be written entirely in the ${language} language.
-      For each story, also analyze and detect the primary emotional tones (e.g., ["Joy", "Suspense", "Motivation"]) and the specific genre.
-      Each story should be in JSON format with fields: "title", "content", "tag" (the main topic), "emotions" (an array of strings), "genre" (a string), and "enhancedPrompt" (the improved prompt used).
-      Ensure each story is approximately ${wordLength} words long.
-      Return only valid JSON array output.`,
-      { signal }
-    );
+      return chatSession.sendMessage(
+        `${genreInstruction}${toneInstruction}${charactersInstruction}You are an expert storyteller and emotion analyst. The user provided the following base prompt: "${prompt}".
+        First, enhance this prompt to be more emotionally engaging and context-sensitive (e.g., add suspense, joy, or mystery).
+        Then, generate ${numStories} different short stories based on this ENHANCED prompt.
+        The stories MUST be written entirely in the ${language} language.
+        For each story, also analyze and detect the primary emotional tones (e.g., ["Joy", "Suspense", "Motivation"]) and the specific genre.
+        Each story should be in JSON format with fields: "title", "content", "tag" (the main topic), "emotions" (an array of strings), "genre" (a string), and "enhancedPrompt" (the improved prompt used).
+        Ensure each story is approximately ${wordLength} words long.
+        Return only valid JSON array output.`,
+        { signal }
+      );
+    }, signal);
 
     throwIfAborted(signal);
 
@@ -250,32 +293,34 @@ export async function generateAlternateEndingsWithGemini(
   assertGeminiApiKeyConfigured();
 
   try {
-    const chatSession = model.startChat({
-      generationConfig,
-      safetySettings,
-      history: [],
-    });
-    const response = await chatSession.sendMessage(
-      `You are a professional narrative editor. Analyze the following story (Title: "${title}", Genre/Tag: "${tag}", Language: "${language}"):
-      Story Content:
-      "${content}"
-      
-      Generate 5 alternate endings for this story corresponding to the following styles:
-      1. "Happy Ending"
-      2. "Dark Ending"
-      3. "Plot Twist Ending"
-      4. "Open Ending"
-      5. "Cliffhanger Ending"
-      
-      The generated alternate endings and the rewritten stories MUST be written entirely in the ${language} language.
-      For each alternate ending, provide:
-      - "style": The style name exactly as listed above.
-      - "ending": A short paragraph or two describing the alternate ending scene itself.
-      - "fullStory": The complete rewritten story with this new ending seamlessly integrated. The new ending should replace the original ending of the story, preserving the original story's context, setup, character names, and writing tone.
-      
-      Return the output as a JSON array of objects with the fields: "style", "ending", and "fullStory".`,
-      { signal }
-    );
+    const response = await executeWithRetryAndFallback(async (activeModel) => {
+      const chatSession = activeModel.startChat({
+        generationConfig,
+        safetySettings,
+        history: [],
+      });
+      return chatSession.sendMessage(
+        `You are a professional narrative editor. Analyze the following story (Title: "${title}", Genre/Tag: "${tag}", Language: "${language}"):
+        Story Content:
+        "${content}"
+        
+        Generate 5 alternate endings for this story corresponding to the following styles:
+        1. "Happy Ending"
+        2. "Dark Ending"
+        3. "Plot Twist Ending"
+        4. "Open Ending"
+        5. "Cliffhanger Ending"
+        
+        The generated alternate endings and the rewritten stories MUST be written entirely in the ${language} language.
+        For each alternate ending, provide:
+        - "style": The style name exactly as listed above.
+        - "ending": A short paragraph or two describing the alternate ending scene itself.
+        - "fullStory": The complete rewritten story with this new ending seamlessly integrated. The new ending should replace the original ending of the story, preserving the original story's context, setup, character names, and writing tone.
+        
+        Return the output as a JSON array of objects with the fields: "style", "ending", and "fullStory".`,
+        { signal }
+      );
+    }, signal);
     throwIfAborted(signal);
     const text = response.response.text();
 
@@ -338,9 +383,7 @@ export async function generateWithGeminiStoriesStream(
     throw new GenerationAbortedError();
   }
 
-  const streamingModel = genAI.getGenerativeModel({
-    model: "gemini-2.5-flash",
-  });
+
 
   const streamingConfig = {
     temperature: 1,
@@ -350,23 +393,25 @@ export async function generateWithGeminiStoriesStream(
   };
 
   try {
-    const result = await streamingModel.generateContentStream({
-      contents: [
-        {
-          role: "user",
-          parts: [
-            {
-              text: `Generate ${numStories} different short stories based on the following prompt: "${prompt}".
-              Each story should be in JSON format with fields: "title", "content", and "tag".
-              Ensure each story is approximately ${wordLength} words long.
-              Return the output as a JSON array.`,
-            },
-          ],
-        },
-      ],
-      generationConfig: streamingConfig,
-      safetySettings,
-    }, { signal });
+    const result = await executeWithRetryAndFallback(async (activeModel) => {
+      return activeModel.generateContentStream({
+        contents: [
+          {
+            role: "user",
+            parts: [
+              {
+                text: `Generate ${numStories} different short stories based on the following prompt: "${prompt}".
+                Each story should be in JSON format with fields: "title", "content", and "tag".
+                Ensure each story is approximately ${wordLength} words long.
+                Return the output as a JSON array.`,
+              },
+            ],
+          },
+        ],
+        generationConfig: streamingConfig,
+        safetySettings,
+      }, { signal });
+    }, signal);
 
     for await (const chunk of result.stream) {
       if (signal?.aborted) {
@@ -424,16 +469,17 @@ Write the remixed story in ${language}. Return a JSON object with this exact str
 }`;
 
   try {
-    const chatSession = model.startChat({
-      generationConfig: {
-        ...generationConfig,
-        maxOutputTokens: 4096,
-      },
-      safetySettings,
-      history: [],
-    });
-
-    const result = await chatSession.sendMessage(prompt, { signal });
+    const result = await executeWithRetryAndFallback(async (activeModel) => {
+      const chatSession = activeModel.startChat({
+        generationConfig: {
+          ...generationConfig,
+          maxOutputTokens: 4096,
+        },
+        safetySettings,
+        history: [],
+      });
+      return chatSession.sendMessage(prompt, { signal });
+    }, signal);
     const rawText = result.response.text();
     const cleanText = sanitizeJsonText(rawText);
     const parsed = JSON.parse(cleanText);
@@ -462,17 +508,18 @@ export async function generateStoryContinuationWithGemini(
   assertGeminiApiKeyConfigured();
 
   try {
-    const chatSession = model.startChat({
-      generationConfig: {
-        ...generationConfig,
-        maxOutputTokens: 2048,
-      },
-      safetySettings,
-      history: [],
-    });
+    const response = await executeWithRetryAndFallback(async (activeModel) => {
+      const chatSession = activeModel.startChat({
+        generationConfig: {
+          ...generationConfig,
+          maxOutputTokens: 2048,
+        },
+        safetySettings,
+        history: [],
+      });
 
-    const response = await chatSession.sendMessage(
-      `You are an expert storyteller. The user has written the following story so far:
+      return chatSession.sendMessage(
+        `You are an expert storyteller. The user has written the following story so far:
 
 "${storyContext}"
 
@@ -482,8 +529,9 @@ Return only valid JSON with this exact structure:
 {
   "continuation": "your continuation text here"
 }`,
-      { signal }
-    );
+        { signal }
+      );
+    }, signal);
 
     throwIfAborted(signal);
 
@@ -542,16 +590,17 @@ Return a JSON object with this exact structure:
 Preserve the story's tone, style and meaning. Only translate — do not modify the story.`;
 
   try {
-    const chatSession = model.startChat({
-      generationConfig: {
-        ...generationConfig,
-        maxOutputTokens: 4096,
-      },
-      safetySettings,
-      history: [],
-    });
-
-    const result = await chatSession.sendMessage(prompt, { signal });
+    const result = await executeWithRetryAndFallback(async (activeModel) => {
+      const chatSession = activeModel.startChat({
+        generationConfig: {
+          ...generationConfig,
+          maxOutputTokens: 4096,
+        },
+        safetySettings,
+        history: [],
+      });
+      return chatSession.sendMessage(prompt, { signal });
+    }, signal);
     const rawText = result.response.text();
     const cleanText = sanitizeJsonText(rawText);
     const parsed = JSON.parse(cleanText);
@@ -611,16 +660,17 @@ Rules:
 - Do not generate images or image URLs.`;
 
   try {
-    const chatSession = model.startChat({
-      generationConfig: {
-        ...generationConfig,
-        maxOutputTokens: 4096,
-      },
-      safetySettings,
-      history: [],
-    });
-
-    const result = await chatSession.sendMessage(prompt, { signal });
+    const result = await executeWithRetryAndFallback(async (activeModel) => {
+      const chatSession = activeModel.startChat({
+        generationConfig: {
+          ...generationConfig,
+          maxOutputTokens: 4096,
+        },
+        safetySettings,
+        history: [],
+      });
+      return chatSession.sendMessage(prompt, { signal });
+    }, signal);
     const parsed = JSON.parse(sanitizeJsonText(result.response.text()));
 
     const scenes = parsed?.scenes;
@@ -686,17 +736,18 @@ export async function chatWithGemini(
   assertGeminiApiKeyConfigured();
 
   try {
-    const chatSession = model.startChat({
-      generationConfig: {
-        ...generationConfig,
-        maxOutputTokens: 4096,
-        responseMimeType: "text/plain",
-      },
-      safetySettings,
-      history,
-    });
-
-    const result = await chatSession.sendMessage(message, { signal });
+    const result = await executeWithRetryAndFallback(async (activeModel) => {
+      const chatSession = activeModel.startChat({
+        generationConfig: {
+          ...generationConfig,
+          maxOutputTokens: 4096,
+          responseMimeType: "text/plain",
+        },
+        safetySettings,
+        history,
+      });
+      return chatSession.sendMessage(message, { signal });
+    }, signal);
 
     return result.response.text();
   } catch (error: unknown) {

--- a/frontend/src/components/loading/story-generating-animation.component.tsx
+++ b/frontend/src/components/loading/story-generating-animation.component.tsx
@@ -11,9 +11,10 @@ const PHASES = [
 
 type StoryGeneratingAnimationProps = {
   onCancel?: () => void;
+  isHighLatency?: boolean;
 };
 
-const StoryGeneratingAnimation = ({ onCancel }: StoryGeneratingAnimationProps) => {
+const StoryGeneratingAnimation = ({ onCancel, isHighLatency }: StoryGeneratingAnimationProps) => {
   const [phaseIndex, setPhaseIndex] = useState(0);
 
   useEffect(() => {
@@ -93,7 +94,7 @@ const StoryGeneratingAnimation = ({ onCancel }: StoryGeneratingAnimationProps) =
       </div>
 
       {/* Progress bar */}
-      <div className="w-72 h-1.5 rounded-full bg-white/10 overflow-hidden">
+      <div className="w-72 h-1.5 rounded-full bg-white/10 overflow-hidden mb-3">
         <motion.div
           className="h-full rounded-full bg-gradient-to-r from-blue-400 via-indigo-400 to-purple-400"
           initial={{ width: "18%" }}
@@ -101,12 +102,24 @@ const StoryGeneratingAnimation = ({ onCancel }: StoryGeneratingAnimationProps) =
           transition={{ duration: 8, repeat: Infinity, ease: "easeInOut" }}
         />
       </div>
-      <p className="text-gray-500 text-xs mt-3">Crafting your story with AI magic...</p>
+      
+      {isHighLatency ? (
+        <motion.p
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          className="text-amber-400/90 text-sm mt-2 text-center"
+        >
+          Experiencing high demand or network latency...<br/>We're trying a fallback model!
+        </motion.p>
+      ) : (
+        <p className="text-gray-500 text-xs mt-1">Crafting your story with AI magic...</p>
+      )}
+
       {onCancel && (
         <button
           type="button"
           onClick={onCancel}
-          className="mt-5 rounded-lg border border-white/10 px-4 py-2 text-sm font-medium text-gray-300 transition-colors duration-200 hover:bg-white/10 hover:text-white"
+          className="mt-6 rounded-lg border border-white/10 px-4 py-2 text-sm font-medium text-gray-300 transition-colors duration-200 hover:bg-white/10 hover:text-white"
         >
           Cancel generation
         </button>

--- a/frontend/src/components/stories/stories.component.tsx
+++ b/frontend/src/components/stories/stories.component.tsx
@@ -626,6 +626,7 @@ useEffect(() => {
   );
   const [showLimitModal, setShowLimitModal] = useState<boolean>(false);
   const [isRecentPromptsOpen, setIsRecentPromptsOpen] = useState<boolean>(false);
+  const [isHighLatency, setIsHighLatency] = useState<boolean>(false);
   const { recentPrompts, addPrompt, removePrompt, clearAll } = useRecentPrompts();
   
   const text = UI_TEXT[selectedLanguage] ?? UI_TEXT.English;
@@ -812,8 +813,10 @@ useEffect(() => {
 
     isGenerationInProgressRef.current = true;
     setLoading(true);
+    setIsHighLatency(false);
 
     let timeoutId: NodeJS.Timeout | null = null;
+    let latencyTimeoutId: NodeJS.Timeout | null = null;
 
     try {
       // 60-second client-side request timeout safeguard
@@ -823,6 +826,13 @@ useEffect(() => {
           handleCancelGeneration(true);
         }
       }, 60000);
+
+      // 10-second high latency warning (for fallback/backoff cases)
+      latencyTimeoutId = setTimeout(() => {
+        if (isGenerationInProgressRef.current) {
+          setIsHighLatency(true);
+        }
+      }, 10000);
 
       const payload = {
         prompt: selectedGenre
@@ -884,9 +894,13 @@ useEffect(() => {
       if (timeoutId) {
         clearTimeout(timeoutId);
       }
+      if (latencyTimeoutId) {
+        clearTimeout(latencyTimeoutId);
+      }
       activeGenerationRef.current = null;
       isGenerationInProgressRef.current = false;
       setLoading(false);
+      setIsHighLatency(false);
     }
   };
 
@@ -1884,7 +1898,7 @@ useEffect(() => {
         </div>
       )}
 
-      {loading && <StoryGeneratingAnimation onCancel={handleCancelGeneration} />}
+      {loading && <StoryGeneratingAnimation onCancel={handleCancelGeneration} isHighLatency={isHighLatency} />}
 
       {/* Search UI */}
       {stories.length > 0 && (


### PR DESCRIPTION
Closes #2569 
Closes #2571 

This PR implements a fallback/retry wrapper in the LLM service to automatically downgrade to a secondary LLM for transient network failures. It also implements an AbortController for streaming endpoints to gracefully terminate generations when the client disconnects.