### PR TITLE
fix: remove debug logs and add fallback UI for related posts API failure

### DIFF
--- a/frontend/src/components/post/post.details.component.tsx
+++ b/frontend/src/components/post/post.details.component.tsx
@@ -74,12 +74,7 @@ const PostDetailsComponent = () => {
   );
   
 
-  console.log("Current Post:", post);
-  console.log("Tag:", tag);
-  console.log(
-  "Related Posts Full Data:",
-  JSON.stringify(relatedPost, null, 2)
-);
+ 
   
   const [toggleReaction] = useToggleReactionMutation();
   const [deletePost, { isLoading: isDeleting }] = useDeletePostMutation();
@@ -531,15 +526,21 @@ const PostDetailsComponent = () => {
             )}
 
             <div>
-              <h3 className="text-xl font-semibold mb-4 text-slate-900 dark:text-gray-300">
-                Related Stories
-              </h3>
+  <h3 className="text-xl font-semibold mb-4 text-slate-900 dark:text-gray-300">
+    Related Stories
+  </h3>
 
-              <RelatedStoriesComponent
-                posts={relatedPost || []}
-                currentPostId={post?._id || ""}
-              />
-            </div>
+  {relatedPost && relatedPost.length > 0 ? (
+    <RelatedStoriesComponent
+      posts={relatedPost}
+      currentPostId={post?._id || ""}
+    />
+  ) : (
+    <div className="text-center py-8 text-slate-500 dark:text-gray-400">
+      <p>No related stories found.</p>
+    </div>
+  )}
+</div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
Closes #2899

## Changes Made

### 1. Removed debug console.logs
- Removed `console.log("Current Post:", post)`
- Removed `console.log("Tag:", tag)`
- Removed `console.log("Related Posts Full Data:", ...)`
These were leaking internal data to the browser console in production.

### 2. Added fallback UI for Related Stories
- When related posts API returns empty or fails, users now see 
  a friendly "No related stories found." message
- Previously the section rendered silently with no user feedback

## Type of Change
- [x] Bug fix

## Testing
- Opened post detail page on live site
- Verified console showed the 500 error and undefined logs
- Fix removes debug logs and adds graceful fallback UI
