### PR TITLE
fix: add freeAiRateLimiter to unprotected AI endpoints

### DIFF
--- a/backend/src/app/modules/ai_editor/ai_editor.router.ts
+++ b/backend/src/app/modules/ai_editor/ai_editor.router.ts
@@ -1,9 +1,10 @@
 import express from "express";
 import { AiEditorController } from "./ai_editor.controller";
+import freeAiRateLimiter from "../../middleware/free-ai.rate-limiter";
 
 const router = express.Router();
 
 // Publicly available to support both guest authors and registered writers
-router.post("/analyze", AiEditorController.analyzeStory);
+router.post("/analyze",freeAiRateLimiter , AiEditorController.analyzeStory);
 
 export const AIEditorRouter = router;

--- a/backend/src/app/modules/engagement/engagement.router.ts
+++ b/backend/src/app/modules/engagement/engagement.router.ts
@@ -1,8 +1,9 @@
 import express from "express";
 import { EngagementController } from "./engagement.controller";
+import freeAiRateLimiter from "../../middleware/free-ai.rate-limiter";
 
 const router = express.Router();
 
-router.post("/analyze", EngagementController.analyzeChapter);
+router.post("/analyze", freeAiRateLimiter, EngagementController.analyzeChapter);
 
 export const EngagementRouter = router;

--- a/backend/src/app/modules/story_inspiration/story_inspiration.router.ts
+++ b/backend/src/app/modules/story_inspiration/story_inspiration.router.ts
@@ -2,11 +2,13 @@ import express from "express";
 import validateRequest from "../../middleware/validate.request";
 import { StoryInspirationController } from "./story_inspiration.controller";
 import { StoryInspirationValidation } from "./story_inspiration.validation";
+import freeAiRateLimiter from "../../middleware/free-ai.rate-limiter";
 
 const router = express.Router();
 
 router.post(
   "/",
+  freeAiRateLimiter,
   validateRequest(StoryInspirationValidation.createStoryInspirationSchema),
   StoryInspirationController.createStoryInspiration
 );

--- a/backend/src/app/modules/story_visualizer/story_visualizer.router.ts
+++ b/backend/src/app/modules/story_visualizer/story_visualizer.router.ts
@@ -2,11 +2,13 @@ import express from "express";
 import validateRequest from "../../middleware/validate.request";
 import { StoryVisualizerController } from "./story_visualizer.controller";
 import { StoryVisualizerValidator } from "./story_visualizer.validation";
+import freeAiRateLimiter from "../../middleware/free-ai.rate-limiter";
 
 const router = express.Router();
 
 router.post(
   "/generate",
+  freeAiRateLimiter,
   validateRequest(StoryVisualizerValidator.generateStoryboard),
   StoryVisualizerController.generateStoryboard
 );


### PR DESCRIPTION
## Summary

This PR adds rate limiting protection to AI-powered endpoints that were previously accessible without request throttling. The change helps prevent excessive usage of Gemini-powered features and aligns these routes with the existing protection already used elsewhere in the application.

## Changes Made

Applied `freeAiRateLimiter` to the following endpoints:

- `POST /ai-editor/analyze`
- `POST /engagement/analyze`
- `POST /story-visualizer/generate`
- `POST /story-inspiration/`

## Why?

These endpoints trigger AI requests but were not using the existing rate-limiting middleware. As a result, they could receive an unlimited number of requests from the same source.

Adding `freeAiRateLimiter` helps:

- Reduce the risk of API abuse
- Protect AI service quotas and usage limits
- Maintain consistency across AI-related routes
- Follow the same security pattern already implemented in other AI endpoints

## Implementation

The middleware was added using the same approach already used in `ai_model.router.ts` for publicly accessible AI routes.

Current limits:

- **5 requests per 24 hours per IP address**

## Testing

- ✅ Verified middleware is applied to all four affected routes
- ✅ Confirmed implementation matches the existing pattern in `ai_model.router.ts`
- ✅ No changes to endpoint functionality beyond rate limiting
- ✅ Existing route behavior remains unchanged for valid requests within the limit

## Result

All four AI endpoints are now protected by the existing rate-limiting mechanism, helping prevent excessive usage while maintaining the intended user experience.

Fixes #2673.