### PR TITLE
fix: resolve login form input overflow on small screens #2648

### DIFF
--- a/frontend/src/components/login/login.component.tsx
+++ b/frontend/src/components/login/login.component.tsx
@@ -214,6 +214,7 @@ const LoginComponent = () => {
               validation={{ required: "Email is required" }}
               error={errors.email}
               autoComplete="email"
+          className="w-full box-border"
               />
 
             {/* Password field — eye icon toggle is provided by SSInput when type="password" */}


### PR DESCRIPTION
## What this PR does
Fixes login form email input field overflowing outside the container on smaller screen widths.

## Changes
- Added `className="w-full box-border"` to email SSInput in login.component.tsx

## Related Issue
Closes #2648

## Screenshots
[NA]