### PR TITLE
feat: add security headers to nginx.conf

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -6,6 +6,11 @@ server {
   index index.html;
   client_max_body_size 20m;
 
+  add_header X-Content-Type-Options  "nosniff"                          always;
+  add_header X-Frame-Options         "DENY"                             always;
+  add_header Referrer-Policy         "strict-origin-when-cross-origin"  always;
+  add_header Permissions-Policy      "geolocation=(), microphone=(), camera=()" always;
+
   location ^~ /api/v1/ {
     proxy_pass http://backend:5000/api/v1/;
     proxy_http_version 1.1;


### PR DESCRIPTION
## What this PR does

`frontend/nginx.conf` had no security headers configured. This PR adds four headers to the `server {}` block to protect against MIME-sniffing, clickjacking, URL leakage, and browser feature abuse. Only `frontend/nginx.conf` is changed, no application logic, routing, or other files are touched.

## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #2925

## More screenshots (optional)

N/A - no UI changes

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
