### PR TITLE
fix(trending-topic): correct invalid JSX closing tag

### DIFF
--- a/frontend/src/components/home/trending_topic/trending_topic.component.tsx
+++ b/frontend/src/components/home/trending_topic/trending_topic.component.tsx
@@ -15,7 +15,7 @@ const TrendingTopicComponent = () => {
             className="story-chip px-3 py-1.5 text-sm font-semibold text-blue-600 dark:text-blue-200"
           >
             {topic.title}
-          </span>
+          </a>
         ))}
       </div>
     </section>


### PR DESCRIPTION
## What this PR does

This PR fixes an incorrect JSX closing tag in `TrendingTopicComponent`.

### Changes Made

* Replaced an incorrect `</span>` closing tag with the correct `</a>` closing tag.
* Restored valid JSX structure in the component.
* Preserved all existing UI, styling, and functionality.

### Why

The component opened an anchor element:

```tsx
<a ...>
```

but incorrectly closed it using:

```tsx
</span>
```

This caused invalid JSX structure and frontend compilation/parsing issues.

The fix is minimal and only corrects the JSX markup without affecting behavior.

---

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

---

## Related issue

Closes #2940 

---

## Screenshots

This PR only fixes an incorrect JSX closing tag. No UI or functionality changes were introduced

---

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.
