### PR TITLE
Fix: remove undefined SafeContributorsComponent route

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -101,7 +101,7 @@ const router = createBrowserRouter([
       { path: "terms", element: <Terms /> },
       { path: "help-center", element: <HelpCenterComponent /> },
       { path: "guidelines", element: <GuidelinesComponent /> },
-      { path: "contributors", element: <SafeContributorsComponent /> },
+      
       { path: "contributors", element: <ContributorsComponent /> },
       { path: "community", element: <CommunityComponent /> },
       { path: "report-bug", element: <ReportBug /> },


### PR DESCRIPTION
#closes 2667

## Fix: remove undefined SafeContributorsComponent route

While navigating to `/contributors`, the app crashed with:
ReferenceError: SafeContributorsComponent is not defined

The route definition on line 104 referenced a non‑existent component. This commit removes that line,
leaving the correct <ContributorsComponent /> route (line 105) as the sole handler for `/contributors`.

**Changes**
- Deleted the faulty `{ path: "contributors", element: <SafeContributorsComponent /> }` entry.

#gssoc
