### PR TITLE
fix: connect standalone auth pages to backend API /api/v1/auth

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -582,7 +582,7 @@ async function handleFormSubmit(e) {
     setAlert('info', currentMode === 'signup' ? 'Creating your account…' : 'Signing you in…');
 
     try {
-        const endpoint = currentMode === 'signup' ? '/api/auth/register' : '/api/auth/login';
+        const endpoint = currentMode === 'signup' ? '/api/v1/auth/register' : '/api/v1/auth/login';
         const body = currentMode === 'signup'
             ? { email, name, password }
             : { email, password, rememberMe };
@@ -692,7 +692,7 @@ function decodeJwt(token) {
 
 async function handleGoogleCredentialResponse(response) {
     try {
-        const res = await fetch('/api/auth/google-login', {
+        const res = await fetch('/api/v1/auth/google-login', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ token: response.credential }),


### PR DESCRIPTION
Closes #924

## What changed
- Updated `auth.js` to use correct backend API endpoints `/api/v1/auth/login`, `/api/v1/auth/register`, and `/api/v1/auth/google-login`
- Previously the endpoints were pointing to `/api/auth/*` which did not match the backend router prefix `/api/v1`

## Testing
- Login form now calls `POST /api/v1/auth/login`
- Signup form now calls `POST /api/v1/auth/register`  
- Google Sign-In now calls `POST /api/v1/auth/google-login`