### PR TITLE
fix: resolve JSX tag mismatch and merge conflict artifacts

### DIFF
--- a/frontend/src/components/stories/stories.component.tsx
+++ b/frontend/src/components/stories/stories.component.tsx
@@ -479,7 +479,6 @@ const StoriesComponent = () => {
   }, []);
 
   const [stories, setStories] = useState<IStories[]>(
-    draft?.stories?.length ? getUniqueStories(draft.stories) : [{uuid:"test-1",title:"The Wizard's Journey",content:"Merlin walked through the forest toward the castle. The village was far behind him. He crossed the bridge over the river and entered the dungeon beneath the tower. Dragons guarded the mountain beyond the valley. Elena watched from the palace window as Merlin approached the cave near the ocean shore.",tag:"Fantasy",imageURL:""}]
     draft?.stories?.length ? getUniqueStories(draft.stories) : []
   );
   


### PR DESCRIPTION
## Screenshot (when helpful)

N/A - Code fix only, no UI changes

## What this PR does

Removes duplicate expression in `stories.component.tsx` (lines 481-483) that was causing a merge conflict artifact.

### Changes:
- Deleted duplicate `draft?.stories?.length ? ...` expression in useState initializer
- Kept only one valid expression

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #2606

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.