### PR TITLE
fix: add keyboard focus styles for interactive elements

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -145,7 +145,8 @@ html, body {
     box-shadow 220ms ease;
 }
 
-.motion-card:hover {
+.motion-card:hover,
+.motion-card:focus-visible {
   transform: translate3d(0, -6px, 0);
   box-shadow:
     0 18px 48px rgba(15, 23, 42, 0.28),
@@ -1056,8 +1057,18 @@ html.dark .contact-input::placeholder { color: rgba(148, 163, 184, 0.78); }
   transform: none;
 }
 
-.contact-submit-btn:focus-visible {
-  box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.24), 0 0 0 1px rgba(139, 92, 246, 0.35);
+.contact-submit-btn:not(:disabled):hover,
+.contact-submit-btn:not(:disabled):focus-visible {
+  transform: translate3d(0, -2px, 0) scale(1.005);
+  box-shadow:
+    0 0 0 1px rgba(139, 92, 246, 0.3),
+    0 12px 32px rgba(99, 102, 241, 0.28),
+    0 0 50px rgba(139, 92, 246, 0.14);
+}
+
+.contact-submit-btn:not(:disabled):hover .contact-btn-gradient,
+.contact-submit-btn:not(:disabled):focus-visible .contact-btn-gradient {
+  filter: brightness(1.1);
 }
 
 @keyframes slideIn {


### PR DESCRIPTION
## Summary

This PR improves keyboard accessibility by adding focus-visible feedback to interactive elements.

## Changes Made

* Added `:focus-visible` styles for `.motion-card`.
* Added `:focus-visible` styles for `.contact-submit-btn`.
* Matched keyboard focus interactions with existing hover effects.
* Added visible focus indicators for keyboard navigation.
* Extended button animation and gradient effects to focused states.

## Why

Previously, hover interactions were only available to mouse users. Keyboard users navigating with the Tab key did not receive equivalent visual feedback, making it harder to identify focused elements.

## Testing

* [x] Verified motion cards respond to keyboard focus
* [x] Verified submit button responds to keyboard focus
* [x] Verified visible focus indicator appears
* [x] Confirmed hover behavior remains unchanged

Closes #2295
