### PR TITLE
fix: replace invalid zinc-850 with zinc-800 in graph components

### DIFF
--- a/frontend/src/components/CharacterDetailsPanel.tsx
+++ b/frontend/src/components/CharacterDetailsPanel.tsx
@@ -37,7 +37,7 @@ const CharacterDetailsPanel = ({
 
   return (
     <div className="flex flex-col bg-zinc-900 border border-zinc-800 rounded-xl p-4 w-full md:w-80 shadow-md h-fit text-sm text-slate-300">
-      <div className="pb-2 border-b border-zinc-850">
+      <div className="pb-2 border-b border-zinc-800">
         <h3 className="font-bold text-white text-base">Details</h3>
       </div>
 
@@ -69,7 +69,7 @@ const CharacterDetailsPanel = ({
                     <button
                       key={r.id}
                       onClick={() => onNodeSelect(targetId)}
-                      className="flex justify-between items-center bg-zinc-950 hover:bg-zinc-850/50 border border-zinc-850 rounded px-2.5 py-1.5 text-xs text-left text-slate-300 transition"
+                      className="flex justify-between items-center bg-zinc-950 hover:bg-zinc-800/50 border border-zinc-800 rounded px-2.5 py-1.5 text-xs text-left text-slate-300 transition"
                     >
                       <span className="font-semibold text-slate-200">{targetName}</span>
                       <span className="text-[10px] bg-slate-800 text-indigo-300 border border-zinc-800 px-1.5 py-0.5 rounded-full font-medium">
@@ -101,7 +101,7 @@ const CharacterDetailsPanel = ({
             </div>
           </div>
 
-          <div className="grid grid-cols-2 gap-3 bg-zinc-950 border border-zinc-850 p-2.5 rounded-lg">
+          <div className="grid grid-cols-2 gap-3 bg-zinc-950 border border-zinc-800 p-2.5 rounded-lg">
             <div>
               <span className="text-[10px] text-slate-500 block">Type</span>
               <strong className="text-white text-sm font-semibold">{selectedEdge.type}</strong>
@@ -110,7 +110,7 @@ const CharacterDetailsPanel = ({
               <span className="text-[10px] text-slate-500 block">Strength</span>
               <strong className="text-white text-sm font-semibold">{selectedEdge.strength}/100</strong>
             </div>
-            <div className="col-span-2 pt-1.5 border-t border-zinc-850 mt-1">
+            <div className="col-span-2 pt-1.5 border-t border-zinc-800 mt-1">
               <span className="text-[10px] text-slate-500 block">Direct Interactions</span>
               <strong className="text-white text-sm font-semibold">
                 {selectedEdge.interactionCount}

--- a/frontend/src/components/GraphFilters.tsx
+++ b/frontend/src/components/GraphFilters.tsx
@@ -33,7 +33,7 @@ const GraphFilters = ({
 
   return (
     <div className="flex flex-col gap-4 bg-zinc-900 border border-zinc-800 rounded-xl p-4 w-full md:w-80 shadow-md h-fit text-sm text-slate-300">
-      <div className="flex justify-between items-center pb-2 border-b border-zinc-850">
+      <div className="flex justify-between items-center pb-2 border-b border-zinc-800">
         <h3 className="font-bold text-white text-base">Filters</h3>
         <button
           onClick={onClear}
@@ -51,7 +51,7 @@ const GraphFilters = ({
             value={search}
             onChange={(e) => onSearchChange(e.target.value)}
             placeholder="Type name..."
-            className="w-full h-9 bg-zinc-950 border border-zinc-850 rounded-lg px-3 pl-8 text-xs text-white placeholder-zinc-500 focus:outline-none focus:border-indigo-500 transition"
+            className="w-full h-9 bg-zinc-950 border border-zinc-800 rounded-lg px-3 pl-8 text-xs text-white placeholder-zinc-500 focus:outline-none focus:border-indigo-500 transition"
           />
           <i className="fas fa-search absolute left-3 top-1/2 -translate-y-1/2 text-zinc-500 text-xs"></i>
         </div>
@@ -68,7 +68,7 @@ const GraphFilters = ({
                 className={`flex items-center justify-center gap-1.5 px-2 py-1 rounded border text-[10px] font-semibold cursor-pointer transition select-none ${
                   isChecked
                     ? "bg-indigo-600/20 border-indigo-500/50 text-indigo-200"
-                    : "bg-zinc-950 border-zinc-850 hover:bg-zinc-800/30 text-slate-400"
+                    : "bg-zinc-950 border-zinc-800 hover:bg-zinc-800/30 text-slate-400"
                 }`}
               >
                 <input


### PR DESCRIPTION
### Description

\zinc-850\ is not a valid TailwindCSS v4 color shade. Valid zinc shades are \50,100,200,300,400,500,600,700,800,900,950\. This PR replaces all occurrences with \zinc-800\.

### Changes

- \rontend/src/components/GraphFilters.tsx\: \order-zinc-850\ → \order-zinc-800\
- \rontend/src/components/CharacterDetailsPanel.tsx\: \order-zinc-850\ → \order-zinc-800\, \hover:bg-zinc-850/50\ → \hover:bg-zinc-800/50\

Closes #2989