### PR TITLE
test: prevent duplicate middleware registration

### DIFF
--- a/backend/src/__tests__/middlewareRegistration.test.ts
+++ b/backend/src/__tests__/middlewareRegistration.test.ts
@@ -1,0 +1,49 @@
+import fs from "fs";
+import path from "path";
+import ts from "typescript";
+
+const appSource = fs.readFileSync(path.join(__dirname, "../app.ts"), "utf8");
+const sourceFile = ts.createSourceFile(
+  "app.ts",
+  appSource,
+  ts.ScriptTarget.Latest,
+  true,
+  ts.ScriptKind.TS
+);
+
+const countMiddlewareRegistrations = (middlewareName: string): number => {
+  let count = 0;
+
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.expression.getText(sourceFile) === "app" &&
+      node.expression.name.text === "use"
+    ) {
+      const middleware = node.arguments[0];
+
+      if (
+        middleware &&
+        ts.isCallExpression(middleware) &&
+        middleware.expression.getText(sourceFile) === middlewareName
+      ) {
+        count += 1;
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return count;
+};
+
+describe("middleware registration", () => {
+  it.each(["express.urlencoded", "cookieParser"])(
+    "registers %s exactly once",
+    (middlewareName) => {
+      expect(countMiddlewareRegistrations(middlewareName)).toBe(1);
+    }
+  );
+});


### PR DESCRIPTION
## Summary

This PR removes duplicate registrations of `express.urlencoded({ extended: true })` and `cookieParser()` in `backend/src/app.ts`.

### Changes Made

* Removed the second registration of `express.urlencoded({ extended: true })`
* Removed the duplicate registration of `cookieParser()`
* Preserved existing middleware behavior while eliminating redundant executions

### Why This Change?

The same middleware was being registered multiple times:

```ts
app.use(express.urlencoded({ extended: true }));
app.use(cookieParser() as any);

...

app.use(express.urlencoded({ extended: true }));
app.use(cookieParser() as unknown as RequestHandler);
```

Although the application continues to function correctly, duplicate middleware execution introduces unnecessary processing overhead on every request and makes the middleware chain harder to maintain.

### Expected Outcome

* Each middleware executes only once per request.
* Reduced unnecessary middleware processing.
* Cleaner and more maintainable middleware configuration.

### Testing

* Verified application starts successfully.
* Verified request body parsing continues to work.
* Verified cookie parsing continues to work.
* Confirmed no middleware-related regressions.

---

## GSSoC 2026

* Issue: #2274 
* Type: Bug Fix
