### PR TITLE
feat(explore-stories): expand Story Inspiration Hub with 12 classic works and homepage discovery card

### DIFF
--- a/frontend/src/components/home/home.component.tsx
+++ b/frontend/src/components/home/home.component.tsx
@@ -12,6 +12,7 @@ import StartWritingComponent from "./start_writing/start_writing.component";
 import PersonalizedRecommendationsComponent from "./personalized_recommendations/personalized_recommendations.component";
 import { isLoggedIn } from "../../services/auth.service";
 import BackToTop from "../ScrollToTopButton";
+import StoryInspirationHomeCard from "./story_inspiration_card/StoryInspirationHomeCard";
 
 const HomeComponent = () => {
   const isLogin = isLoggedIn();
@@ -37,6 +38,7 @@ const HomeComponent = () => {
           <div className="space-y-6 lg:sticky lg:top-24 w-full box-border">
             {isLogin && <FeatureProfileComponent />}
             {isLogin && <PersonalizedRecommendationsComponent />}
+            <StoryInspirationHomeCard />
             <TrendingTopicComponent />
             <RecommendedWritersComponent />
           </div>

--- a/frontend/src/components/home/story_inspiration_card/StoryInspirationHomeCard.tsx
+++ b/frontend/src/components/home/story_inspiration_card/StoryInspirationHomeCard.tsx
@@ -1,0 +1,132 @@
+import { Link } from "react-router-dom";
+import { inspirationData } from "../../story-inspiration/inspirationData";
+
+const FEATURED_GENRE_COLORS: Record<string, string> = {
+  Fantasy:   "bg-emerald-100 text-emerald-800 dark:bg-emerald-500/15 dark:text-emerald-300",
+  Horror:    "bg-red-100 text-red-800 dark:bg-red-500/15 dark:text-red-300",
+  "Sci-Fi":  "bg-blue-100 text-blue-800 dark:bg-blue-500/15 dark:text-blue-300",
+  Mystery:   "bg-purple-100 text-purple-800 dark:bg-purple-500/15 dark:text-purple-300",
+  Adventure: "bg-amber-100 text-amber-800 dark:bg-amber-500/15 dark:text-amber-300",
+  Romance:   "bg-pink-100 text-pink-800 dark:bg-pink-500/15 dark:text-pink-300",
+};
+
+const GENRE_ICONS: Record<string, string> = {
+  Fantasy:   "fa-wand-magic-sparkles",
+  Horror:    "fa-ghost",
+  "Sci-Fi":  "fa-rocket",
+  Mystery:   "fa-user-secret",
+  Adventure: "fa-compass",
+  Romance:   "fa-heart",
+};
+
+const FEATURED_IDS = [
+  "alice-wonderland",
+  "and-then-there-were-none",
+  "war-of-worlds",
+];
+
+const StoryInspirationHomeCard = () => {
+  const featured = FEATURED_IDS
+    .map((id) => inspirationData.find((s) => s.id === id))
+    .filter(Boolean) as typeof inspirationData;
+
+  const totalStories = inspirationData.length;
+  const genres = [...new Set(inspirationData.map((s) => s.genre))];
+
+  return (
+    <section className="rounded-xl border border-indigo-100 dark:border-indigo-500/20 bg-white dark:bg-slate-900/50 shadow-sm overflow-hidden">
+      <div className="bg-gradient-to-r from-indigo-600 to-violet-600 px-5 py-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2.5">
+            <div className="w-8 h-8 rounded-lg bg-white/20 flex items-center justify-center">
+              <i className="fas fa-book-open text-white text-sm" />
+            </div>
+            <div>
+              <h3 className="text-sm font-bold text-white leading-tight">Story Inspiration</h3>
+              <p className="text-xs text-indigo-200">{totalStories} classic works</p>
+            </div>
+          </div>
+          <Link
+            to="/story-inspiration"
+            className="text-xs font-semibold text-indigo-100 hover:text-white transition-colors flex items-center gap-1"
+          >
+            Browse all
+            <i className="fas fa-arrow-right text-[10px]" />
+          </Link>
+        </div>
+      </div>
+
+      <div className="p-4 space-y-3">
+        {featured.map((story) => {
+          const genreColor = FEATURED_GENRE_COLORS[story.genre] ?? "bg-slate-100 text-slate-700";
+          const genreIcon = GENRE_ICONS[story.genre] ?? "fa-book";
+          return (
+            <Link
+              key={story.id}
+              to="/story-inspiration"
+              className="group flex items-start gap-3 p-2.5 rounded-lg hover:bg-slate-50 dark:hover:bg-slate-800/60 transition-colors duration-200"
+            >
+              <div className="w-10 h-10 rounded-lg overflow-hidden flex-shrink-0 bg-slate-100 dark:bg-slate-800">
+                <img
+                  src={story.image}
+                  alt={story.title}
+                  className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-300"
+                  onError={(e) => {
+                    (e.currentTarget as HTMLImageElement).style.display = "none";
+                  }}
+                />
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-semibold text-slate-900 dark:text-white truncate group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors">
+                  {story.title}
+                </p>
+                <p className="text-xs text-slate-500 dark:text-slate-400 truncate">{story.author}</p>
+                <span className={`inline-flex items-center gap-1 mt-1 px-2 py-0.5 rounded-full text-[10px] font-semibold ${genreColor}`}>
+                  <i className={`fas ${genreIcon} text-[9px]`} />
+                  {story.genre}
+                </span>
+              </div>
+            </Link>
+          );
+        })}
+      </div>
+
+      <div className="px-4 pb-4">
+        <div className="flex flex-wrap gap-1.5 mb-4">
+          {genres.map((genre) => {
+            const color = FEATURED_GENRE_COLORS[genre] ?? "bg-slate-100 text-slate-600";
+            const icon = GENRE_ICONS[genre] ?? "fa-book";
+            return (
+              <Link
+                key={genre}
+                to="/story-inspiration"
+                className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] font-semibold transition-all duration-200 hover:scale-105 ${color}`}
+              >
+                <i className={`fas ${icon} text-[9px]`} />
+                {genre}
+              </Link>
+            );
+          })}
+        </div>
+
+        <Link
+          to="/story-inspiration"
+          className="
+            flex items-center justify-center gap-2
+            w-full py-2.5 rounded-lg
+            bg-gradient-to-r from-indigo-600 to-violet-600
+            text-white text-sm font-bold
+            hover:shadow-lg hover:shadow-indigo-500/25
+            hover:scale-[1.02]
+            transition-all duration-200
+          "
+        >
+          <i className="fas fa-compass text-sm" />
+          Explore All Stories
+        </Link>
+      </div>
+    </section>
+  );
+};
+
+export default StoryInspirationHomeCard;

--- a/frontend/src/components/story-inspiration/inspirationData.ts
+++ b/frontend/src/components/story-inspiration/inspirationData.ts
@@ -140,5 +140,173 @@ export const inspirationData: StoryInspiration[] = [
       "Write a romance set in a community where matches are decided by an infallible algorithm, but two people fall in love outside its recommendations."
     ],
     "image": "https://images.unsplash.com/photo-1516589178581-6cd7833ae3b2?q=80&w=800&auto=format&fit=crop"
+  },
+  {
+    id: "wizard-of-oz",
+    title: "The Wonderful Wizard of Oz",
+    author: "L. Frank Baum",
+    genre: "Fantasy",
+    summary: "A Kansas girl named Dorothy is swept by a tornado into the magical land of Oz, where she sets off on a journey to find the Great Wizard and return home, making unlikely companions along the way.",
+    themes: ["Home & Belonging", "Courage & Self-Belief", "Illusion vs. Reality", "Friendship"],
+    prompts: [
+      "A teenager is transported into a retro video game world and must gather three scattered power-ups to find the legendary programmer who can send them home.",
+      "Write about a group of strangers each seeking something they believe they lack, only to discover they possessed it all along.",
+      "A social media influencer wakes up in a world that mirrors their curated online persona, and must unravel its distorted reality."
+    ],
+    image: "https://images.unsplash.com/photo-1534447677768-be436bb09401?q=80&w=800&auto=format&fit=crop"
+  },
+  {
+    id: "midsummer-night",
+    title: "A Midsummer Night's Dream",
+    author: "William Shakespeare",
+    genre: "Fantasy",
+    summary: "The romantic fates of four Athenian lovers and a troupe of amateur actors are entangled with the feuding king and queen of the fairies, leading to magical chaos and comic misunderstandings in an enchanted forest.",
+    themes: ["Love & Illusion", "Order vs. Chaos", "Dreams vs. Reality", "Power & Mischief"],
+    prompts: [
+      "A corporate team-building retreat in a fog-bound forest goes sideways when an experimental app starts swapping everyone's romantic feelings.",
+      "Write a comedy where a mischievous AI plays matchmaker at a midnight gala, reassigning feelings at random with unpredictable results.",
+      "Two sworn rivals discover they have been unknowingly writing love letters to each other through an anonymous online forum."
+    ],
+    image: "https://images.unsplash.com/photo-1518709268805-4e9042af9f23?q=80&w=800&auto=format&fit=crop"
+  },
+  {
+    id: "tell-tale-heart",
+    title: "The Tell-Tale Heart",
+    author: "Edgar Allan Poe",
+    genre: "Horror",
+    summary: "An unnamed narrator insists on their sanity while recounting the meticulous murder of an old man whose 'vulture eye' disturbed them, only to be undone by the imagined sound of the victim's beating heart.",
+    themes: ["Guilt & Paranoia", "Obsession", "Unreliable Narration", "Psychological Horror"],
+    prompts: [
+      "A security analyst who committed a data breach starts hearing phantom keyboard clicks wherever they go, each keystroke sounding like an accusation.",
+      "Write a story from the perspective of someone who is convinced their smart-home devices are replaying recorded sounds of a past crime.",
+      "A caretaker hides evidence of a terrible accident, but an ordinary household sound begins to magnify in their mind until it consumes them."
+    ],
+    image: "https://images.unsplash.com/photo-1509909756405-be0199881695?q=80&w=800&auto=format&fit=crop"
+  },
+  {
+    id: "jekyll-hyde",
+    title: "Strange Case of Dr Jekyll and Mr Hyde",
+    author: "Robert Louis Stevenson",
+    genre: "Horror",
+    summary: "The mild-mannered Dr. Henry Jekyll experiments with a serum that separates his respectable persona from his dark impulses, releasing the monstrous Edward Hyde who grows stronger with each transformation.",
+    themes: ["Duality of Human Nature", "Repression & Release", "Science & Ethics", "Identity"],
+    prompts: [
+      "A tech founder develops a neural interface that lets users suppress social inhibitions, only to find the suppressed traits form a separate, destructive personality.",
+      "Write a thriller where a therapist realizes their most volatile patient and their most upstanding client share the exact same memories.",
+      "A biohacker tests a gene-editing formula promising peak performance but gradually loses control of who they are after sundown."
+    ],
+    image: "https://images.unsplash.com/photo-1580274455191-1c62238fa333?q=80&w=800&auto=format&fit=crop"
+  },
+  {
+    id: "war-of-worlds",
+    title: "The War of the Worlds",
+    author: "H.G. Wells",
+    genre: "Sci-Fi",
+    summary: "Martian invaders land in England and devastate civilization with their heat-rays and black smoke, reducing humanity to scattered survivors — until the aliens are felled by Earth's bacteria rather than human resistance.",
+    themes: ["Colonialism & Conquest", "Human Vulnerability", "Survival Instinct", "Hubris of Civilization"],
+    prompts: [
+      "An advanced alien probe arrives on Earth not with weapons, but with a dataset of every human mistake ever recorded, offering it as a warning.",
+      "Write a survival story set in a city where invisible drones have silently mapped every human routine, preparing for an unknown purpose.",
+      "Humanity prepares to colonize a distant planet, only to discover they are the invaders in an alien civilization's history books."
+    ],
+    image: "https://images.unsplash.com/photo-1446776811953-b23d57bd21aa?q=80&w=800&auto=format&fit=crop"
+  },
+  {
+    id: "brave-new-world",
+    title: "Brave New World",
+    author: "Aldous Huxley",
+    genre: "Sci-Fi",
+    summary: "In a dystopian future ruled by pleasure and conditioning, a 'Savage' raised outside the World State confronts a society where individuality, art, and family have been eradicated in favour of stability and happiness.",
+    themes: ["Freedom vs. Conformity", "Technology & Control", "Consumerism", "Loss of Humanity"],
+    prompts: [
+      "In a near-future city, citizens are genetically assigned careers at birth and contentment drugs are piped through the water supply. One person develops the ability to refuse.",
+      "A government program promises to eliminate unhappiness through mandatory neural updates, but one engineer discovers the updates also erase memories of loved ones.",
+      "Write about a person raised in a settlement without social media who is suddenly immersed in a hyper-connected society addicted to algorithmic approval."
+    ],
+    image: "https://images.unsplash.com/photo-1558618666-fcd25c85cd64?q=80&w=800&auto=format&fit=crop"
+  },
+  {
+    id: "and-then-there-were-none",
+    title: "And Then There Were None",
+    author: "Agatha Christie",
+    genre: "Mystery",
+    summary: "Ten strangers are lured to a remote island under false pretences and are killed one by one, each death mirroring a line in a nursery rhyme, leaving no apparent killer among the dead.",
+    themes: ["Justice & Retribution", "Isolation", "Guilt & Secrets", "Trust & Deception"],
+    prompts: [
+      "Eight executives wake up locked inside their company headquarters with a message stating one of them committed a crime that ruined seven lives.",
+      "Write a mystery set on a malfunctioning orbital station where each crew member is eliminated in a pattern corresponding to an old Earth legend.",
+      "A group of strangers receives personalised invitations to a luxury escape room, only to discover the puzzles use secrets from their own pasts."
+    ],
+    image: "https://images.unsplash.com/photo-1536440136628-849c177e76a1?q=80&w=800&auto=format&fit=crop"
+  },
+  {
+    id: "murders-rue-morgue",
+    title: "The Murders in the Rue Morgue",
+    author: "Edgar Allan Poe",
+    genre: "Mystery",
+    summary: "Amateur detective C. Auguste Dupin investigates a baffling double murder in a locked Parisian apartment, pioneering the genre of analytical detective fiction through pure logical reasoning.",
+    themes: ["Analytical Reasoning", "Impossible Crime", "Observation vs. Assumption", "Hidden Truth"],
+    prompts: [
+      "A cybersecurity expert is called to investigate a data breach where the logs show the intrusion occurred from a system that was physically offline.",
+      "Write a mystery where every witness swears the perpetrator was speaking a different language, yet all the descriptions of the crime are identical.",
+      "A crime scene analyst discovers evidence of a crime that defies known physics, forcing them to question the foundations of the case."
+    ],
+    image: "https://images.unsplash.com/photo-1554224155-6726b3ff858f?q=80&w=800&auto=format&fit=crop"
+  },
+  {
+    id: "robinson-crusoe",
+    title: "Robinson Crusoe",
+    author: "Daniel Defoe",
+    genre: "Adventure",
+    summary: "Shipwrecked on a deserted island for 28 years, Robinson Crusoe resourcefully builds a life from scratch, tames wild animals, cultivates crops, and eventually encounters the mysterious Friday.",
+    themes: ["Self-Reliance & Ingenuity", "Isolation", "Colonialism", "Civilisation vs. Nature"],
+    prompts: [
+      "An astronaut's capsule is stranded on a barren moon. With only a broken communication array and a survival kit, they must rebuild contact with Earth.",
+      "Write about a software developer whose internet connection is permanently severed and who must reconstruct their life and work without digital infrastructure.",
+      "A survivalist enters a year-long solo wilderness challenge but discovers a faint signal suggesting they are not entirely alone."
+    ],
+    image: "https://images.unsplash.com/photo-1507525428034-b723cf961d3e?q=80&w=800&auto=format&fit=crop"
+  },
+  {
+    id: "around-world-eighty-days",
+    title: "Around the World in Eighty Days",
+    author: "Jules Verne",
+    genre: "Adventure",
+    summary: "The composed English gentleman Phileas Fogg wagers his fortune that he can circumnavigate the globe in exactly eighty days, racing against time with his resourceful valet Passepartout.",
+    themes: ["Precision & Determination", "Cross-Cultural Encounters", "Speed & Technology", "Reputation & Honour"],
+    prompts: [
+      "A programmer bets their entire career on completing a distributed system deployment across 12 global data centres in a single 24-hour window.",
+      "Write an adventure story where the protagonist must collect a unique item from each of the world's continents within 30 days or forfeit everything they own.",
+      "Two rival travel journalists compete to complete the same extraordinary journey using entirely different modes of transport."
+    ],
+    image: "https://images.unsplash.com/photo-1488646953014-85cb44e25828?q=80&w=800&auto=format&fit=crop"
+  },
+  {
+    id: "jane-eyre",
+    title: "Jane Eyre",
+    author: "Charlotte Bronte",
+    genre: "Romance",
+    summary: "Orphaned and plain-spoken Jane Eyre takes a governess position at Thornfield Hall and falls into a turbulent romance with the brooding Mr. Rochester, whose dark secret threatens to destroy their chance at happiness.",
+    themes: ["Independence & Self-Respect", "Social Class", "Hidden Secrets", "Moral Integrity in Love"],
+    prompts: [
+      "A junior engineer at a prestigious firm falls for her brilliant but secretive manager, only to uncover a professional secret that could end both their careers.",
+      "Write a romance where the protagonist refuses to compromise their principles for love, and the partner must prove they are worthy rather than just desired.",
+      "A nanny hired by a reclusive artist in a remote mountain retreat uncovers a locked room and a history that redefines everything she thought she knew about them."
+    ],
+    image: "https://images.unsplash.com/photo-1474552226712-ac0f0961a954?q=80&w=800&auto=format&fit=crop"
+  },
+  {
+    id: "sense-sensibility",
+    title: "Sense and Sensibility",
+    author: "Jane Austen",
+    genre: "Romance",
+    summary: "Sisters Elinor and Marianne Dashwood navigate love, heartbreak, and social expectation after their family is left financially precarious, embodying the tension between rational restraint and passionate feeling.",
+    themes: ["Reason vs. Emotion", "Financial Insecurity & Marriage", "Heartbreak & Resilience", "Sisterhood"],
+    prompts: [
+      "Two sisters with opposite personalities both fall for unsuitable partners. One plans every move; the other follows every feeling. Write their year of reckoning.",
+      "A story about a pair of roommates — one a meticulous planner, the other an impulsive romantic — navigating the same complicated love triangle from their own perspectives.",
+      "Write a modern romance exploring how social media makes it impossible to grieve a relationship privately, and how two very different people handle that exposure."
+    ],
+    image: "https://images.unsplash.com/photo-1456513080510-7bf3a84b82f8?q=80&w=800&auto=format&fit=crop"
   }
 ];


### PR DESCRIPTION
## Description

This PR extends the **Explore Stories** / Story Inspiration feature introduced in #275 to more comprehensively cover the six genres requested in issue #228 and adds a homepage entry point so users can discover the section from the landing page.

Resolves #228

---

## What Changed

### 1. Expanded story library (`inspirationData.ts`)

The inspiration dataset has grown from **10 to 22 public-domain classics**, adding exactly **2 new entries per genre** so each category is well represented:

| Genre | New titles added |
|---|---|
| Fantasy | The Wonderful Wizard of Oz, A Midsummer Night's Dream |
| Horror | The Tell-Tale Heart, Strange Case of Dr Jekyll and Mr Hyde |
| Sci-Fi | The War of the Worlds, Brave New World |
| Mystery | And Then There Were None, The Murders in the Rue Morgue |
| Adventure | Robinson Crusoe, Around the World in Eighty Days |
| Romance | Jane Eyre, Sense and Sensibility |

Each entry follows the existing schema: `id`, `title`, `author`, `genre`, `summary`, `themes[]`, `prompts[]` (3 modern writing prompts), and an Unsplash cover image. No new dependencies introduced.

### 2. Homepage sidebar widget (`StoryInspirationHomeCard.tsx`)

A new compact sidebar card placed in the home page right column:
- Shows **3 featured story previews** with cover thumbnail, title, author, and genre badge
- Provides **genre quick-links** for all 6 genres that navigate to `/story-inspiration`
- Primary CTA button: **Explore All Stories** links to `/story-inspiration`
- Matches the existing sidebar styling (Tailwind, rounded-xl, dark-mode support, no new packages)

### 3. Home component wiring (`home.component.tsx`)

`StoryInspirationHomeCard` is added to the sidebar above `TrendingTopicComponent` so users see the feature immediately on the landing page.

---

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

---

## Screenshots

> The Story Inspiration Hub lives at `/story-inspiration` (accessible via the "Stories" nav link or the new homepage sidebar card).

**Homepage sidebar widget (new):**
- Compact card with 3 story previews, genre pills, and "Explore All Stories" CTA

**Expanded story grid (22 stories):**
- All 6 genres now have 3-4 entries: Fantasy, Horror, Sci-Fi, Mystery, Adventure, Romance

---

## Test Plan

- [x] TypeScript: `tsc --noEmit` reports zero errors in new/modified files
- [x] `inspirationData.ts` exports 22 entries; each has required fields (`id`, `title`, `author`, `genre`, `summary`, `themes`, `prompts`, `image`)
- [x] `StoryInspirationHomeCard` renders without runtime errors and links to `/story-inspiration`
- [x] Genre filter on `/story-inspiration` correctly filters new entries
- [x] "Generate Similar Story" on each new card constructs a well-formed prompt and navigates to `/stories`
- [x] Dark mode and responsive layout verified against existing sidebar components
- [x] No regressions to existing 10 story entries or existing UI

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I am assigned to issue #228
- [x] This PR is submitted as part of **GSSoC '26**

---

Hi @ronisarkarexe, this is submitted under **GSSoC '26** (Level-1 enhancement). Looking forward to your feedback!