### PR TITLE
Fix overlapping help category cards layout

### DIFF
--- a/frontend/src/components/help_center/help_category_card/help_category_card.component.tsx
+++ b/frontend/src/components/help_center/help_category_card/help_category_card.component.tsx
@@ -14,7 +14,7 @@ const HelpCategoryCard: FC<HelpCategoryCardProps> = ({ category }) => {
     <button
       type="button"
       onClick={handleClick}
-      className="group text-left w-full bg-white dark:bg-[#111827]/40 border border-slate-200 dark:border-white/10 hover:border-blue-500/40 dark:hover:border-blue-500/30 p-5 sm:p-6 rounded-2xl shadow-sm hover:shadow-xl transition-all duration-300 hover:scale-[1.02] focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/20 cursor-pointer flex flex-col justify-between box-border"
+      className="group text-left bg-white dark:bg-[#111827]/40 border border-slate-200 dark:border-white/10 hover:border-blue-500/40 dark:hover:border-blue-500/30 p-5 sm:p-6 rounded-2xl shadow-sm hover:shadow-xl transition-all duration-300 hover:scale-[1.02] focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/20 cursor-pointer flex flex-col justify-between box-border"
     >
       <div className="w-full">
         <div className="w-11 h-11 sm:w-12 sm:h-12 rounded-xl bg-gradient-to-br from-blue-500/10 to-indigo-500/10 border border-blue-500/20 flex items-center justify-center text-xl sm:text-2xl text-blue-500 dark:text-blue-400 mb-5 select-none group-hover:scale-105 transition-transform duration-300 shrink-0">


### PR DESCRIPTION
## What this PR does

Fixed the UI overlap issue in the Help Center categories section.

The category cards were overlapping because the card button had an unnecessary `w-full` width constraint inside the grid layout. Removed the extra width styling so the grid can correctly control card sizing and spacing.

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

## Related issue

Closes #2738

## Screenshot (when helpful)

<img width="1478" height="761" alt="Screenshot 2026-06-10 162829" src="https://github.com/user-attachments/assets/ca5a7c21-6f5b-4d7b-916e-7ac5660e0989" />
N/A

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.
