### PR TITLE
docs: fix broken TOC anchors and nested blockquote in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,9 @@ VITE_GOOGLE_CLIENT_ID=your-google-client-id
 
 
 
-<a id="contributing"></a>
+
+<a id="troubleshooting"></a>
+
 ## Troubleshooting 🛠️
 
 Running into issues during setup? Here are the most common errors and how to fix them.
@@ -310,8 +312,8 @@ git commit -m "chore: regenerate package-lock.json"
 
 ---
 
-> > 💡 **Still stuck?** Open an issue or check existing ones — your problem may already have a solution!
-
+> 💡 **Still stuck?** Open an issue or check existing ones — your problem may already have a solution!
+<a id="contributing"></a>
 ## Contributing 👨‍💻
 
 Contributions make the open source community such an amazing place to learn, inspire, and create. <br>


### PR DESCRIPTION

## What this PR does
Fixes three structural bugs found in README.md while investigating issue #2417:

1. Added missing `<a id="troubleshooting"></a>` anchor before the
   Troubleshooting 🛠️ section — the Table of Contents link was silently broken.

2. Moved `<a id="contributing"></a>` to before the Contributing 👨‍💻 heading —
   it was incorrectly placed after the section content, breaking the TOC link.

3. Fixed `> >` double nested blockquote to a single `>` on the "Still stuck?"
   tip — was rendering as a broken nested indent in Markdown.

No content changes — structure and rendering fixes only.

## Type of change
- [x] Documentation update

## Related issue
Fixes #2417

## More screenshots (optional)
N/A

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.