### PR TITLE
fix: resolve login form input overflow layouts on sign-in page

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1355,3 +1355,5 @@ html.dark .contact-input::placeholder { color: rgba(148, 163, 184, 0.78); }
   transform: none;
 }
 
+/* Core UI Fix for Authentication Component Inputs */ 
+.login-container input, .form-control, input[type='email'], input[type='password'] { box-sizing: border-box !important; max-width: 100% !important; } 


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Closes #1640
- **Description:** Added core CSS responsive styling rules to secure input box limits and boundaries.
- **Screenshots:** N/A (CSS layout enforcement rules)

## What this PR does

This PR addresses issue #1640 where the sign-in page inputs overflowed or layout styles conflicts broke parent bounds. 

- Appended layout boundary controls (`box-sizing` and `max-width` enforcements) to `frontend/src/index.css` to force login container input structures (`email`, `password`, `.form-control`) to scale cleanly inside their corresponding parent component walls across responsive viewports.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #1640

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.