### PR TITLE
fix: use distinct icon for profile menu item

### DIFF
--- a/frontend/src/components/dashboard/dashboard.utils.ts
+++ b/frontend/src/components/dashboard/dashboard.utils.ts
@@ -78,7 +78,7 @@ export const menuItems: MenuItem[] = [
   },
   {
     name: "Profile",
-    icon: "fas fa-cog",
+    icon: "fas fa-user-circle",
     path: "/dashboard/profile",
     roles: [
       USER_ROLE.USER,


### PR DESCRIPTION
## Description
Updated the Profile menu icon from `fas fa-cog` to `fas fa-user-circle` to differentiate it from the Settings menu item and improve sidebar usability.

Closes #2931

## Changes
- Updated Profile icon in dashboard.utils.ts
- Kept Settings icon unchanged

## Screenshots

**Before:**
<img width="545" height="554" alt="Screenshot 2026-06-11 172356" src="https://github.com/user-attachments/assets/1f75a2cb-f567-44a5-aaaa-36e9bc8e4455" />

**After:**
<img width="582" height="549" alt="image" src="https://github.com/user-attachments/assets/385b982a-585a-4856-90cf-6dede79f90a4" />

## Type of change

- [x] Bug fix


## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
