### PR TITLE
feat: add evaluation report generation after training

### DIFF
--- a/backend/ml/train.py
+++ b/backend/ml/train.py
@@ -25,6 +25,7 @@ from model import build_model, SEQ_LEN, N_FEATURES
 MODEL_PATH     = "saved/model.keras"
 SCALER_PATH    = "saved/scaler.pkl"
 THRESHOLD_PATH = "saved/threshold.json"
+EVALUATION_REPORT_PATH = "saved/evaluation_report.json"
 TUNER_DIR      = "my_tuner"
 
 os.makedirs("saved", exist_ok=True)
@@ -245,6 +246,27 @@ def train():
     print(f"  Stuck   err  mean={np.mean(err_stuck):.4f}  "
           f"max={np.max(err_stuck):.4f}")
     print(f"  Threshold  = {threshold:.4f}")
+
+    # Save evaluation report
+    evaluation_report = {
+        "threshold": threshold,
+        "false_positive_rate": fp_pct/100,
+        "detection_rate": tp_pct/100,
+
+        "normal_error_mean": float(np.mean(err_val)),
+        "normal_error_max": float(np.max(err_val)),
+
+        "stuck_error_mean": float(np.mean(err_stuck)),
+        "stuck_error_max": float(np.max(err_stuck)),
+
+        "normal_samples": len(X_val),
+        "stuck_samples": len(stuck_raw),
+    }
+
+    with open(EVALUATION_REPORT_PATH, "w") as fh:
+        json.dump(evaluation_report, fh, indent=4)
+
+    print(f"  Evaluation report → {EVALUATION_REPORT_PATH}")
 
     if tp_pct < 50:
         print("\n  ⚠  Detection rate still low. Consider:")


### PR DESCRIPTION
This PR adds automatic generation of an evaluation_report.json file after the Writer's Block Detector model finishes training.

The report stores important evaluation metrics such as:

- Threshold value
- False positive rate
- Detection rate
- Reconstruction error statistics
- Evaluation sample counts

Currently, these metrics are only printed in the terminal and are lost after training completes.

By saving them as a JSON artifact, it becomes easier to:
 
- Compare model performance across different training runs
- Track whether performance improves or degrades after future model changes
- Debug threshold tuning and anomaly detection behavior
- Maintain a persistent record of evaluation results

## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [ ] Bug fix
- [x] New feature -
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #2661

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
yes checked all