### PR TITLE
fix: remove duplicate Contact section from Home page (#319)

### DIFF
--- a/frontend/src/components/home/home.component.tsx
+++ b/frontend/src/components/home/home.component.tsx
@@ -10,7 +10,6 @@ import ResourceComponent from "./resources/resources.component";
 import PricingComponent from "./pricing/pricing.component";
 import WriterFeedbackComponent from "./writer_feedback/writer_feedback.component";
 import StartWritingComponent from "./start_writing/start_writing.component";
-import Contactus from "../contactus/contactus";
 import PersonalizedRecommendationsComponent from "./personalized_recommendations/personalized_recommendations.component";
 import { isLoggedIn } from "../../services/auth.service";
 import BackToTop from "../ScrollToTopButton";


### PR DESCRIPTION
Removes the duplicate Contact section from the Home page by deleting the unused `Contactus` import.

## Changes
- `frontend/src/components/home/home.component.tsx`: removed unused import line

The dedicated Contact Us page (`/contact-us`) remains unchanged.

Closes #319