### PR TITLE
fix: remove duplicate contributors route and undefined SafeContributo…

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -101,7 +101,6 @@ const router = createBrowserRouter([
       { path: "terms", element: <Terms /> },
       { path: "help-center", element: <HelpCenterComponent /> },
       { path: "guidelines", element: <GuidelinesComponent /> },
-      { path: "contributors", element: <SafeContributorsComponent /> },
       { path: "contributors", element: <ContributorsComponent /> },
       { path: "community", element: <CommunityComponent /> },
       { path: "report-bug", element: <ReportBug /> },


### PR DESCRIPTION
## What this PR does
Removes duplicate `/contributors` route and undefined 
`SafeContributorsComponent` reference from `App.tsx`.

- Deleted the duplicate route using `SafeContributorsComponent` 
  which was never imported or defined anywhere in the file
- Kept the valid route using `ContributorsComponent` which is 
  correctly imported via lazy loading

## Type of change
- [x] Bug fix

## Related issue
Closes #2695

## Screenshot
N/A — routing fix with no visual changes, no UI affected

## Checklist
- [x] I have added screenshots or a recording when they help explain 
  this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.