### PR TITLE
fix: remove duplicate drag callbacks and restore speakText function s…

### DIFF
--- a/frontend/src/components/story-map/StoryWorldMap.tsx
+++ b/frontend/src/components/story-map/StoryWorldMap.tsx
@@ -94,16 +94,11 @@ export default function StoryWorldMap({ story, title, onClose }: Props) {
       .style("cursor", "pointer")
       .call(
         d3.drag<SVGGElement, SimNode>()
-          .on("start", (event: d3.D3DragEvent<SVGGElement, SimNode, SimNode>, d: SimNode) => {
           .on("start", (event: d3.D3DragEvent<SVGGElement, SimNode, SimNode>, node: SimNode) => {
             if (!event.active) simulation.alphaTarget(0.3).restart();
             node.fx = node.x;
             node.fy = node.y;
           })
-          .on("drag", (event: d3.D3DragEvent<SVGGElement, SimNode, SimNode>, d: SimNode) => {
-            d.fx = event.x; d.fy = event.y;
-          })
-          .on("end", (event: d3.D3DragEvent<SVGGElement, SimNode, SimNode>, d: SimNode) => {
           .on("drag", (event: d3.D3DragEvent<SVGGElement, SimNode, SimNode>, node: SimNode) => {
             node.fx = event.x;
             node.fy = event.y;

--- a/frontend/src/hooks/useSpeechSynthesis.ts
+++ b/frontend/src/hooks/useSpeechSynthesis.ts
@@ -1,4 +1,4 @@
-﻿import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 type WordRange = {
   start: number;
@@ -306,29 +306,6 @@ export const useSpeechSynthesis = (
         setError("Text-to-speech is not supported in this browser.");
         return;
       }
-    };
-
-    utteranceRef.current = utterance;
-    speechSynthesis.speak(utterance);
-  }, [
-    clearUtterance,
-    isReady,
-    isSupported,
-    pitchState,
-    rateState,
-    resolveBrowserVoice,
-    selectedLanguage,
-    selectedVoiceId,
-    text,
-    totalWords,
-    volumeState,
-    wordRanges,
-  ]);
-
-  const pause = useCallback(() => {
-    if (!isSupported || !utteranceRef.current) {
-      return;
-    }
 
       if (!textToSpeak) {
         setError("No text to speak.");
@@ -367,25 +344,6 @@ export const useSpeechSynthesis = (
         if (event.name !== "word") {
           return;
         }
-  const setPitch = useCallback((nextPitch: number) => {
-    setPitchState(nextPitch);
-
-    if (utteranceRef.current) {
-      utteranceRef.current.pitch = nextPitch;
-    }
-  }, []);
-
-  const setVolume = useCallback((nextVolume: number) => {
-    setVolumeState(nextVolume);
-
-    if (utteranceRef.current) {
-      utteranceRef.current.volume = nextVolume;
-    }
-  }, []);
-
-  useEffect(() => {
-    const supported = hasSpeechSupport();
-    setIsSupported(supported);
 
         const nextWordIndex = getWordIndexAtCharIndex(
           event.charIndex,
@@ -408,11 +366,11 @@ export const useSpeechSynthesis = (
         setIsPaused(false);
         setError("Unable to play narration. Please try again.");
       };
+
       const loadedVoices = speechSynthesis.getVoices();
       browserVoicesRef.current = loadedVoices;
       setBrowserVoices(loadedVoices);
       setIsReady(loadedVoices.length > 0);
-    };
 
       synthRef.current.cancel();
       synthRef.current.speak(utterance);
@@ -420,6 +378,22 @@ export const useSpeechSynthesis = (
     },
     [availableVoices, isSupported, rate, selectedVoiceIndex, stop],
   );
+
+  const setPitch = useCallback((nextPitch: number) => {
+    setPitchState(nextPitch);
+
+    if (utteranceRef.current) {
+      utteranceRef.current.pitch = nextPitch;
+    }
+  }, []);
+
+  const setVolume = useCallback((nextVolume: number) => {
+    setVolumeState(nextVolume);
+
+    if (utteranceRef.current) {
+      utteranceRef.current.volume = nextVolume;
+    }
+  }, []);
 
   const pause = useCallback(() => {
     if (synthRef.current && isSpeaking && !isPaused) {


### PR DESCRIPTION
## What this PR does

This PR fixes two code structure issues affecting drag interactions and speech synthesis functionality.

### Changes

#### StoryWorldMap.tsx

* Removed duplicate `.on("start")` callbacks.
* Removed duplicate `.on("drag")` callbacks.
* Removed duplicate `.on("end")` callbacks.
* Retained a single valid drag lifecycle implementation.

#### useSpeechSynthesis.ts

* Removed premature callback termination.
* Restored speech synthesis logic to the `speakText` callback body.
* Corrected function scope and execution flow.

### Why

The codebase contained signs of unresolved merge artifacts and misplaced function boundaries, resulting in:

* Duplicate event registrations.
* Confusing control flow.
* Potential runtime issues.
* TypeScript compilation concerns.
* Reduced maintainability.

This change restores a clean implementation while preserving existing behavior.

---

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

---

## Related issue

Closes #<ISSUE_NUMBER>

OR

None

---

## More screenshots (optional)

N/A

---

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.
