### PR TITLE
fix: remove duplicate /contributors route in App.tsx

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -101,7 +101,7 @@ const router = createBrowserRouter([
       { path: "terms", element: <Terms /> },
       { path: "help-center", element: <HelpCenterComponent /> },
       { path: "guidelines", element: <GuidelinesComponent /> },
-      { path: "contributors", element: <SafeContributorsComponent /> },
+      
       { path: "contributors", element: <ContributorsComponent /> },
       { path: "community", element: <CommunityComponent /> },
       { path: "report-bug", element: <ReportBug /> },


### PR DESCRIPTION
Fixes #620

### What was wrong
The issue title mentions `/templates` but the actual duplicate found 
in `App.tsx` was the `/contributors` route, registered twice:
- Once with `SafeContributorsComponent` (which was never imported)
- Once with the correctly imported `ContributorsComponent`

### Fix
Removed the duplicate `/contributors` route entry that referenced 
the undefined `SafeContributorsComponent`.

### Testing
- `/contributors` still renders `ContributorsComponent` ✅
- No other routes affected ✅

Note: The frontend has pre-existing build errors in other components
unrelated to this fix.

Contributing under GSSoC'26 🌸 
<img width="1263" height="887" alt="image" src="https://github.com/user-attachments/assets/d292b50a-3d0d-4b37-a2c1-cee942a39556" />
