### PR TITLE
fix: allow OPTIONS preflight requests without origin in CORS

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -40,11 +40,11 @@ const corsOrigins =
 app.use(
   cors({
     origin: (origin, callback) => {
-      if (!origin && process.env.NODE_ENV === 'production') {
-        return callback(new Error('Origin header required in production'));
+      if (!origin) {
+        return callback(null, true);
       }
 
-      if (!origin || corsOrigins.includes(origin)) {
+      if (corsOrigins.includes(origin)) {
         callback(null, true);
       } else {
         callback(new Error("Blocked by Cross-Origin Resource Sharing (CORS) Policy"));


### PR DESCRIPTION
### Description

The CORS origin callback rejected requests with no \Origin\ header in production, which blocks \OPTIONS\ preflight requests from browsers. This PR removes the overly strict check and allows requests without an origin to pass through while still rejecting disallowed origins.

### Changes

- Removed the \!origin && production\ rejection in the CORS origin callback
- Requests without an \Origin\ header (including OPTIONS preflight) are now allowed
- Disallowed origins are still rejected with the same CORS policy error

Closes #2983
