### PR TITLE
fix: align name validation with User model constraints

### DIFF
--- a/backend/src/app/modules/user/user.validation.ts
+++ b/backend/src/app/modules/user/user.validation.ts
@@ -13,7 +13,8 @@ const register = z.object({
     email: z.string({ required_error: "Email is required" }),
     name: z
       .string({ required_error: "Name is required" })
-      .min(2, "Name must be at least 2 characters long"),
+      .min(5, "Name must be at least 5 characters long")
+      .max(100),
     password: passwordSchema,
     verificationToken: z
       .string({ required_error: "Verification token is required" })
@@ -46,7 +47,7 @@ const resetPassword = z.object({
 const updateUser = z.object({
   body: z
     .object({
-      name: z.string().trim().min(1, "Full Name cannot be empty.").max(100).optional(),
+      name: z.string().trim().min(5, "Name must be at least 5 characters long").max(100).optional(),
       profile: z
         .object({
           avatar: z.string().max(2000).optional(),


### PR DESCRIPTION


## What this PR does

This PR fixes an inconsistency between the Zod validation schema and the Mongoose User model for the `name` field.

Previously, the registration schema accepted names with a minimum length of 2 characters, while the User model enforced a minimum length of 5 characters. This could cause requests to pass request validation but later fail during user creation.

This change aligns the validation rules by updating the Zod schemas to require a minimum name length of 5 characters, matching the User model constraints.

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

## Related issue

Closes #2941 

## More screenshots (optional)

N/A

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.
