### PR TITLE
fix: remove stray div causing parse error in cookie consent component

### DIFF
--- a/frontend/src/components/cookie-consent/cookie-consent.component.tsx
+++ b/frontend/src/components/cookie-consent/cookie-consent.component.tsx
@@ -129,14 +129,7 @@ const CookieConsentBanner: FC<CookieConsentBannerProps> = ({ onLayoutChange }) =
     : "w-full rounded-xl border border-slate-200 bg-white px-5 py-3 text-xs font-bold text-slate-900 transition-all duration-150 hover:bg-slate-100 active:scale-[0.98] cursor-pointer text-center uppercase tracking-wider";
 
   return (
-    <div ref={bannerRef} className="fixed inset-x-0 bottom-0 z-50 px-4 pb-4 text-white sm:px-6 lg:px-8">
-      <div className="mx-auto flex max-h-[82vh] max-w-5xl flex-col gap-4 overflow-y-auto rounded-2xl border border-slate-700 bg-slate-950/95 p-4 shadow-2xl backdrop-blur-xl sm:p-5 xl:flex-row xl:items-start xl:justify-between xl:gap-6">
-        <div className="max-w-3xl space-y-3">
-          <p className="text-xs uppercase tracking-[0.26em] text-slate-400">Cookie Preferences</p>
-          <h2 className="text-xl font-semibold text-white sm:text-2xl">Manage your cookie settings</h2>
-          <p className="text-sm leading-6 text-slate-300 sm:text-base sm:leading-7">
-    <div className="fixed inset-x-0 bottom-0 z-50 bg-slate-950/95 border-t border-slate-200/10 dark:border-white/10 py-6 shadow-2xl backdrop-blur-xl text-white transition-colors duration-300 max-h-[85vh] overflow-y-auto sidebar">
-    <div className={bannerClasses}>
+    <div ref={bannerRef} className={bannerClasses}>
       <div className="mx-auto flex max-w-6xl flex-col gap-6 px-4 sm:px-6 lg:px-8 xl:flex-row xl:items-start xl:justify-between xl:gap-8">
         <div className="max-w-3xl space-y-4">
           <div className="space-y-1.5">


### PR DESCRIPTION
## Screenshot (when helpful)

N/A – No UI changes. This PR removes stray duplicate markup and fixes a JSX parse error.

---

## What this PR does

This PR fixes an issue in `cookie-consent.component.tsx` where a stray raw `<div>` was present inside JSX content.

### Changes

- Removed the stray raw `<div>` element.
- Removed duplicate/dead banner markup.
- Fixed the `Unexpected token` JSX parsing error.
- Preserved the existing cookie consent banner implementation.
- Improved component maintainability and readability.

### Why

The component already renders the cookie consent banner correctly. An additional raw `<div>` existed outside the intended JSX structure, causing:

- JSX parsing failures.
- Build/lint errors.
- Duplicate unused markup.
- Text being rendered incorrectly on screen.

---

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

---

## Related issue

Closes #2602 

OR

None

---

## More screenshots (optional)

N/A

---

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.