### PR TITLE
fix(auth): validate user status in authentication middleware

### DIFF
--- a/backend/src/app/middleware/auth.middleware.ts
+++ b/backend/src/app/middleware/auth.middleware.ts
@@ -6,6 +6,7 @@ import ApiError from "../../errors/api_error";
 import { JwtHelpers } from "../../utils/jwt.helper";
 import { User } from "../modules/user/user.model";
 import { TokenBlacklist } from "../modules/auth/tokenBlacklist.model";
+import { USER_STATUS } from "../../enums/user_status";
 
 const auth =
   (...requiredRole: string[]) =>
@@ -51,6 +52,13 @@ const auth =
         throw new ApiError(
           httpStatus.UNAUTHORIZED,
           "Token is invalid or expired"
+        );
+      }
+
+      if (user.status !== USER_STATUS.ACTIVE) {
+        throw new ApiError(
+          httpStatus.FORBIDDEN,
+          "Your account is not active"
         );
       }
 


### PR DESCRIPTION


## Before you open this PR 
 
 - **Issue:** Closes #2717
 - **Description:** Prevent blocked or inactive users from accessing protected API endpoints by validating their account status in the authentication middleware. 
 - **Screenshots:** N/A (Backend logic change verified via unit tests). 
 
 ## Screenshot (when helpful) 
 
 <!-- Drag & drop or paste. For non-UI work, you can use tests output, logs, or API responses. Write “N/A” in the checklist if you skip this section. --> 
 N/A
 
 
 ## What this PR does 
 
 <!-- Short summary: what problem does this solve, and how? --> 
 Currently, the authentication middleware only verifies JWT validity, user existence, and token version. It fails to check if a user's account has been `BLOCKED` or set to `INACTIVE` by an admin. This PR adds a status validation check in the [auth.middleware.ts](file:///c:/Users/lenovo/story-spark-ai/backend/src/app/middleware/auth.middleware.ts) file. If a user's status is not `ACTIVE`, the middleware will now return a `403 Forbidden` response, ensuring that revoked access is enforced immediately across all protected routes.
 
 
 ## Type of change 
 
 Check all that apply (if more than one, explain in “What this PR does”). 
 
 - [x] Bug fix 
 - [ ] New feature 
 - [ ] Code refactor 
 - [ ] Documentation update 
 
 ## Related issue 
 

 Closes #2717
 
  ## Checklist 
 
 - [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason. 
 - [x] I have filled in the related issue number when there is one. 
 - [x] I have tested my changes. 
 - [x] I have done a self-review of the code.