### PR TITLE
fix: add rate limiting to story generation stream endpoint

### DIFF
--- a/backend/src/app/modules/ai_model/ai_model.router.ts
+++ b/backend/src/app/modules/ai_model/ai_model.router.ts
@@ -33,6 +33,7 @@ router.post(
 // Generate Model Stream - PROTECTED
 router.post(
   "/generate-model-stream",
+  aiGenerationRateLimiter,
   auth(),
   validateRequest(AIModelValidator.aiModel),
   checkRequestLimit(),


### PR DESCRIPTION
## Screenshot (when helpful)

N/A - Backend middleware change only, no UI changes.

## What this PR does

Fixes missing rate limiting protection on the story generation streaming endpoint.

Changes:
- Added `aiGenerationRateLimiter` middleware to `/generate-model-stream`.
- Ensures streaming AI generation requests follow existing rate limits.
- Helps prevent unlimited AI generation usage and unnecessary API cost.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Fixes #2847

## More screenshots (optional)

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.