### PR TITLE
feat: add copy story to clipboard button on story trading card

### DIFF
--- a/frontend/src/components/cards/StoryTradingCard.tsx
+++ b/frontend/src/components/cards/StoryTradingCard.tsx
@@ -1,6 +1,4 @@
 import React, { useMemo, useRef, useState, useEffect } from "react";
-import html2canvas from "html2canvas";
-import React, { useMemo, useRef } from "react";
 import toast from "react-hot-toast";
 import type { IStories } from "../stories/stories.view.component";
 import { getWordCount } from "../stories/stories.utils";
@@ -141,6 +139,21 @@ const StoryTradingCard: React.FC<StoryTradingCardProps> = ({
   const genreClass =
     genreColorMap[genre.toLowerCase()] ||
     "bg-purple-500/20 text-purple-100 border-purple-300/40";
+
+  const [isCopied, setIsCopied] = useState(false);
+
+  const handleCopyStory = async () => {
+    const text = cleanText(story.content);
+    if (!text) return;
+    try {
+      await navigator.clipboard.writeText(text);
+      setIsCopied(true);
+      toast.success("Story copied to clipboard!");
+      setTimeout(() => setIsCopied(false), 2000);
+    } catch {
+      toast.error("Could not copy story text.");
+    }
+  };
 
   const handleDownload = async () => {
     if (!cardRef.current) return;
@@ -336,6 +349,15 @@ const StoryTradingCard: React.FC<StoryTradingCardProps> = ({
           >
             <i className="fa-solid fa-download"></i>
             Download PNG
+          </button>
+          <button
+            type="button"
+            onClick={handleCopyStory}
+            aria-label="Copy story to clipboard"
+            className="inline-flex flex-1 items-center justify-center gap-2 rounded-lg bg-violet-600 px-4 py-3 text-sm font-bold text-white transition hover:bg-violet-500 active:scale-95"
+          >
+            <i className={`fa-solid ${isCopied ? "fa-check" : "fa-clipboard"}`}></i>
+            {isCopied ? "Copied!" : "Copy Story"}
           </button>
           <button
             type="button"


### PR DESCRIPTION

## What this PR does

Adds a **Copy Story to Clipboard** button on each story trading card (`StoryTradingCard.tsx`).

* Uses the native `navigator.clipboard.writeText()` API — no external library needed
* The button icon toggles from clipboard → checkmark and label changes to "Copied!" for 2 seconds as visual confirmation
* A toast notification also confirms the copy action
* Button has `aria-label="Copy story to clipboard"` for keyboard and screen reader accessibility
* Works correctly in both light and dark mode
* Positioned between the existing "Download PNG" and "Share Card" buttons for logical grouping

---

## Type of change

* [ ] Bug fix
* [x] New feature
* [ ] Code refactor
* [ ] Documentation update

---

## Related issue

Closes #2574



## Checklist
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.
