### PR TITLE
fix: replace deprecated bg-gradient-to-* with bg-linear-to-* for TWv4

### DIFF
--- a/frontend/src/components/AchievementBadge.tsx
+++ b/frontend/src/components/AchievementBadge.tsx
@@ -23,7 +23,7 @@ const AchievementBadge: React.FC<AchievementBadgeProps> = ({ achievement }) => {
       tabIndex={0}
       className={`group relative flex flex-col justify-between rounded-2xl border p-5 transition-all duration-300 hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-indigo-500 ${
         isUnlocked
-          ? "border-yellow-100 bg-gradient-to-br from-yellow-50/20 via-white to-amber-50/10 shadow-md hover:shadow-lg dark:border-yellow-500/10 dark:from-yellow-500/5 dark:via-transparent dark:to-amber-500/5"
+          ? "border-yellow-100 bg-linear-to-br from-yellow-50/20 via-white to-amber-50/10 shadow-md hover:shadow-lg dark:border-yellow-500/10 dark:from-yellow-500/5 dark:via-transparent dark:to-amber-500/5"
           : "border-slate-200 bg-white/40 opacity-70 hover:opacity-90 dark:border-white/[0.06] dark:bg-white/[0.01]"
       }`}
       role="article"
@@ -34,7 +34,7 @@ const AchievementBadge: React.FC<AchievementBadgeProps> = ({ achievement }) => {
         <div
           className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-xl text-2xl shadow-sm transition-transform group-hover:rotate-12 ${
             isUnlocked
-              ? "bg-gradient-to-tr from-yellow-400 to-amber-300 text-slate-900"
+              ? "bg-linear-to-tr from-yellow-400 to-amber-300 text-slate-900"
               : "bg-slate-100 text-slate-400 dark:bg-white/[0.05]"
           }`}
           aria-hidden="true"

--- a/frontend/src/components/AchievementProgress.tsx
+++ b/frontend/src/components/AchievementProgress.tsx
@@ -30,7 +30,7 @@ const AchievementProgress: React.FC<AchievementProgressProps> = ({
         aria-label={label || "Achievement progress"}
       >
         <div
-          className="h-full bg-gradient-to-r from-indigo-500 to-blue-500 rounded-full transition-all duration-700 ease-out"
+          className="h-full bg-linear-to-r from-indigo-500 to-blue-500 rounded-full transition-all duration-700 ease-out"
           style={{ width: `${percentage}%` }}
         />
       </div>

--- a/frontend/src/components/AudioPlayer.tsx
+++ b/frontend/src/components/AudioPlayer.tsx
@@ -244,7 +244,7 @@ const AudioPlayer = forwardRef<AudioPlayerHandle, AudioPlayerProps>(
                   className="h-2 overflow-hidden rounded-full bg-slate-200 dark:bg-slate-800"
                 >
                   <div
-                    className="h-full rounded-full bg-gradient-to-r from-indigo-500 via-violet-500 to-fuchsia-500 transition-all duration-300"
+                    className="h-full rounded-full bg-linear-to-r from-indigo-500 via-violet-500 to-fuchsia-500 transition-all duration-300"
                     style={{ width: `${Math.round(speech.progress.percentage * 100)}%` }}
                   />
                 </div>

--- a/frontend/src/components/CharacterNode.tsx
+++ b/frontend/src/components/CharacterNode.tsx
@@ -32,7 +32,7 @@ const CharacterNode = ({ data }: NodeProps<any>) => {
 
       <div 
         style={{ width: `${size}px`, height: `${size}px` }}
-        className={`rounded-full bg-gradient-to-br from-slate-900 to-slate-950 border-2 ${borderGlow} flex items-center justify-center transition-all duration-300 hover:scale-105 cursor-pointer`}
+        className={`rounded-full bg-linear-to-br from-slate-900 to-slate-950 border-2 ${borderGlow} flex items-center justify-center transition-all duration-300 hover:scale-105 cursor-pointer`}
       >
         <span 
           style={{ fontSize: `${Math.max(10, size * 0.18)}px` }}

--- a/frontend/src/components/ErrorPage.tsx
+++ b/frontend/src/components/ErrorPage.tsx
@@ -32,7 +32,7 @@ const ErrorPage = () => {
   };
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-950 dark:to-slate-900 px-4 py-8">
+    <div className="min-h-screen flex flex-col items-center justify-center bg-linear-to-br from-slate-50 to-slate-100 dark:from-slate-950 dark:to-slate-900 px-4 py-8">
       {/* Background decoration */}
       <div
         className="absolute inset-0 overflow-hidden pointer-events-none opacity-40"
@@ -79,7 +79,7 @@ const ErrorPage = () => {
           <button
             onClick={handleReload}
             disabled={isReloading}
-            className="w-full px-6 py-3 bg-gradient-to-r from-blue-600 to-blue-700 text-white font-semibold rounded-lg hover:from-blue-700 hover:to-blue-800 transition-all transform hover:-translate-y-0.5 disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none flex items-center justify-center gap-2"
+            className="w-full px-6 py-3 bg-linear-to-r from-blue-600 to-blue-700 text-white font-semibold rounded-lg hover:from-blue-700 hover:to-blue-800 transition-all transform hover:-translate-y-0.5 disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none flex items-center justify-center gap-2"
             aria-label="Reload the page"
           >
             {isReloading ? (

--- a/frontend/src/components/Scrolltotopandscrolltobottom.tsx
+++ b/frontend/src/components/Scrolltotopandscrolltobottom.tsx
@@ -55,8 +55,8 @@ export default function DualScrollButton() {
         active:scale-95
         ${
           isBottomMode
-            ? "bg-gradient-to-br from-cyan-500 to-blue-500 shadow-[0_0_25px_rgba(6,182,212,0.45)] hover:shadow-[0_0_35px_rgba(59,130,246,0.65)]"
-            : "bg-gradient-to-br from-violet-600 to-fuchsia-500 shadow-[0_0_25px_rgba(139,92,246,0.45)] hover:shadow-[0_0_35px_rgba(217,70,239,0.65)]"
+            ? "bg-linear-to-br from-cyan-500 to-blue-500 shadow-[0_0_25px_rgba(6,182,212,0.45)] hover:shadow-[0_0_35px_rgba(59,130,246,0.65)]"
+            : "bg-linear-to-br from-violet-600 to-fuchsia-500 shadow-[0_0_25px_rgba(139,92,246,0.45)] hover:shadow-[0_0_35px_rgba(217,70,239,0.65)]"
         }
         ${
           visible

--- a/frontend/src/components/StreakCard.tsx
+++ b/frontend/src/components/StreakCard.tsx
@@ -37,7 +37,7 @@ const StreakCard: React.FC<StreakCardProps> = ({ streak, isLoading }) => {
 
   return (
     <div 
-      className="relative overflow-hidden rounded-2xl border border-orange-100 bg-gradient-to-br from-orange-50/40 via-white to-amber-50/30 p-6 shadow-lg transition-all hover:shadow-xl dark:border-orange-500/10 dark:from-orange-500/5 dark:via-transparent dark:to-amber-500/5"
+      className="relative overflow-hidden rounded-2xl border border-orange-100 bg-linear-to-br from-orange-50/40 via-white to-amber-50/30 p-6 shadow-lg transition-all hover:shadow-xl dark:border-orange-500/10 dark:from-orange-500/5 dark:via-transparent dark:to-amber-500/5"
       role="region"
       aria-label="Writing Streak Tracker"
     >
@@ -61,7 +61,7 @@ const StreakCard: React.FC<StreakCardProps> = ({ streak, isLoading }) => {
         </div>
 
         <div 
-          className="flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-tr from-orange-500 to-amber-400 text-white shadow-md shadow-orange-500/20 animate-bounce"
+          className="flex h-14 w-14 items-center justify-center rounded-2xl bg-linear-to-tr from-orange-500 to-amber-400 text-white shadow-md shadow-orange-500/20 animate-bounce"
           style={{ animationDuration: "3s" }}
           aria-hidden="true"
         >

--- a/frontend/src/components/admin/review_approval.component.tsx
+++ b/frontend/src/components/admin/review_approval.component.tsx
@@ -94,7 +94,7 @@ const ReviewApprovalComponent = () => {
                   <button
                     onClick={() => review._id && handleApprove(review._id)}
                     disabled={!review._id || isApproving}
-                    className="w-full sm:w-auto bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-500 hover:to-indigo-500 text-white text-xs font-bold py-2.5 px-5 rounded-xl shadow-md shadow-blue-500/10 transition-all duration-150 active:scale-[0.98] disabled:opacity-50 select-none uppercase tracking-wider cursor-pointer flex items-center justify-center gap-2"
+                    className="w-full sm:w-auto bg-linear-to-r from-blue-600 to-indigo-600 hover:from-blue-500 hover:to-indigo-500 text-white text-xs font-bold py-2.5 px-5 rounded-xl shadow-md shadow-blue-500/10 transition-all duration-150 active:scale-[0.98] disabled:opacity-50 select-none uppercase tracking-wider cursor-pointer flex items-center justify-center gap-2"
                   >
                     <i className="fa-solid fa-circle-check text-xs" />
                     <span>{isApproving ? "Approving..." : "Approve Review"}</span>

--- a/frontend/src/components/analytics/AnalyticsDashboard.tsx
+++ b/frontend/src/components/analytics/AnalyticsDashboard.tsx
@@ -160,7 +160,7 @@ export default function AnalyticsDashboard() {
         {/* Header */}
 <div className="flex items-center justify-between mb-10">
   <div>
-    <h1 className="text-4xl font-bold bg-gradient-to-r from-indigo-400 to-purple-400 bg-clip-text text-transparent">
+    <h1 className="text-4xl font-bold bg-linear-to-r from-indigo-400 to-purple-400 bg-clip-text text-transparent">
       📊 Story Analytics
     </h1>
     <p className="text-white/40 mt-2">

--- a/frontend/src/components/back_home/back.home.component.tsx
+++ b/frontend/src/components/back_home/back.home.component.tsx
@@ -1,7 +1,7 @@
 import { ArrowLeft } from "lucide-react";
 const BackHomeComponent = () => {
   return (
-    <div className="bg-gradient-to-r from-slate-800 via-blue-500/10 to-slate-800 rounded-lg p-2 hover:from-slate-800 hover:via-blue-500/30 hover:to-slate-800 transition text-blue-600">
+    <div className="bg-linear-to-r from-slate-800 via-blue-500/10 to-slate-800 rounded-lg p-2 hover:from-slate-800 hover:via-blue-500/30 hover:to-slate-800 transition text-blue-600">
       <ArrowLeft size={16} className="inline mr-1" /> Back
     </div>
   );

--- a/frontend/src/components/bookshelf/BookShelf.tsx
+++ b/frontend/src/components/bookshelf/BookShelf.tsx
@@ -65,7 +65,7 @@ export default function BookShelf({ stories }: Props) {
 
         {/* Header */}
         <div className="mb-8">
-          <h1 className="text-4xl font-bold bg-gradient-to-r from-amber-400 to-orange-400 bg-clip-text text-transparent mb-2">
+          <h1 className="text-4xl font-bold bg-linear-to-r from-amber-400 to-orange-400 bg-clip-text text-transparent mb-2">
             📚 My Bookshelf
           </h1>
           <p className="text-white/40">Your personal story library</p>

--- a/frontend/src/components/cards/StoryTradingCard.tsx
+++ b/frontend/src/components/cards/StoryTradingCard.tsx
@@ -224,7 +224,7 @@ const StoryTradingCard: React.FC<StoryTradingCardProps> = ({
         transition-all duration-300 hover:-translate-y-2 hover:scale-[1.02] hover:shadow-[0_20px_50px_rgba(0,0,0,0.45)]`}
       >
         <div
-          className={`absolute inset-0 bg-gradient-to-br ${rarityStyle.accent} opacity-20`}
+          className={`absolute inset-0 bg-linear-to-br ${rarityStyle.accent} opacity-20`}
         />
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,rgba(255,255,255,0.24),transparent_28%),radial-gradient(circle_at_80%_12%,rgba(255,255,255,0.18),transparent_24%),linear-gradient(135deg,rgba(255,255,255,0.06),transparent_42%)]" />
 
@@ -269,7 +269,7 @@ const StoryTradingCard: React.FC<StoryTradingCardProps> = ({
             >
               <i className={`${isBookmarked ? "fas text-amber-400" : "far text-white/70"} fa-bookmark`}></i>
             </button>
-            <div className="absolute inset-0 bg-gradient-to-t from-slate-950 via-transparent to-transparent" />
+            <div className="absolute inset-0 bg-linear-to-t from-slate-950 via-transparent to-transparent" />
             <div className="absolute bottom-3 left-3 right-3 flex items-center justify-between gap-2">
               <span
                 className={`rounded-full border px-3 py-1 text-[10px] font-bold uppercase tracking-wider ${genreClass}`}

--- a/frontend/src/components/collab/CollabHome.tsx
+++ b/frontend/src/components/collab/CollabHome.tsx
@@ -87,7 +87,7 @@ export default function CollabHome() {
 
         <div className="bg-white dark:bg-[#111827]/40 backdrop-blur-xl border border-slate-200 dark:border-white/10 rounded-2xl sm:rounded-3xl p-6 sm:p-10 shadow-sm hover:shadow-xl transition-shadow duration-300 w-full box-border text-center">
           <div className="text-5xl mb-4 select-none">✍️</div>
-          <h1 className="text-2xl sm:text-3xl font-extrabold bg-gradient-to-r from-blue-600 to-indigo-600 dark:from-blue-400 dark:to-indigo-400 bg-clip-text text-transparent mb-3 tracking-tight select-none">
+          <h1 className="text-2xl sm:text-3xl font-extrabold bg-linear-to-r from-blue-600 to-indigo-600 dark:from-blue-400 dark:to-indigo-400 bg-clip-text text-transparent mb-3 tracking-tight select-none">
             Story Collab Mode
           </h1>
           <p className="text-slate-500 dark:text-slate-400 text-xs sm:text-sm font-medium leading-relaxed mb-8 select-none">
@@ -105,7 +105,7 @@ export default function CollabHome() {
             <button
               onClick={createRoom}
               disabled={isCreating}
-              className="w-full h-12 bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-500 hover:to-indigo-500 disabled:opacity-50 text-white text-xs sm:text-sm font-bold uppercase tracking-wider rounded-xl shadow-md shadow-blue-500/10 transition-all duration-150 active:scale-[0.98] select-none cursor-pointer"
+              className="w-full h-12 bg-linear-to-r from-blue-600 to-indigo-600 hover:from-blue-500 hover:to-indigo-500 disabled:opacity-50 text-white text-xs sm:text-sm font-bold uppercase tracking-wider rounded-xl shadow-md shadow-blue-500/10 transition-all duration-150 active:scale-[0.98] select-none cursor-pointer"
             >
               {isCreating ? "Creating Room..." : "✨ Create a New Story Room"}
             </button>

--- a/frontend/src/components/collab/CollabRoom.tsx
+++ b/frontend/src/components/collab/CollabRoom.tsx
@@ -225,7 +225,7 @@ export default function CollabRoom() {
           {/* Story Editor Area */}
           <div className="lg:col-span-2">
             <div className="bg-white dark:bg-slate-900 rounded-2xl border border-slate-200 dark:border-white/10 p-6 mb-6 shadow-sm">
-              <h1 className="text-2xl font-bold mb-4 bg-gradient-to-r from-blue-600 to-indigo-600 dark:from-blue-400 dark:to-indigo-400 bg-clip-text text-transparent">
+              <h1 className="text-2xl font-bold mb-4 bg-linear-to-r from-blue-600 to-indigo-600 dark:from-blue-400 dark:to-indigo-400 bg-clip-text text-transparent">
                 Collab Room Canvas
               </h1>
               <p className="text-xs text-slate-400 dark:text-slate-500 mb-2">Room ID: {roomId}</p>
@@ -291,7 +291,7 @@ export default function CollabRoom() {
 
           {/* Participants Sidebar */}
           <div className="bg-white dark:bg-slate-900 rounded-2xl border border-slate-200 dark:border-white/10 p-6 shadow-sm self-start">
-            <h2 className="text-lg font-bold mb-4 bg-gradient-to-r from-blue-600 to-indigo-600 dark:from-blue-400 dark:to-indigo-400 bg-clip-text text-transparent">
+            <h2 className="text-lg font-bold mb-4 bg-linear-to-r from-blue-600 to-indigo-600 dark:from-blue-400 dark:to-indigo-400 bg-clip-text text-transparent">
               Active Writers ({room?.participants.length || 0})
             </h2>
             <div className="space-y-3">

--- a/frontend/src/components/community/Githubcontributors.component.tsx
+++ b/frontend/src/components/community/Githubcontributors.component.tsx
@@ -115,7 +115,7 @@ const GithubcontributorsComponent: React.FC = () => {
               Our GitHub{" "}
               <span
                 className="
-                bg-gradient-to-r
+                bg-linear-to-r
                 from-blue-500
                 via-violet-500
                 to-fuchsia-500
@@ -167,7 +167,7 @@ const GithubcontributorsComponent: React.FC = () => {
             {/* Floating Glow Particles */}
 
           
-            <div className="absolute inset-0 bg-gradient-to-tr from-blue-500/10 via-violet-500/5 to-fuchsia-500/10 blur-3xl"></div>
+            <div className="absolute inset-0 bg-linear-to-tr from-blue-500/10 via-violet-500/5 to-fuchsia-500/10 blur-3xl"></div>
 
             <div className="absolute top-12 left-20 w-3 h-3 bg-cyan-400 rounded-full blur-[2px] animate-pulse"></div>
 
@@ -505,7 +505,7 @@ const GithubcontributorsComponent: React.FC = () => {
             }}
             className="
             px-7 py-3 rounded-full
-            bg-gradient-to-r from-violet-600 to-blue-600
+            bg-linear-to-r from-violet-600 to-blue-600
             text-white font-semibold
           "
           >
@@ -543,7 +543,7 @@ const GithubcontributorsComponent: React.FC = () => {
             rel="noreferrer"
             className="
             px-8 py-5 rounded-2xl
-            bg-gradient-to-r from-violet-600 to-fuchsia-600
+            bg-linear-to-r from-violet-600 to-fuchsia-600
             hover:scale-105
             text-white font-bold text-lg
             shadow-2xl

--- a/frontend/src/components/community/community.component.tsx
+++ b/frontend/src/components/community/community.component.tsx
@@ -64,7 +64,7 @@ const CommunityComponent: React.FC = () => {
             Community Hub Live
           </div>
 
-          <h1 className="text-5xl md:text-7xl font-bold tracking-tight mb-8 bg-clip-text text-transparent bg-gradient-to-b from-slate-900 to-slate-500 dark:from-white dark:to-gray-500">
+          <h1 className="text-5xl md:text-7xl font-bold tracking-tight mb-8 bg-clip-text text-transparent bg-linear-to-b from-slate-900 to-slate-500 dark:from-white dark:to-gray-500">
             Where Imagination <br /> Meets Community
           </h1>
 
@@ -189,7 +189,7 @@ const CommunityComponent: React.FC = () => {
 
       {/* CTA Footer */}
       <section id="guidelines" className="max-w-5xl mx-auto px-6 py-32 text-center">
-        <div className="p-16 rounded-[2.5rem] bg-gradient-to-br from-blue-50 via-white to-slate-100 border border-gray-200 shadow-2xl relative overflow-hidden text-slate-900 transition-colors duration-300 dark:from-blue-900/40 dark:via-slate-900 dark:to-black dark:border-white/10 dark:text-white">
+        <div className="p-16 rounded-[2.5rem] bg-linear-to-br from-blue-50 via-white to-slate-100 border border-gray-200 shadow-2xl relative overflow-hidden text-slate-900 transition-colors duration-300 dark:from-blue-900/40 dark:via-slate-900 dark:to-black dark:border-white/10 dark:text-white">
           <div className="absolute top-0 right-0 w-64 h-64 bg-blue-600/10 rounded-full blur-[80px] -z-10"></div>
           <h2 className="text-4xl md:text-5xl font-bold mb-6 text-slate-900 dark:text-white">Ready to spark your first story?</h2>
           <p className="text-slate-600 dark:text-gray-400 text-lg mb-12 max-w-xl mx-auto leading-relaxed">

--- a/frontend/src/components/community/resources_list.component.tsx
+++ b/frontend/src/components/community/resources_list.component.tsx
@@ -16,7 +16,7 @@ const ResourcesListComponent: React.FC = () => {
 
         {/* Header */}
         <div className="mb-12">
-          <h1 className="text-4xl md:text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-b from-white to-gray-500">
+          <h1 className="text-4xl md:text-5xl font-bold mb-4 bg-clip-text text-transparent bg-linear-to-b from-white to-gray-500">
             Writing Resources
           </h1>
           <p className="text-slate-600 max-w-2xl dark:text-gray-400">

--- a/frontend/src/components/contactus/contactus.tsx
+++ b/frontend/src/components/contactus/contactus.tsx
@@ -1,4 +1,4 @@
-๏ปฟimport { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect } from "react";
 import type { ChangeEvent, FormEvent } from "react";
 import {
   Mail,
@@ -17,7 +17,7 @@ import { instance as axios } from "../../helpers/axios/axiosInstance";
 import { getBaseUrl } from "../../helpers/config";
 import storybook from "../../assets/storybook.png";
 
-// ฮ“รถรฮ“รถรฮ“รถร Types ฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถร
+// G๖วG๖วG๖ว Types G๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖ว
 
 type FormData = {
   fullname: string;
@@ -28,7 +28,7 @@ type FormData = {
 
 type FormField = keyof FormData;
 
-// ฮ“รถรฮ“รถรฮ“รถร Constants ฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถร
+// G๖วG๖วG๖ว Constants G๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖ว
 
 const INITIAL_FORM_DATA: FormData = {
   fullname: "",
@@ -102,7 +102,7 @@ const STATS = [
   { value: "Open", label: "Source project" },
 ] as const;
 
-// ฮ“รถรฮ“รถรฮ“รถร FloatingLabelInput ฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถร
+// G๖วG๖วG๖ว FloatingLabelInput G๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖ว
 
 interface FloatingLabelInputProps {
   id: string;
@@ -179,7 +179,7 @@ const FloatingLabelInput = ({
   );
 };
 
-// ฮ“รถรฮ“รถรฮ“รถร FloatingLabelTextarea ฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถร
+// G๖วG๖วG๖ว FloatingLabelTextarea G๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖ว
 
 interface FloatingLabelTextareaProps {
   value: string;
@@ -245,7 +245,7 @@ const FloatingLabelTextarea = ({
   );
 };
 
-// ฮ“รถรฮ“รถรฮ“รถร Main Contact component ฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถรฮ“รถร
+// G๖วG๖วG๖ว Main Contact component G๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖วG๖ว
 
 export default function Contact() {
   const [formData, setFormData] = useState<FormData>(INITIAL_FORM_DATA);
@@ -352,14 +352,14 @@ export default function Contact() {
       aria-labelledby="contact-heading"
       className="contact-section relative overflow-hidden bg-[#020617] text-white"
     >
-      {/* ฮ“รถรฮ“รถร Layered background ฮ“รถรฮ“รถร */}
+      {/* G๖วG๖ว Layered background G๖วG๖ว */}
       <div aria-hidden="true" className="contact-bg-mesh" />
       <div aria-hidden="true" className="contact-orb contact-orb-blue" />
       <div aria-hidden="true" className="contact-orb contact-orb-purple" />
       <div aria-hidden="true" className="contact-orb contact-orb-pink" />
       <div aria-hidden="true" className="contact-grid-overlay" />
 
-      {/* ฮ“รถรฮ“รถร Page content ฮ“รถรฮ“รถร */}
+      {/* G๖วG๖ว Page content G๖วG๖ว */}
       <div className="relative z-10 mx-auto w-full max-w-7xl px-5 py-14 sm:px-8 sm:py-18 lg:px-12 lg:py-20 xl:px-16">
 
         {/* Mobile badge */}
@@ -375,7 +375,7 @@ export default function Contact() {
 
         <div className="grid items-start gap-10 lg:grid-cols-[1fr_1.1fr] lg:gap-14 xl:gap-20">
 
-          {/* ฮ“รถรฮ“รถร LEFT COLUMN ฮ“รถรฮ“รถร */}
+          {/* G๖วG๖ว LEFT COLUMN G๖วG๖ว */}
           <div
             className={`contact-col-left flex flex-col transition-all duration-700 ${isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"
               }`}
@@ -440,7 +440,7 @@ export default function Contact() {
                       className={`contact-channel-link group flex items-center gap-3.5 rounded-2xl border border-white/[0.07] bg-white/[0.03] px-4 py-3.5 backdrop-blur-sm ${hoverBorder}`}
                     >
                       <span
-                        className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br ${color} ${iconColor}`}
+                        className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-linear-to-br ${color} ${iconColor}`}
                       >
                         <Icon className="h-4 w-4" aria-hidden="true" />
                       </span>
@@ -478,7 +478,7 @@ export default function Contact() {
             </div>
           </div>
 
-          {/* ฮ“รถรฮ“รถร RIGHT COLUMN ฮ“รรถ FORM ฮ“รถรฮ“รถร */}
+          {/* G๖วG๖ว RIGHT COLUMN Gว๖ FORM G๖วG๖ว */}
           <div
             className={`contact-col-right w-full lg:sticky lg:top-24 transition-all duration-700 delay-150 ${isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"
               }`}
@@ -533,14 +533,14 @@ export default function Contact() {
                     type="submit"
                     disabled={loading}
                     aria-busy={loading}
-                    aria-label={loading ? "Sending messageฮ“รยช" : "Send message"}
+                    aria-label={loading ? "Sending messageGวช" : "Send message"}
                     className="contact-submit-btn group relative mt-1 flex h-12 w-full items-center justify-center gap-2.5 overflow-hidden rounded-xl text-sm font-bold text-white sm:h-[3.125rem] sm:text-base"
                   >
                     <span aria-hidden="true" className="contact-btn-gradient absolute inset-0" />
                     {/* Shimmer sweep on hover */}
                     <span
                       aria-hidden="true"
-                      className="absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-white/[0.12] to-transparent transition-transform duration-700 group-hover:translate-x-full"
+                      className="absolute inset-0 -translate-x-full bg-linear-to-r from-transparent via-white/[0.12] to-transparent transition-transform duration-700 group-hover:translate-x-full"
                     />
                     <span className="relative flex items-center gap-2.5">
                       {loading ? (
@@ -549,7 +549,7 @@ export default function Contact() {
                             aria-hidden="true"
                             className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white"
                           />
-                          <span>Sendingฮ“รยช</span>
+                          <span>SendingGวช</span>
                         </>
                       ) : (
                         <>
@@ -575,7 +575,7 @@ export default function Contact() {
                         aria-hidden="true"
                       />
                       <p className="text-sm font-medium text-emerald-400">
-                        Message sent ฮ“รรถ we'll get back to you within 24 hours.
+                        Message sent Gว๖ we'll get back to you within 24 hours.
                       </p>
                     </div>
                   )}

--- a/frontend/src/components/cookie-consent/cookie-consent.component.tsx
+++ b/frontend/src/components/cookie-consent/cookie-consent.component.tsx
@@ -207,7 +207,7 @@ const CookieConsentBanner: FC<CookieConsentBannerProps> = ({ onLayoutChange }) =
         <div className="flex flex-col gap-2.5 xl:w-[280px] shrink-0 xl:pt-11 w-full">
           <button
             onClick={handleAcceptAll}
-            className="w-full rounded-xl bg-gradient-to-r from-blue-600 to-indigo-600 px-5 py-3 text-xs font-bold text-white shadow-lg shadow-blue-600/10 transition-all duration-150 hover:from-blue-500 hover:to-indigo-500 active:scale-[0.98] cursor-pointer text-center uppercase tracking-wider"
+            className="w-full rounded-xl bg-linear-to-r from-blue-600 to-indigo-600 px-5 py-3 text-xs font-bold text-white shadow-lg shadow-blue-600/10 transition-all duration-150 hover:from-blue-500 hover:to-indigo-500 active:scale-[0.98] cursor-pointer text-center uppercase tracking-wider"
           >
             Accept all cookies
           </button>

--- a/frontend/src/components/dashboard/dashboard.component.tsx
+++ b/frontend/src/components/dashboard/dashboard.component.tsx
@@ -186,7 +186,7 @@ const DashboardComponent = () => {
   return (
     <div className="space-y-6 sm:space-y-8">
       {/* HERO SECTION */}
-      <div className="relative overflow-hidden rounded-2xl border border-slate-200 bg-gradient-to-br from-indigo-50 via-slate-50 to-blue-50 p-5 shadow-xl dark:border-white/[0.07] dark:from-[#0f1c3a] dark:via-[#0d1a3a] dark:to-[#111433] sm:p-6 lg:p-8">
+      <div className="relative overflow-hidden rounded-2xl border border-slate-200 bg-linear-to-br from-indigo-50 via-slate-50 to-blue-50 p-5 shadow-xl dark:border-white/[0.07] dark:from-[#0f1c3a] dark:via-[#0d1a3a] dark:to-[#111433] sm:p-6 lg:p-8">
         <div className="absolute -top-16 -right-16 w-64 h-64 bg-blue-600/15 rounded-full blur-[60px]" />
         <div className="absolute bottom-0 left-8 w-48 h-48 bg-indigo-500/10 rounded-full blur-[50px]" />
 
@@ -336,7 +336,7 @@ const DashboardComponent = () => {
               </div>
 
               {/* Collab Banner */}
-              <div className="flex flex-col gap-6 rounded-2xl border border-indigo-100 bg-gradient-to-br from-indigo-500/5 to-purple-500/5 p-6 dark:border-indigo-500/10 dark:from-indigo-500/10 dark:to-purple-500/10 md:flex-row md:items-center md:justify-between sm:p-8">
+              <div className="flex flex-col gap-6 rounded-2xl border border-indigo-100 bg-linear-to-br from-indigo-500/5 to-purple-500/5 p-6 dark:border-indigo-500/10 dark:from-indigo-500/10 dark:to-purple-500/10 md:flex-row md:items-center md:justify-between sm:p-8">
                 <div className="max-w-2xl min-w-0">
                   <div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-indigo-100 text-indigo-600 dark:bg-indigo-500/20 dark:text-indigo-400 mb-4 font-bold">
                     <i className="fas fa-users text-xl"></i>
@@ -348,7 +348,7 @@ const DashboardComponent = () => {
                 </div>
                 <a
                   href="/collab"
-                  className="inline-flex w-full shrink-0 items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-indigo-500 to-blue-600 px-8 py-4 font-bold text-white shadow-lg shadow-indigo-500/20 transition-all hover:scale-[1.02] hover:from-indigo-600 hover:to-blue-700 sm:w-auto"
+                  className="inline-flex w-full shrink-0 items-center justify-center gap-2 rounded-xl bg-linear-to-r from-indigo-500 to-blue-600 px-8 py-4 font-bold text-white shadow-lg shadow-indigo-500/20 transition-all hover:scale-[1.02] hover:from-indigo-600 hover:to-blue-700 sm:w-auto"
                 >
                   <i className="fas fa-satellite-dish animate-pulse"></i> Open Collab Space
                 </a>

--- a/frontend/src/components/dashboard/dashboard_analysis_header.tsx
+++ b/frontend/src/components/dashboard/dashboard_analysis_header.tsx
@@ -42,7 +42,7 @@ const DashboardAnalysisHeader: React.FC<{ data: DashboardAnalysis }> = ({ data }
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
         <div className="relative overflow-hidden rounded-2xl bg-slate-50 border border-slate-200 dark:bg-white/[0.03] dark:border-blue-500/15 p-5 hover:-translate-y-0.5 transition-transform duration-200">
-          <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-blue-500/40 to-transparent" />
+          <div className="absolute top-0 left-0 right-0 h-px bg-linear-to-r from-transparent via-blue-500/40 to-transparent" />
           <div className="flex items-start justify-between mb-3">
             <div>
               <p className="text-slate-500 text-xs uppercase tracking-wider font-medium mb-1">
@@ -76,7 +76,7 @@ const DashboardAnalysisHeader: React.FC<{ data: DashboardAnalysis }> = ({ data }
         </div>
 
         <div className="relative overflow-hidden rounded-2xl bg-slate-50 border border-slate-200 dark:bg-white/[0.03] dark:border-violet-500/15 p-5 hover:-translate-y-0.5 transition-transform duration-200">
-          <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-violet-500/40 to-transparent" />
+          <div className="absolute top-0 left-0 right-0 h-px bg-linear-to-r from-transparent via-violet-500/40 to-transparent" />
           <div className="flex items-start justify-between mb-3">
             <div>
               <p className="text-slate-500 text-xs uppercase tracking-wider font-medium mb-1">
@@ -110,7 +110,7 @@ const DashboardAnalysisHeader: React.FC<{ data: DashboardAnalysis }> = ({ data }
         </div>
 
         <div className="relative overflow-hidden rounded-2xl bg-slate-50 border border-slate-200 dark:bg-white/[0.03] dark:border-emerald-500/15 p-5 hover:-translate-y-0.5 transition-transform duration-200">
-          <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-emerald-500/40 to-transparent" />
+          <div className="absolute top-0 left-0 right-0 h-px bg-linear-to-r from-transparent via-emerald-500/40 to-transparent" />
           <div className="flex items-start justify-between mb-3">
             <div>
               <p className="text-slate-500 text-xs uppercase tracking-wider font-medium mb-1">
@@ -146,7 +146,7 @@ const DashboardAnalysisHeader: React.FC<{ data: DashboardAnalysis }> = ({ data }
         </div>
 
         <div className="relative overflow-hidden rounded-2xl bg-slate-50 border border-slate-200 dark:bg-white/[0.03] dark:border-amber-500/15 p-5 hover:-translate-y-0.5 transition-transform duration-200">
-          <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-amber-500/40 to-transparent" />
+          <div className="absolute top-0 left-0 right-0 h-px bg-linear-to-r from-transparent via-amber-500/40 to-transparent" />
           <div className="flex items-start justify-between mb-3">
             <div>
               <p className="text-slate-500 text-xs uppercase tracking-wider font-medium mb-1">
@@ -203,7 +203,7 @@ const DashboardAnalysisHeader: React.FC<{ data: DashboardAnalysis }> = ({ data }
                   <p className="w-20 text-xs text-slate-500 font-mono shrink-0">{month}</p>
                   <div className="flex-1 bg-slate-200 dark:bg-white/[0.05] h-2 rounded-full overflow-hidden">
                     <div
-                      className="h-full bg-gradient-to-r from-blue-500 to-cyan-400 rounded-full transition-all duration-700"
+                      className="h-full bg-linear-to-r from-blue-500 to-cyan-400 rounded-full transition-all duration-700"
                       style={{ width: `${pct}%` }}
                     />
                   </div>

--- a/frontend/src/components/dashboard/gamification_card.component.tsx
+++ b/frontend/src/components/dashboard/gamification_card.component.tsx
@@ -17,10 +17,10 @@ const GamificationCard: React.FC<{ data?: GamificationData }> = ({ data }) => {
   const progressPercent = Math.min(100, Math.max(0, ((xp - currentLevelXp) / (nextLevelXp - currentLevelXp)) * 100));
 
   return (
-    <div className="rounded-2xl border border-blue-100 bg-gradient-to-br from-blue-50/50 to-indigo-50/50 p-6 dark:border-blue-500/10 dark:from-blue-500/5 dark:to-indigo-500/5 flex flex-col justify-between">
+    <div className="rounded-2xl border border-blue-100 bg-linear-to-br from-blue-50/50 to-indigo-50/50 p-6 dark:border-blue-500/10 dark:from-blue-500/5 dark:to-indigo-500/5 flex flex-col justify-between">
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-3">
-          <div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-gradient-to-tr from-blue-500 to-cyan-400 text-white shadow-lg shadow-blue-500/20 mb-2">
+          <div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-linear-to-tr from-blue-500 to-cyan-400 text-white shadow-lg shadow-blue-500/20 mb-2">
             <span className="font-black text-xl">Lvl {level}</span>
           </div>
           <div>
@@ -41,7 +41,7 @@ const GamificationCard: React.FC<{ data?: GamificationData }> = ({ data }) => {
         </div>
         <div className="w-full bg-slate-200 dark:bg-white/[0.05] h-3 rounded-full overflow-hidden">
           <div
-            className="h-full bg-gradient-to-r from-blue-500 to-cyan-400 rounded-full transition-all duration-1000 relative"
+            className="h-full bg-linear-to-r from-blue-500 to-cyan-400 rounded-full transition-all duration-1000 relative"
             style={{ width: `${progressPercent}%` }}
           >
             <div className="absolute top-0 right-0 bottom-0 left-0 bg-[url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDAiIGhlaWdodD0iNDAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PHBhdHRlcm4gaWQ9ImEiIHdpZHRoPSI0MCIgaGVpZ2h0PSI0MCIgcGF0dGVyblVuaXRzPSJ1c2VyU3BhY2VPblVzZSI+PHBhdGggZD0iTTAgNDBsNDAtNDBIMzBMMCAzMHYxMHptNDAgMEw0MCAwSDBMMCA0MGg0MHoiIGZpbGw9IiNmZmZmZmYiIGZpbGwtb3BhY2l0eT0iLjIiLz48L3BhdHRlcm4+PC9kZWZzPjxyZWN0IHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjYSkiLz48L3N2Zz4=')] opacity-50"></div>

--- a/frontend/src/components/dashboard/posts/published_stories.component.tsx
+++ b/frontend/src/components/dashboard/posts/published_stories.component.tsx
@@ -137,7 +137,7 @@ const PublishedStoriesComponent: React.FC = () => {
       )}
 
       {!isLoading && !isError && stories.length === 0 && (
-  <div className="rounded-2xl border border-dashed border-blue-200 bg-gradient-to-br from-blue-50 via-white to-indigo-50 p-12 text-center shadow-sm dark:border-blue-500/20 dark:from-blue-500/10 dark:via-[#0a1020] dark:to-indigo-500/10">
+  <div className="rounded-2xl border border-dashed border-blue-200 bg-linear-to-br from-blue-50 via-white to-indigo-50 p-12 text-center shadow-sm dark:border-blue-500/20 dark:from-blue-500/10 dark:via-[#0a1020] dark:to-indigo-500/10">
     <div className="mx-auto mb-5 flex h-20 w-20 items-center justify-center rounded-full bg-blue-100 text-4xl text-blue-600 shadow-inner dark:bg-blue-500/15 dark:text-blue-300">
       <i className="fas fa-book-open"></i>
     </div>

--- a/frontend/src/components/dashboard/settings/settings.component.tsx
+++ b/frontend/src/components/dashboard/settings/settings.component.tsx
@@ -89,7 +89,7 @@ const SettingComponent = () => {
           <button
             onClick={handleSave}
             disabled={saving}
-            className={`px-6 py-2.5 rounded-lg bg-gradient-to-r from-indigo-500 to-blue-600 hover:from-indigo-600 hover:to-blue-700 text-white font-semibold flex items-center gap-2 shadow-lg shadow-indigo-500/25 transition-all duration-300 hover:scale-105 ${
+            className={`px-6 py-2.5 rounded-lg bg-linear-to-r from-indigo-500 to-blue-600 hover:from-indigo-600 hover:to-blue-700 text-white font-semibold flex items-center gap-2 shadow-lg shadow-indigo-500/25 transition-all duration-300 hover:scale-105 ${
               saving ? "opacity-75 cursor-not-allowed" : ""
             }`}
           >

--- a/frontend/src/components/footer/Privacy.tsx
+++ b/frontend/src/components/footer/Privacy.tsx
@@ -142,7 +142,7 @@ const PrivacyPolicy: React.FC = () => {
             </ul>
           </section>
 
-          <section className="bg-gradient-to-r from-purple-600 to-pink-600 rounded-2xl p-8 shadow-lg text-center">
+          <section className="bg-linear-to-r from-purple-600 to-pink-600 rounded-2xl p-8 shadow-lg text-center">
             <h2 className="text-3xl font-bold mb-4">
               Contact Us
             </h2>

--- a/frontend/src/components/footer/about-us.tsx
+++ b/frontend/src/components/footer/about-us.tsx
@@ -63,7 +63,7 @@ const AboutUs = () => {
           {/* HEADING */}
           <h1 className="text-4xl sm:text-6xl font-extrabold leading-tight mb-6">
             About{" "}
-            <span className="bg-gradient-to-r from-blue-500 to-purple-500 bg-clip-text text-transparent">
+            <span className="bg-linear-to-r from-blue-500 to-purple-500 bg-clip-text text-transparent">
               StorySparkAI
             </span>
           </h1>
@@ -139,9 +139,9 @@ const AboutUs = () => {
 
           {/* RIGHT SIDE CARD */}
           <div className="relative">
-            <div className="absolute inset-0 bg-gradient-to-r from-blue-500 to-purple-500 blur-3xl opacity-20 rounded-3xl"></div>
+            <div className="absolute inset-0 bg-linear-to-r from-blue-500 to-purple-500 blur-3xl opacity-20 rounded-3xl"></div>
 
-            <div className="relative bg-gradient-to-br from-blue-600 to-purple-600 rounded-3xl p-10 text-white shadow-2xl">
+            <div className="relative bg-linear-to-br from-blue-600 to-purple-600 rounded-3xl p-10 text-white shadow-2xl">
               <h3 className="text-3xl font-bold mb-4">
                 Why StorySparkAI?
               </h3>
@@ -226,7 +226,7 @@ const AboutUs = () => {
 
       {/* CTA SECTION */}
       <section className="px-6 py-16">
-        <div className="max-w-5xl mx-auto rounded-3xl bg-gradient-to-r from-blue-600 to-purple-600 p-10 sm:p-14 text-center text-white shadow-2xl">
+        <div className="max-w-5xl mx-auto rounded-3xl bg-linear-to-r from-blue-600 to-purple-600 p-10 sm:p-14 text-center text-white shadow-2xl">
           <h2 className="text-4xl font-bold mb-4">
             Ready to Create Your Story?
           </h2>

--- a/frontend/src/components/footer/blog.tsx
+++ b/frontend/src/components/footer/blog.tsx
@@ -53,7 +53,7 @@ const Blog = () => {
         </div>
 
         {/* FEATURED SECTION */}
-        <div className="mb-10 p-8 rounded-2xl bg-gradient-to-r from-blue-600 to-purple-600 text-white shadow-lg">
+        <div className="mb-10 p-8 rounded-2xl bg-linear-to-r from-blue-600 to-purple-600 text-white shadow-lg">
           <h2 className="text-2xl font-bold mb-2">🔥 Featured Article</h2>
           <p className="text-lg font-semibold">
             Introducing StorySparkAI v2.0 — A new era of AI storytelling

--- a/frontend/src/components/footer/career.tsx
+++ b/frontend/src/components/footer/career.tsx
@@ -111,7 +111,7 @@ const Career = () => {
 
             <h1 className="text-5xl sm:text-7xl font-extrabold leading-tight tracking-tight">
               Build the future of{" "}
-              <span className="bg-gradient-to-r from-blue-500 via-indigo-500 to-cyan-400 bg-clip-text text-transparent">
+              <span className="bg-linear-to-r from-blue-500 via-indigo-500 to-cyan-400 bg-clip-text text-transparent">
                 AI storytelling
               </span>
             </h1>
@@ -124,7 +124,7 @@ const Career = () => {
             <div className="mt-10 flex flex-wrap gap-4">
               <a
                 href="#open-roles"
-                className="inline-flex items-center gap-2 rounded-2xl bg-gradient-to-r from-blue-600 to-indigo-600 px-7 py-4 text-white font-semibold shadow-xl hover:scale-105 hover:shadow-blue-500/30 transition-all duration-300"
+                className="inline-flex items-center gap-2 rounded-2xl bg-linear-to-r from-blue-600 to-indigo-600 px-7 py-4 text-white font-semibold shadow-xl hover:scale-105 hover:shadow-blue-500/30 transition-all duration-300"
               >
                 Explore Roles
                 <ArrowRight size={18} />
@@ -141,7 +141,7 @@ const Career = () => {
 
           {/* RIGHT SIDE GLASS CARD */}
           <div className="relative mx-auto w-full max-w-lg">
-            <div className="absolute inset-0 bg-gradient-to-r from-blue-500/20 to-purple-500/20 blur-3xl rounded-full"></div>
+            <div className="absolute inset-0 bg-linear-to-r from-blue-500/20 to-purple-500/20 blur-3xl rounded-full"></div>
 
             <div className="relative rounded-[2rem] border border-white/10 bg-white/70 dark:bg-slate-900/70 p-8 shadow-2xl backdrop-blur-xl">
 
@@ -278,7 +278,7 @@ const Career = () => {
                     href={`mailto:careers@storysparkai.com?subject=Application%3A%20${encodeURIComponent(
                       title
                     )}`}
-                    className="mt-8 inline-flex w-full items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-blue-600 to-indigo-600 px-5 py-3.5 text-white font-semibold shadow-lg hover:scale-[1.02] hover:shadow-blue-500/25 transition-all duration-300"
+                    className="mt-8 inline-flex w-full items-center justify-center gap-2 rounded-2xl bg-linear-to-r from-blue-600 to-indigo-600 px-5 py-3.5 text-white font-semibold shadow-lg hover:scale-[1.02] hover:shadow-blue-500/25 transition-all duration-300"
                   >
                     Apply Now
                     <ArrowRight size={17} />
@@ -330,7 +330,7 @@ const Career = () => {
 
       {/* CTA SECTION */}
       <section className="px-6 pb-24">
-        <div className="mx-auto max-w-6xl rounded-[2.5rem] bg-gradient-to-r from-blue-700 via-indigo-700 to-slate-900 p-10 sm:p-14 text-white shadow-2xl">
+        <div className="mx-auto max-w-6xl rounded-[2.5rem] bg-linear-to-r from-blue-700 via-indigo-700 to-slate-900 p-10 sm:p-14 text-white shadow-2xl">
 
           <div className="grid gap-10 lg:grid-cols-2 items-center">
 

--- a/frontend/src/components/footer/contact-us.tsx
+++ b/frontend/src/components/footer/contact-us.tsx
@@ -30,7 +30,7 @@ const ContactUs = () => {
             style={{ fontFamily: "'Space Grotesk', sans-serif" }}
           >
             Contact{" "}
-            <span className="bg-gradient-to-r from-blue-400 to-purple-500 bg-clip-text text-transparent">
+            <span className="bg-linear-to-r from-blue-400 to-purple-500 bg-clip-text text-transparent">
               Us
             </span>
           </h1>
@@ -47,7 +47,7 @@ const ContactUs = () => {
             <ul className="space-y-3 text-left" aria-label="Contact information">
               {CONTACT_ITEMS.map(({ icon: Icon, text }) => (
                 <li key={text} className="flex items-center gap-3 text-sm text-slate-600 dark:text-slate-300 sm:text-base">
-                  <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-gradient-to-br from-blue-500/15 to-purple-500/15 text-purple-400">
+                  <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-linear-to-br from-blue-500/15 to-purple-500/15 text-purple-400">
                     <Icon className="h-3.5 w-3.5" aria-hidden="true" />
                   </span>
                   {text}
@@ -60,7 +60,7 @@ const ContactUs = () => {
           <div className="mt-6 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
             <Link
               to="/contact-us"
-              className="motion-cta group inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-blue-600 to-purple-600 px-6 py-3 text-sm font-bold text-white shadow-lg shadow-purple-500/20 sm:text-base"
+              className="motion-cta group inline-flex items-center gap-2 rounded-full bg-linear-to-r from-blue-600 to-purple-600 px-6 py-3 text-sm font-bold text-white shadow-lg shadow-purple-500/20 sm:text-base"
             >
               Open Contact Form
               <ArrowRight className="h-4 w-4 transition-transform duration-200 group-hover:translate-x-1" aria-hidden="true" />

--- a/frontend/src/components/footer/contributors.tsx
+++ b/frontend/src/components/footer/contributors.tsx
@@ -178,21 +178,21 @@ const ContributorCard = ({
   const rankColors = [
     {
       glow: "rgba(251,191,36,0.3)",
-      badge: "bg-gradient-to-r from-amber-400 to-yellow-500",
+      badge: "bg-linear-to-r from-amber-400 to-yellow-500",
       label: "🥇",
       label: "\uD83E\uDD47",
       borderColor: "rgba(251,191,36,0.4)",
     },
     {
       glow: "rgba(148,163,184,0.3)",
-      badge: "bg-gradient-to-r from-slate-300 to-gray-400",
+      badge: "bg-linear-to-r from-slate-300 to-gray-400",
       label: "🥈",
       label: "\uD83E\uDD48",
       borderColor: "rgba(148,163,184,0.3)",
     },
     {
       glow: "rgba(251,146,60,0.25)",
-      badge: "bg-gradient-to-r from-orange-400 to-amber-600",
+      badge: "bg-linear-to-r from-orange-400 to-amber-600",
       label: "🥉",
       label: "\uD83E\uDD49",
       borderColor: "rgba(251,146,60,0.3)",
@@ -363,7 +363,7 @@ const ContributorCard = ({
         <div className="h-1.5 w-full rounded-full bg-slate-800 overflow-hidden">
           <div
             ref={barRef}
-            className="h-full rounded-full bg-gradient-to-r from-indigo-500 via-purple-500 to-fuchsia-500"
+            className="h-full rounded-full bg-linear-to-r from-indigo-500 via-purple-500 to-fuchsia-500"
             style={{ width: "0%" }}
           />
         </div>
@@ -738,7 +738,7 @@ const ContributorsComponent = () => {
               }}
             >
               <div
-                className={`absolute inset-0 bg-gradient-to-br ${stat.gradient} opacity-0 group-hover:opacity-[0.06] transition-opacity duration-500`}
+                className={`absolute inset-0 bg-linear-to-br ${stat.gradient} opacity-0 group-hover:opacity-[0.06] transition-opacity duration-500`}
               />
               <div className="relative z-10">
                 <div
@@ -750,7 +750,7 @@ const ContributorsComponent = () => {
                   {stat.label}
                 </p>
                 <p
-                  className={`text-4xl font-black bg-gradient-to-r ${stat.gradient} bg-clip-text text-transparent`}
+                  className={`text-4xl font-black bg-linear-to-r ${stat.gradient} bg-clip-text text-transparent`}
                 >
                   <AnimatedCounter value={stat.value} suffix={stat.suffix} />
                 </p>
@@ -761,12 +761,12 @@ const ContributorsComponent = () => {
 
         {/* ─── SECTION HEADER ─── */}
         <div className="flex items-center gap-4 mb-12">
-          <div className="h-px flex-1 bg-gradient-to-r from-transparent via-indigo-500/30 to-transparent" />
+          <div className="h-px flex-1 bg-linear-to-r from-transparent via-indigo-500/30 to-transparent" />
           <h2 className="text-2xl md:text-3xl font-bold text-white flex items-center gap-3">
             <Trophy size={24} className="text-amber-400" />
             Hall of Fame
           </h2>
-          <div className="h-px flex-1 bg-gradient-to-r from-transparent via-indigo-500/30 to-transparent" />
+          <div className="h-px flex-1 bg-linear-to-r from-transparent via-indigo-500/30 to-transparent" />
         </div>
 
         {/* ─── CONTRIBUTORS GRID ─── */}

--- a/frontend/src/components/footer/cookie-policy.tsx
+++ b/frontend/src/components/footer/cookie-policy.tsx
@@ -88,7 +88,7 @@ const CookiePolicy: React.FC = () => {
             </p>
           </section>
 
-          <section className="bg-gradient-to-r from-purple-600 to-pink-600 rounded-2xl p-8 shadow-lg text-center">
+          <section className="bg-linear-to-r from-purple-600 to-pink-600 rounded-2xl p-8 shadow-lg text-center">
             <h2 className="text-3xl font-bold mb-4">Have Questions?</h2>
             <p className="text-lg text-white/90 mb-3">
               Reach out if you want more detail on how cookies are used on the platform.

--- a/frontend/src/components/footer/footer.component.tsx
+++ b/frontend/src/components/footer/footer.component.tsx
@@ -89,7 +89,7 @@ const FooterComponent: React.FC = () => {
   const currentYear = new Date().getFullYear();
 
   return (
-    <footer className="relative w-full bg-gradient-to-b from-[#090F24] via-[#080E22] to-[#060A18] overflow-hidden">
+    <footer className="relative w-full bg-linear-to-b from-[#090F24] via-[#080E22] to-[#060A18] overflow-hidden">
       <div
         aria-hidden="true"
         className="pointer-events-none absolute inset-x-0 top-0"
@@ -278,7 +278,7 @@ const FooterComponent: React.FC = () => {
               <button
                 type="submit"
                 disabled={status === "loading"}
-                className="self-start h-8 px-3 rounded-md bg-gradient-to-r from-blue-500 to-indigo-500 text-[11px] font-medium text-white hover:from-blue-400 hover:to-indigo-400 active:scale-95 transition-all duration-200 disabled:opacity-60 cursor-pointer"
+                className="self-start h-8 px-3 rounded-md bg-linear-to-r from-blue-500 to-indigo-500 text-[11px] font-medium text-white hover:from-blue-400 hover:to-indigo-400 active:scale-95 transition-all duration-200 disabled:opacity-60 cursor-pointer"
               >
                 {status === "loading" ? "..." : "Subscribe"}
               </button>

--- a/frontend/src/components/guidelines/guidelines.component.tsx
+++ b/frontend/src/components/guidelines/guidelines.component.tsx
@@ -138,8 +138,8 @@ const GuidelinesComponent: React.FC = () => {
               transition={{ duration: 0.45, delay: Math.min(index * 0.06, 0.3) }}
               className="group relative overflow-hidden bg-white dark:bg-[#111827]/40 border border-slate-200 dark:border-white/10 p-5 sm:p-8 rounded-2xl sm:rounded-3xl shadow-sm hover:shadow-xl transition-all duration-300 w-full box-border"
             >
-              <div className="absolute top-0 left-0 w-full h-[2px] bg-gradient-to-r from-transparent via-slate-200 dark:via-white/5 to-transparent opacity-100 group-hover:opacity-0 transition-opacity duration-300 pointer-events-none" />
-              <div className={`absolute top-0 left-0 w-full h-[2px] bg-gradient-to-r ${section.color} opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none`} />
+              <div className="absolute top-0 left-0 w-full h-[2px] bg-linear-to-r from-transparent via-slate-200 dark:via-white/5 to-transparent opacity-100 group-hover:opacity-0 transition-opacity duration-300 pointer-events-none" />
+              <div className={`absolute top-0 left-0 w-full h-[2px] bg-linear-to-r ${section.color} opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none`} />
 
               <div className="flex flex-col sm:flex-row items-start gap-4 sm:gap-5 w-full box-border mb-6">
                 <div className={`flex items-center justify-center w-11 h-11 sm:w-12 sm:h-12 rounded-xl sm:rounded-2xl ${section.bgLight} border ${section.borderLight} ${section.iconColor} transition-transform duration-300 group-hover:scale-105 select-none shrink-0`}>
@@ -159,7 +159,7 @@ const GuidelinesComponent: React.FC = () => {
                 {section.items.map((item) => (
                   <li key={item} className="flex items-start gap-3 text-xs sm:text-sm text-slate-600 dark:text-slate-300 leading-relaxed font-medium">
                     <div className="flex items-center justify-center h-5 w-5 shrink-0 select-none mt-0.5">
-                      <div className={`h-1.5 w-1.5 rounded-full bg-gradient-to-br ${section.color} shadow-sm`} />
+                      <div className={`h-1.5 w-1.5 rounded-full bg-linear-to-br ${section.color} shadow-sm`} />
                     </div>
                     <span>{item}</span>
                   </li>

--- a/frontend/src/components/help_center/faq_accordion/faq_accordion.component.tsx
+++ b/frontend/src/components/help_center/faq_accordion/faq_accordion.component.tsx
@@ -59,7 +59,7 @@ const FAQAccordion: FC<FAQAccordionProps> = ({ items }) => {
               className="group overflow-hidden rounded-3xl border border-slate-200 dark:border-white/10 bg-white dark:bg-[#111827]/40 backdrop-blur-xl shadow-sm hover:shadow-md transition-all duration-300 w-full box-border"
             >
               <div
-                className={`h-[2px] w-full bg-gradient-to-r from-indigo-500 via-blue-500 to-purple-500 transition-opacity duration-300 ${
+                className={`h-[2px] w-full bg-linear-to-r from-indigo-500 via-blue-500 to-purple-500 transition-opacity duration-300 ${
                   isOpen ? "opacity-100" : "opacity-0"
                 }`}
               />

--- a/frontend/src/components/help_center/help_category_card/help_category_card.component.tsx
+++ b/frontend/src/components/help_center/help_category_card/help_category_card.component.tsx
@@ -17,7 +17,7 @@ const HelpCategoryCard: FC<HelpCategoryCardProps> = ({ category }) => {
       className="group text-left w-full bg-white dark:bg-[#111827]/40 border border-slate-200 dark:border-white/10 hover:border-blue-500/40 dark:hover:border-blue-500/30 p-5 sm:p-6 rounded-2xl shadow-sm hover:shadow-xl transition-all duration-300 hover:scale-[1.02] focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/20 cursor-pointer flex flex-col justify-between box-border"
     >
       <div className="w-full">
-        <div className="w-11 h-11 sm:w-12 sm:h-12 rounded-xl bg-gradient-to-br from-blue-500/10 to-indigo-500/10 border border-blue-500/20 flex items-center justify-center text-xl sm:text-2xl text-blue-500 dark:text-blue-400 mb-5 select-none group-hover:scale-105 transition-transform duration-300 shrink-0">
+        <div className="w-11 h-11 sm:w-12 sm:h-12 rounded-xl bg-linear-to-br from-blue-500/10 to-indigo-500/10 border border-blue-500/20 flex items-center justify-center text-xl sm:text-2xl text-blue-500 dark:text-blue-400 mb-5 select-none group-hover:scale-105 transition-transform duration-300 shrink-0">
           <i className={`fa-solid ${category.icon}`} aria-hidden="true"></i>
         </div>
         <h3 className="text-base sm:text-lg font-bold mb-2 text-slate-900 dark:text-white tracking-tight group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors truncate max-w-full">

--- a/frontend/src/components/help_center/help_hero/help_hero.component.new.tsx
+++ b/frontend/src/components/help_center/help_hero/help_hero.component.new.tsx
@@ -23,7 +23,7 @@ const HelpHero: FC<HelpHeroProps> = ({
   return (
     <section
       id="help-hero"
-      className="relative overflow-hidden border-b border-slate-200/80 dark:border-white/10 bg-gradient-to-b from-slate-50 to-white dark:from-[#0B1120]/40 dark:to-transparent transition-colors duration-300 w-full box-border"
+      className="relative overflow-hidden border-b border-slate-200/80 dark:border-white/10 bg-linear-to-b from-slate-50 to-white dark:from-[#0B1120]/40 dark:to-transparent transition-colors duration-300 w-full box-border"
       aria-labelledby="help-center-title"
     >
       <div className="absolute inset-0 overflow-hidden pointer-events-none select-none">

--- a/frontend/src/components/help_center/help_hero/help_hero.component.tsx
+++ b/frontend/src/components/help_center/help_hero/help_hero.component.tsx
@@ -51,7 +51,7 @@ const HelpHero: FC<HelpHeroProps> = ({ searchQuery = "", onSearchChange, resultC
 
           <motion.h1
             id="help-center-title"
-            className="text-4xl sm:text-5xl lg:text-6xl font-bold text-slate-900 dark:bg-clip-text dark:text-transparent dark:bg-gradient-to-r dark:from-gray-200 dark:via-blue-400 dark:to-indigo-400 mb-6 tracking-tight"
+            className="text-4xl sm:text-5xl lg:text-6xl font-bold text-slate-900 dark:bg-clip-text dark:text-transparent dark:bg-linear-to-r dark:from-gray-200 dark:via-blue-400 dark:to-indigo-400 mb-6 tracking-tight"
           >
             How can we help you today?
           </motion.h1>

--- a/frontend/src/components/help_center/help_search_bar/help_search_bar.component.tsx
+++ b/frontend/src/components/help_center/help_search_bar/help_search_bar.component.tsx
@@ -22,7 +22,7 @@ const HelpSearchBar: FC<HelpSearchBarProps> = ({
       <label htmlFor="help-search" className="sr-only">
         Search help center
       </label>
-      <div className="relative before:absolute before:inset-0 before:-z-10 before:bg-gradient-to-r before:from-purple-500/20 before:via-indigo-500/20 before:to-blue-500/20 before:blur-xl before:rounded-2xl">
+      <div className="relative before:absolute before:inset-0 before:-z-10 before:bg-linear-to-r before:from-purple-500/20 before:via-indigo-500/20 before:to-blue-500/20 before:blur-xl before:rounded-2xl">
         <div className="absolute inset-y-0 left-0 pl-4 sm:pl-5 flex items-center pointer-events-none select-none">
           <i className="fas fa-search text-slate-400 dark:text-slate-400 text-sm sm:text-base" aria-hidden="true"></i>
 
@@ -34,7 +34,7 @@ const HelpSearchBar: FC<HelpSearchBarProps> = ({
         Search help center
       </label>
 
-      <div className="relative before:absolute before:inset-0 before:-z-10 before:bg-gradient-to-r before:from-purple-500/10 before:via-indigo-500/10 before:to-blue-500/10 before:blur-xl before:rounded-2xl">
+      <div className="relative before:absolute before:inset-0 before:-z-10 before:bg-linear-to-r before:from-purple-500/10 before:via-indigo-500/10 before:to-blue-500/10 before:blur-xl before:rounded-2xl">
         
         <div className="absolute inset-y-0 left-0 pl-4 sm:pl-5 flex items-center pointer-events-none select-none">
           <i

--- a/frontend/src/components/help_center/help_sidebar/help_sidebar.component.tsx
+++ b/frontend/src/components/help_center/help_sidebar/help_sidebar.component.tsx
@@ -100,7 +100,7 @@ const HelpSidebar = () => {
 
             <div className="relative z-10">
               <div className="mb-8">
-                <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-gradient-to-r from-blue-500/10 to-indigo-500/10 border border-blue-200 dark:border-blue-500/20 mb-4">
+                <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-linear-to-r from-blue-500/10 to-indigo-500/10 border border-blue-200 dark:border-blue-500/20 mb-4">
                   <div className="w-2 h-2 rounded-full bg-blue-500 animate-pulse" />
                   <span className="text-xs font-semibold tracking-wide uppercase text-blue-700 dark:text-blue-300">
                     Quick Navigation
@@ -126,7 +126,7 @@ const HelpSidebar = () => {
                       onClick={() => scrollToSection(section.id)}
                       className={`relative group w-full flex items-center gap-4 px-4 py-4 rounded-2xl transition-all duration-300 overflow-hidden border focus:outline-none ${
                         isActive
-                          ? "border-blue-300 dark:border-blue-500/30 bg-gradient-to-r from-blue-500/10 to-indigo-500/10"
+                          ? "border-blue-300 dark:border-blue-500/30 bg-linear-to-r from-blue-500/10 to-indigo-500/10"
                           : "border-slate-200 dark:border-white/5 bg-white/50 dark:bg-white/[0.03] hover:border-blue-200 dark:hover:border-white/10 hover:bg-slate-50 dark:hover:bg-white/[0.05]"
                       }`}
                     >
@@ -148,7 +148,7 @@ const HelpSidebar = () => {
                       {isActive && (
                         <motion.div
                           layoutId="sidebar-active-pill"
-                          className="absolute inset-0 rounded-2xl bg-gradient-to-r from-blue-500/10 to-indigo-500/10 dark:from-blue-500/20 dark:to-indigo-500/20"
+                          className="absolute inset-0 rounded-2xl bg-linear-to-r from-blue-500/10 to-indigo-500/10 dark:from-blue-500/20 dark:to-indigo-500/20"
                           transition={{ type: "spring", stiffness: 260, damping: 24 }}
                         />
                       )}
@@ -167,12 +167,12 @@ const HelpSidebar = () => {
 
               <motion.div
                 whileHover={{ y: -2 }}
-                className="relative overflow-hidden mt-8 rounded-3xl border border-blue-200 dark:border-indigo-500/20 bg-gradient-to-br from-blue-50 via-indigo-50 to-white dark:from-indigo-500/10 dark:via-blue-500/10 dark:to-slate-900/30 p-6"
+                className="relative overflow-hidden mt-8 rounded-3xl border border-blue-200 dark:border-indigo-500/20 bg-linear-to-br from-blue-50 via-indigo-50 to-white dark:from-indigo-500/10 dark:via-blue-500/10 dark:to-slate-900/30 p-6"
               >
                 <div className="absolute top-0 right-0 w-28 h-28 bg-blue-500/10 rounded-full blur-3xl" />
                 <div className="relative z-10">
                   <div className="flex items-center gap-4 mb-4">
-                    <div className="w-14 h-14 rounded-2xl bg-gradient-to-br from-blue-500 to-indigo-600 text-white flex items-center justify-center shadow-lg">
+                    <div className="w-14 h-14 rounded-2xl bg-linear-to-br from-blue-500 to-indigo-600 text-white flex items-center justify-center shadow-lg">
                       <i className="fa-solid fa-sparkles text-lg"></i>
                     </div>
                     <div>
@@ -182,7 +182,7 @@ const HelpSidebar = () => {
                   </div>
                   <button
                     onClick={() => scrollToSection("support-links-section")}
-                    className="w-full rounded-2xl bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white font-semibold py-3 transition-all duration-300 hover:scale-[1.02] shadow-lg shadow-blue-500/20"
+                    className="w-full rounded-2xl bg-linear-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white font-semibold py-3 transition-all duration-300 hover:scale-[1.02] shadow-lg shadow-blue-500/20"
                   >
                     Support Links
                   </button>

--- a/frontend/src/components/help_center/setup_guide/setup_guide.component.tsx
+++ b/frontend/src/components/help_center/setup_guide/setup_guide.component.tsx
@@ -38,7 +38,7 @@ const SetupGuide: FC<SetupGuideProps> = ({ steps }) => {
       <div className="relative max-w-4xl mx-auto px-4 sm:px-0 w-full box-border">
         {/* Vertical connector line (desktop) */}
         <div
-          className="absolute left-6 top-8 bottom-8 hidden md:block w-px bg-gradient-to-b from-indigo-500/50 via-blue-500/30 to-transparent pointer-events-none"
+          className="absolute left-6 top-8 bottom-8 hidden md:block w-px bg-linear-to-b from-indigo-500/50 via-blue-500/30 to-transparent pointer-events-none"
           aria-hidden="true"
         />
 
@@ -104,7 +104,7 @@ const SetupGuide: FC<SetupGuideProps> = ({ steps }) => {
                 )}
 
                 {/* Visual Ambient Bottom Accent Line */}
-                <div className="mt-6 h-1 w-20 rounded-full bg-gradient-to-r from-indigo-500 to-blue-500 opacity-70 transition-all duration-300 group-hover:w-32" />
+                <div className="mt-6 h-1 w-20 rounded-full bg-linear-to-r from-indigo-500 to-blue-500 opacity-70 transition-all duration-300 group-hover:w-32" />
               </div>
             </motion.li>
           ))}
@@ -117,7 +117,7 @@ const SetupGuide: FC<SetupGuideProps> = ({ steps }) => {
         whileInView={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.45, delay: 0.1 }}
         viewport={{ once: true }}
-        className="mt-12 overflow-hidden rounded-2xl sm:rounded-3xl border border-indigo-200 bg-gradient-to-r from-indigo-50/50 via-white to-blue-50/50 p-5 sm:p-6 shadow-sm dark:border-indigo-500/20 dark:from-indigo-950/20 dark:via-slate-900/60 dark:to-blue-950/20 max-w-4xl mx-auto px-4 sm:px-6 w-full box-border"
+        className="mt-12 overflow-hidden rounded-2xl sm:rounded-3xl border border-indigo-200 bg-linear-to-r from-indigo-50/50 via-white to-blue-50/50 p-5 sm:p-6 shadow-sm dark:border-indigo-500/20 dark:from-indigo-950/20 dark:via-slate-900/60 dark:to-blue-950/20 max-w-4xl mx-auto px-4 sm:px-6 w-full box-border"
       >
         <div className="flex flex-col sm:flex-row items-start gap-4 sm:gap-5 w-full box-border">
           {/* Info Icon Container */}

--- a/frontend/src/components/help_center/troubleshoot/troubleshoot.component.tsx
+++ b/frontend/src/components/help_center/troubleshoot/troubleshoot.component.tsx
@@ -69,13 +69,13 @@ const Troubleshoot: FC<TroubleshootProps> = ({ items }) => {
               <div className="absolute -top-10 -right-10 w-36 h-36 bg-orange-500/10 rounded-full blur-3xl opacity-0 group-hover:opacity-100 transition-opacity duration-500 pointer-events-none" />
               
               {/* Top Accent Line */}
-              <div className="absolute top-0 left-0 h-[2px] w-full bg-gradient-to-r from-orange-500 via-amber-500 to-yellow-500 opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none" />
+              <div className="absolute top-0 left-0 h-[2px] w-full bg-linear-to-r from-orange-500 via-amber-500 to-yellow-500 opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none" />
 
               <div className="relative z-10 p-5 sm:p-7 w-full box-border">
                 {/* Item Details Header */}
                 <div className="flex flex-col sm:flex-row sm:items-center gap-4 mb-6">
                   {/* Dynamic Icon */}
-                  <div className="flex items-center justify-center w-12 h-12 sm:w-14 sm:h-14 rounded-xl sm:rounded-2xl bg-gradient-to-br from-orange-500/10 to-amber-500/10 border border-orange-500/20 text-orange-500 dark:text-orange-400 text-lg sm:text-xl shrink-0 select-none group-hover:scale-105 transition-transform duration-300">
+                  <div className="flex items-center justify-center w-12 h-12 sm:w-14 sm:h-14 rounded-xl sm:rounded-2xl bg-linear-to-br from-orange-500/10 to-amber-500/10 border border-orange-500/20 text-orange-500 dark:text-orange-400 text-lg sm:text-xl shrink-0 select-none group-hover:scale-105 transition-transform duration-300">
                     <i className={item.icon || "fa-solid fa-bug"} aria-hidden="true"></i>
                   </div>
 

--- a/frontend/src/components/hero/hero_section.component.tsx
+++ b/frontend/src/components/hero/hero_section.component.tsx
@@ -34,7 +34,7 @@ const features = [
   {
     title: "Infinite Variations",
     description: "Generate multiple unique branches of your story from a single starting prompt. Explore every creative possibility.",
-    bgClass: "bg-gradient-to-br from-blue-900 to-sky-600/70 dark:from-blue-950 dark:to-sky-800/90",
+    bgClass: "bg-linear-to-br from-blue-900 to-sky-600/70 dark:from-blue-950 dark:to-sky-800/90",
     icon: (
       <svg className="w-7 h-7 text-sky-200" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
@@ -44,7 +44,7 @@ const features = [
   {
     title: "AI Co-Writer",
     description: "Stuck on a paragraph? Let our advanced AI models suggest the next perfect sentence to keep your momentum going.",
-    bgClass: "bg-gradient-to-br from-indigo-900 to-purple-600/70 dark:from-indigo-950 dark:to-purple-800/90",
+    bgClass: "bg-linear-to-br from-indigo-900 to-purple-600/70 dark:from-indigo-950 dark:to-purple-800/90",
     icon: (
       <svg className="w-7 h-7 text-purple-200" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
@@ -54,7 +54,7 @@ const features = [
   {
     title: "Community Driven",
     description: "Publish your stories, gather likes, and interact with other creators in a thriving, collaborative ecosystem.",
-    bgClass: "bg-gradient-to-br from-fuchsia-900 to-pink-600/70 dark:from-fuchsia-950 dark:to-pink-800/90",
+    bgClass: "bg-linear-to-br from-fuchsia-900 to-pink-600/70 dark:from-fuchsia-950 dark:to-pink-800/90",
     icon: (
       <svg className="w-7 h-7 text-pink-200" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" />
@@ -132,7 +132,7 @@ const FeatureCard = ({ feature }: { feature: Feature }) => {
         ref={cardRef}
         className={`motion-card relative overflow-hidden backdrop-blur-xl border border-slate-200/50 dark:border-white/10 rounded-3xl p-6 sm:p-8 transition-shadow duration-500 shadow-sm group cursor-pointer ${feature.bgClass} hover:shadow-[0_0_40px_rgba(255,255,255,0.12)] h-full w-full box-border`}
       >
-        <div className="absolute inset-0 bg-gradient-to-br from-white/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500 pointer-events-none"></div>
+        <div className="absolute inset-0 bg-linear-to-br from-white/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500 pointer-events-none"></div>
 
         <div ref={contentRef} className="relative z-10 pointer-events-none w-full box-border">
           <div className="w-12 h-12 sm:w-14 sm:h-14 rounded-2xl flex items-center justify-center mb-5 sm:mb-6 bg-white/10 shadow-md group-hover:scale-105 transition-transform duration-300 shrink-0">
@@ -324,7 +324,7 @@ const HeroSectionComponent = () => {
             <div className="relative max-w-3xl w-full box-border">
               <div className="flex flex-wrap items-center justify-center gap-3 sm:gap-4 select-none">
                 <Link to="/stories" className="w-full sm:w-auto">
-                  <button className="w-full sm:w-auto px-6 sm:px-8 py-3 rounded-xl bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-500 hover:to-indigo-500 text-white text-xs sm:text-sm font-bold shadow-md shadow-blue-500/10 hover:scale-[1.02] active:scale-[0.98] transition-all duration-150 flex items-center justify-center gap-2.5 cursor-pointer uppercase tracking-wider">
+                  <button className="w-full sm:w-auto px-6 sm:px-8 py-3 rounded-xl bg-linear-to-r from-blue-600 to-indigo-600 hover:from-blue-500 hover:to-indigo-500 text-white text-xs sm:text-sm font-bold shadow-md shadow-blue-500/10 hover:scale-[1.02] active:scale-[0.98] transition-all duration-150 flex items-center justify-center gap-2.5 cursor-pointer uppercase tracking-wider">
                     <i className="fa fa-wand-magic-sparkles text-sm"></i>
                     <span>Get Started</span>
                   </button>

--- a/frontend/src/components/hero/nav_list.component.tsx
+++ b/frontend/src/components/hero/nav_list.component.tsx
@@ -124,7 +124,7 @@ const NavListComponent = () => {
           </NavLink>
     <header className="sticky top-0 z-50 w-full">
       <div className="absolute inset-0 border-b border-white/50 bg-white/70 shadow-sm shadow-slate-900/5 backdrop-blur-2xl dark:border-white/10 dark:bg-slate-950/70 dark:shadow-black/20" />
-      <div className="absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-indigo-500/35 to-transparent" />
+      <div className="absolute inset-x-0 bottom-0 h-px bg-linear-to-r from-transparent via-indigo-500/35 to-transparent" />
 
       <div className="relative mx-auto flex max-w-7xl items-center justify-between px-4 py-3 sm:px-6 lg:px-8">
         <motion.div
@@ -147,7 +147,7 @@ const NavListComponent = () => {
               handleNavClick();
             }}
           >
-            <div className="relative grid h-11 w-11 place-items-center rounded-2xl border border-white/70 bg-gradient-to-br from-indigo-600 via-violet-600 to-fuchsia-500 text-white shadow-lg shadow-indigo-600/25 transition duration-300 group-hover:-translate-y-0.5 group-hover:shadow-indigo-600/40 dark:border-white/15">
+            <div className="relative grid h-11 w-11 place-items-center rounded-2xl border border-white/70 bg-linear-to-br from-indigo-600 via-violet-600 to-fuchsia-500 text-white shadow-lg shadow-indigo-600/25 transition duration-300 group-hover:-translate-y-0.5 group-hover:shadow-indigo-600/40 dark:border-white/15">
               <div className="absolute inset-0 rounded-2xl bg-white/15 opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
               <Sparkles className="relative h-5 w-5" />
             </div>
@@ -187,7 +187,7 @@ const NavListComponent = () => {
                 {isActive(item.to) && (
                   <motion.span
                     layoutId="activeIndicator"
-                    className="absolute inset-0 rounded-full bg-gradient-to-r from-indigo-600 via-violet-600 to-fuchsia-500 shadow-lg shadow-indigo-600/25"
+                    className="absolute inset-0 rounded-full bg-linear-to-r from-indigo-600 via-violet-600 to-fuchsia-500 shadow-lg shadow-indigo-600/25"
                     transition={{ type: "spring", stiffness: 420, damping: 34 }}
                   />
                 )}
@@ -217,7 +217,7 @@ const NavListComponent = () => {
                 {isActive("/dashboard") && (
                   <motion.span
                     layoutId="activeIndicator"
-                    className="absolute inset-0 rounded-full bg-gradient-to-r from-indigo-600 via-violet-600 to-fuchsia-500 shadow-lg shadow-indigo-600/25"
+                    className="absolute inset-0 rounded-full bg-linear-to-r from-indigo-600 via-violet-600 to-fuchsia-500 shadow-lg shadow-indigo-600/25"
                     transition={{ type: "spring", stiffness: 420, damping: 34 }}
                   />
                 )}
@@ -336,7 +336,7 @@ const NavListComponent = () => {
                   <Link
                     to="/signup"
                     onClick={handleNavClick}
-                    className="group inline-flex h-10 items-center gap-2 rounded-full bg-gradient-to-r from-indigo-600 via-violet-600 to-fuchsia-500 px-5 text-sm font-bold text-white shadow-lg shadow-indigo-600/25 transition-all duration-300 hover:shadow-indigo-600/40"
+                    className="group inline-flex h-10 items-center gap-2 rounded-full bg-linear-to-r from-indigo-600 via-violet-600 to-fuchsia-500 px-5 text-sm font-bold text-white shadow-lg shadow-indigo-600/25 transition-all duration-300 hover:shadow-indigo-600/40"
                   >
                     <span>Get Started</span>
                     <ArrowRight className="h-4 w-4 transition-transform duration-300 group-hover:translate-x-0.5" />
@@ -416,7 +416,7 @@ const NavListComponent = () => {
                       onClick={handleNavClick}
                       className={`flex items-center justify-between rounded-xl px-4 py-3 text-sm font-semibold transition-all duration-300 ${
                         isActive(item.to)
-                          ? "bg-gradient-to-r from-indigo-600 to-violet-600 text-white shadow-lg shadow-indigo-600/20"
+                          ? "bg-linear-to-r from-indigo-600 to-violet-600 text-white shadow-lg shadow-indigo-600/20"
                           : "text-slate-700 hover:bg-slate-100/80 dark:text-slate-300 dark:hover:bg-white/10"
                       }`}
                     >
@@ -438,7 +438,7 @@ const NavListComponent = () => {
                       onClick={handleNavClick}
                       className={`flex items-center justify-between rounded-xl px-4 py-3 text-sm font-semibold transition-all duration-300 ${
                         isActive("/dashboard")
-                          ? "bg-gradient-to-r from-indigo-600 to-violet-600 text-white shadow-lg shadow-indigo-600/20"
+                          ? "bg-linear-to-r from-indigo-600 to-violet-600 text-white shadow-lg shadow-indigo-600/20"
                           : "text-slate-700 hover:bg-slate-100/80 dark:text-slate-300 dark:hover:bg-white/10"
                       }`}
                     >
@@ -474,7 +474,7 @@ const NavListComponent = () => {
                       <Link
                         to="/signup"
                         onClick={handleNavClick}
-                        className="flex items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-indigo-600 via-violet-600 to-fuchsia-500 px-4 py-3 text-sm font-bold text-white shadow-lg shadow-indigo-600/25 transition-all duration-300"
+                        className="flex items-center justify-center gap-2 rounded-xl bg-linear-to-r from-indigo-600 via-violet-600 to-fuchsia-500 px-4 py-3 text-sm font-bold text-white shadow-lg shadow-indigo-600/25 transition-all duration-300"
                       >
                         <span>Get Started</span>
                         <ArrowRight className="h-4 w-4" />

--- a/frontend/src/components/home/community_spotlight/community_spotlight.component.tsx
+++ b/frontend/src/components/home/community_spotlight/community_spotlight.component.tsx
@@ -165,7 +165,7 @@ const CommunitySpotlightComponent = () => {
                     onClick={() => navigate(`/post/${writer.topPost._id}`)}
                     className="group relative flex h-full flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white/80 p-5 text-left shadow-sm backdrop-blur transition-all duration-300 hover:-translate-y-1 hover:border-blue-300 hover:shadow-xl hover:shadow-blue-500/10 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:border-slate-700/60 dark:bg-slate-900/70 dark:hover:border-blue-400/50 dark:focus:ring-offset-slate-950 box-border w-full"
                   >
-                    <div className="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-blue-500 via-violet-500 to-amber-400"></div>
+                    <div className="absolute inset-x-0 top-0 h-1 bg-linear-to-r from-blue-500 via-violet-500 to-amber-400"></div>
 
                     <div className="mb-6 flex items-start justify-between gap-4 w-full box-border">
                       <div className="flex min-w-0 items-center gap-4">

--- a/frontend/src/components/home/pricing/payment.component.tsx
+++ b/frontend/src/components/home/pricing/payment.component.tsx
@@ -264,7 +264,7 @@ const PaymentComponent = () => {
               type="button"
               onClick={handlePayment}
               disabled={loading}
-              className="inline-flex w-full items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-cyan-500 to-blue-600 px-5 py-4 text-base font-semibold text-white shadow-lg shadow-cyan-500/20 transition hover:shadow-cyan-500/30 disabled:cursor-not-allowed disabled:opacity-50"
+              className="inline-flex w-full items-center justify-center gap-2 rounded-2xl bg-linear-to-r from-cyan-500 to-blue-600 px-5 py-4 text-base font-semibold text-white shadow-lg shadow-cyan-500/20 transition hover:shadow-cyan-500/30 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {loading ? (
                 <>

--- a/frontend/src/components/home/recommended_writers/recommended_writers.component.tsx
+++ b/frontend/src/components/home/recommended_writers/recommended_writers.component.tsx
@@ -106,7 +106,7 @@ const RecommendedWritersComponent = () => {
               <div className="flex flex-col gap-3">
                 <Link
                   to="/login"
-                  className="w-full bg-gradient-to-r from-blue-500 to-indigo-600 hover:from-blue-600 hover:to-indigo-700 text-white font-semibold py-3 px-4 rounded-xl transition-all shadow-lg hover:shadow-indigo-500/25"
+                  className="w-full bg-linear-to-r from-blue-500 to-indigo-600 hover:from-blue-600 hover:to-indigo-700 text-white font-semibold py-3 px-4 rounded-xl transition-all shadow-lg hover:shadow-indigo-500/25"
                 >
                   Log In
                 </Link>

--- a/frontend/src/components/home/resources/resources.component.tsx
+++ b/frontend/src/components/home/resources/resources.component.tsx
@@ -75,13 +75,13 @@ const ResourceComponent = () => {
               key={resource.title}
               className={`group relative overflow-hidden rounded-3xl border transition-all duration-500 hover:-translate-y-2 hover:shadow-2xl ${
                 resource.featured
-                  ? "bg-gradient-to-br from-blue-600 via-blue-700 to-indigo-700 border-blue-500 text-white lg:scale-105 shadow-xl"
+                  ? "bg-linear-to-br from-blue-600 via-blue-700 to-indigo-700 border-blue-500 text-white lg:scale-105 shadow-xl"
                   : "bg-white dark:bg-slate-900/70 backdrop-blur-xl border-slate-200 dark:border-slate-800 hover:border-blue-500/40"
               }`}
             >
               {/* Hover Gradient */}
               {!resource.featured && (
-                <div className="absolute inset-0 bg-gradient-to-br from-blue-500/5 via-transparent to-indigo-500/10 opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
+                <div className="absolute inset-0 bg-linear-to-br from-blue-500/5 via-transparent to-indigo-500/10 opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
               )}
 
               <div className="relative z-10 p-7 sm:p-8 h-full flex flex-col">

--- a/frontend/src/components/home/start_writing/start_writing.component.tsx
+++ b/frontend/src/components/home/start_writing/start_writing.component.tsx
@@ -21,7 +21,7 @@ const StartWritingComponent = () => {
               with our AI-powered platform pipelines.
             </p>
             <Link to="/stories" className="w-full sm:w-auto inline-block">
-              <button className="w-full sm:w-auto inline-flex items-center justify-center bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-500 hover:to-indigo-500 text-white px-8 py-3.5 rounded-xl text-xs sm:text-sm font-bold shadow-md shadow-blue-500/10 transition-all duration-150 active:scale-[0.98] cursor-pointer group/btn uppercase tracking-wider select-none">
+              <button className="w-full sm:w-auto inline-flex items-center justify-center bg-linear-to-r from-blue-600 to-indigo-600 hover:from-blue-500 hover:to-indigo-500 text-white px-8 py-3.5 rounded-xl text-xs sm:text-sm font-bold shadow-md shadow-blue-500/10 transition-all duration-150 active:scale-[0.98] cursor-pointer group/btn uppercase tracking-wider select-none">
                 Get Started Free
                 <i className="fa-solid fa-wand-magic-sparkles text-xs ml-2.5 transition-transform duration-200 group-hover/btn:rotate-12 shrink-0"></i>
               </button>

--- a/frontend/src/components/home/writer_feedback/ReviewForm.tsx
+++ b/frontend/src/components/home/writer_feedback/ReviewForm.tsx
@@ -98,7 +98,7 @@ const ReviewForm = () => {
 
   return (
     <div className="mx-auto max-w-2xl">
-      <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-br from-[#0f172a]/90 to-[#111827]/90 p-6 sm:p-8 md:p-10 shadow-2xl shadow-blue-500/10 backdrop-blur-md">
+      <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-linear-to-br from-[#0f172a]/90 to-[#111827]/90 p-6 sm:p-8 md:p-10 shadow-2xl shadow-blue-500/10 backdrop-blur-md">
         {/* Background Glow */}
         <div className="pointer-events-none absolute -right-20 -top-20 h-60 w-60 rounded-full bg-blue-500/10 blur-3xl" />
         <div className="pointer-events-none absolute -bottom-20 -left-20 h-60 w-60 rounded-full bg-indigo-500/10 blur-3xl" />
@@ -271,7 +271,7 @@ const ReviewForm = () => {
                 type="button"
                 onClick={handleSubmit}
                 disabled={isLoading}
-                className="w-auto rounded-xl bg-gradient-to-r from-blue-600 to-indigo-600 px-8 py-3 font-semibold text-white transition-all duration-200 hover:scale-[1.02] hover:from-blue-500 hover:to-indigo-500 hover:shadow-xl hover:shadow-blue-500/25 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-500/50"
+                className="w-auto rounded-xl bg-linear-to-r from-blue-600 to-indigo-600 px-8 py-3 font-semibold text-white transition-all duration-200 hover:scale-[1.02] hover:from-blue-500 hover:to-indigo-500 hover:shadow-xl hover:shadow-blue-500/25 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-500/50"
               >
               {isLoading ? (
                 <span className="flex items-center justify-center gap-2">

--- a/frontend/src/components/home/writer_feedback/writer_feedback.component.tsx
+++ b/frontend/src/components/home/writer_feedback/writer_feedback.component.tsx
@@ -80,7 +80,7 @@ const WriterFeedbackComponent = () => {
 
         {/* Featured Testimonial */}
         {featuredReview && (
-          <div className="relative mb-16 overflow-hidden rounded-3xl border border-blue-500/20 bg-gradient-to-r from-blue-500/10 via-cyan-500/5 to-purple-500/10 p-8 md:p-10">
+          <div className="relative mb-16 overflow-hidden rounded-3xl border border-blue-500/20 bg-linear-to-r from-blue-500/10 via-cyan-500/5 to-purple-500/10 p-8 md:p-10">
             <div className="absolute right-6 top-6 opacity-20">
               <Quote size={80} />
             </div>

--- a/frontend/src/components/layout/floating_nav.component.tsx
+++ b/frontend/src/components/layout/floating_nav.component.tsx
@@ -207,7 +207,7 @@ const FloatingNavComponent: React.FC = () => {
                     <Link
                       to="/signup"
                       onClick={() => setIsMoreOpen(false)}
-                      className="flex items-center justify-center gap-2 p-2.5 rounded-xl bg-gradient-to-r from-indigo-600 to-violet-600 hover:from-indigo-500 hover:to-violet-500 dark:from-blue-600 dark:to-indigo-600 dark:hover:from-blue-500 dark:hover:to-indigo-500 text-white shadow-lg shadow-indigo-600/15 dark:shadow-blue-600/10 transition-all text-xs sm:text-sm font-semibold min-w-0"
+                      className="flex items-center justify-center gap-2 p-2.5 rounded-xl bg-linear-to-r from-indigo-600 to-violet-600 hover:from-indigo-500 hover:to-violet-500 dark:from-blue-600 dark:to-indigo-600 dark:hover:from-blue-500 dark:hover:to-indigo-500 text-white shadow-lg shadow-indigo-600/15 dark:shadow-blue-600/10 transition-all text-xs sm:text-sm font-semibold min-w-0"
                     >
                       <UserPlus size={16} />
                       <span className="truncate">Sign Up</span>

--- a/frontend/src/components/loading/story-generating-animation.component.tsx
+++ b/frontend/src/components/loading/story-generating-animation.component.tsx
@@ -95,7 +95,7 @@ const StoryGeneratingAnimation = ({ onCancel }: StoryGeneratingAnimationProps) =
       {/* Progress bar */}
       <div className="w-72 h-1.5 rounded-full bg-white/10 overflow-hidden">
         <motion.div
-          className="h-full rounded-full bg-gradient-to-r from-blue-400 via-indigo-400 to-purple-400"
+          className="h-full rounded-full bg-linear-to-r from-blue-400 via-indigo-400 to-purple-400"
           initial={{ width: "18%" }}
           animate={{ width: ["18%", "88%", "18%"] }}
           transition={{ duration: 8, repeat: Infinity, ease: "easeInOut" }}

--- a/frontend/src/components/login/login.component.tsx
+++ b/frontend/src/components/login/login.component.tsx
@@ -102,7 +102,7 @@ const LoginComponent = () => {
       <div className="flex w-full max-w-5xl flex-row justify-center gap-16 py-12 relative z-10 box-border items-center">
         {/* Left side — feature highlights */}
         <div className="hidden lg:flex flex-col gap-5 max-w-sm">
-          <h1 className="text-4xl font-bold bg-gradient-to-r from-blue-400 to-purple-700 bg-clip-text text-transparent">
+          <h1 className="text-4xl font-bold bg-linear-to-r from-blue-400 to-purple-700 bg-clip-text text-transparent">
             Turns Ideas into
             <br />
             unforgettable stories
@@ -192,7 +192,7 @@ const LoginComponent = () => {
           </button>
 
           <div className="mb-6 text-center">
-            <h2 className="text-2xl font-extrabold tracking-tight bg-clip-text text-transparent bg-gradient-to-r from-blue-400 to-indigo-400">
+            <h2 className="text-2xl font-extrabold tracking-tight bg-clip-text text-transparent bg-linear-to-r from-blue-400 to-indigo-400">
               Welcome back
             </h2>
             <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">

--- a/frontend/src/components/not-found.component.tsx
+++ b/frontend/src/components/not-found.component.tsx
@@ -5,7 +5,7 @@ const NotFoundComponent = () => {
   return (
     <div className="flex flex-col items-center justify-center min-h-screen bg-gray-900 text-white text-center px-4">
       <motion.h1
-        className="text-9xl font-bold bg-gradient-to-r from-blue-400 to-purple-600 text-transparent bg-clip-text"
+        className="text-9xl font-bold bg-linear-to-r from-blue-400 to-purple-600 text-transparent bg-clip-text"
         initial={{ opacity: 0, y: -50 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 1 }}

--- a/frontend/src/components/post/bookmarks.component.tsx
+++ b/frontend/src/components/post/bookmarks.component.tsx
@@ -94,7 +94,7 @@ const BookmarksComponent = () => {
           </div>
           <div className="w-full md:w-1/2 lg:w-1/3">
             <div className="relative group">
-              <div className="absolute inset-0 bg-gradient-to-r from-indigo-500/10 to-purple-500/10 rounded-2xl blur-lg opacity-40 dark:opacity-20"></div>
+              <div className="absolute inset-0 bg-linear-to-r from-indigo-500/10 to-purple-500/10 rounded-2xl blur-lg opacity-40 dark:opacity-20"></div>
               <input
                 type="text"
                 placeholder="Search your saved stories..."

--- a/frontend/src/components/post/post.component.tsx
+++ b/frontend/src/components/post/post.component.tsx
@@ -217,7 +217,7 @@ const ExploreComponent = () => {
                     onClick={() => setFeaturedPost(false)}
                     className={`text-3xl font-extrabold mb-6 cursor-pointer transition-all duration-300 ${
                       !featuredPost
-                        ? "bg-clip-text text-transparent bg-gradient-to-r from-blue-500 to-indigo-500 drop-shadow-sm"
+                        ? "bg-clip-text text-transparent bg-linear-to-r from-blue-500 to-indigo-500 drop-shadow-sm"
                         : "text-slate-500 hover:text-slate-900 dark:text-slate-500 dark:hover:text-slate-300"
                     }`}
                   >
@@ -227,7 +227,7 @@ const ExploreComponent = () => {
                   <h2
                     className={`text-2xl font-bold mb-6 cursor-pointer transition-all duration-300 flex items-center ${
                       featuredPost
-                        ? "bg-clip-text text-transparent bg-gradient-to-r from-yellow-500 to-amber-500 drop-shadow-sm"
+                        ? "bg-clip-text text-transparent bg-linear-to-r from-yellow-500 to-amber-500 drop-shadow-sm"
                         : "text-slate-500 hover:text-slate-900 dark:text-slate-500 dark:hover:text-slate-300"
                     }`}
                     onClick={() => setFeaturedPost(!featuredPost)}

--- a/frontend/src/components/post/post.details.component.tsx
+++ b/frontend/src/components/post/post.details.component.tsx
@@ -375,13 +375,13 @@ const PostDetailsComponent = () => {
                 </button>
                 <button
                   onClick={() => setShowTimeline(true)}
-                  className="flex items-center gap-1.5 px-4 py-2 text-sm bg-gradient-to-r from-purple-500 to-indigo-600 text-white hover:opacity-90 rounded-lg transition-all active:scale-95 cursor-pointer font-semibold shadow-md"
+                  className="flex items-center gap-1.5 px-4 py-2 text-sm bg-linear-to-r from-purple-500 to-indigo-600 text-white hover:opacity-90 rounded-lg transition-all active:scale-95 cursor-pointer font-semibold shadow-md"
                 >
                   ✨ Story Timeline & History
                 </button>
                 <button
                   onClick={() => setShowComparison(true)}
-                  className="flex items-center gap-1.5 px-4 py-2 text-sm bg-gradient-to-r from-cyan-500 to-blue-600 text-white hover:opacity-90 rounded-lg transition-all active:scale-95 cursor-pointer font-semibold shadow-md"
+                  className="flex items-center gap-1.5 px-4 py-2 text-sm bg-linear-to-r from-cyan-500 to-blue-600 text-white hover:opacity-90 rounded-lg transition-all active:scale-95 cursor-pointer font-semibold shadow-md"
                 >
                   📊 Compare Variations
                 </button>
@@ -419,7 +419,7 @@ const PostDetailsComponent = () => {
                   <button
                     onClick={handleSaveChanges}
                     disabled={isUpdating}
-                    className="px-4 py-2 rounded bg-gradient-to-r from-blue-500 to-indigo-600 text-white hover:opacity-90 font-semibold text-sm cursor-pointer disabled:opacity-50"
+                    className="px-4 py-2 rounded bg-linear-to-r from-blue-500 to-indigo-600 text-white hover:opacity-90 font-semibold text-sm cursor-pointer disabled:opacity-50"
                   >
                     {isUpdating ? "Saving Iteration..." : "Save Iteration"}
                   </button>
@@ -560,7 +560,7 @@ const PostDetailsComponent = () => {
 
           <div className="flex items-center justify-between w-full mb-6">
             <div>
-              <h3 className="text-xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-purple-300 to-blue-400 flex items-center gap-2">
+              <h3 className="text-xl font-bold bg-clip-text text-transparent bg-linear-to-r from-purple-300 to-blue-400 flex items-center gap-2">
                 ✨ Story Timeline
               </h3>
 
@@ -611,7 +611,7 @@ const PostDetailsComponent = () => {
                             <button
                               onClick={() => handleRestore(v._id)}
                               disabled={isRestoring}
-                              className="px-3 py-1 bg-gradient-to-r from-blue-500 to-indigo-600 hover:from-blue-600 hover:to-indigo-700 text-white font-bold text-[10px] rounded transition-all active:scale-95 cursor-pointer disabled:opacity-50"
+                              className="px-3 py-1 bg-linear-to-r from-blue-500 to-indigo-600 hover:from-blue-600 hover:to-indigo-700 text-white font-bold text-[10px] rounded transition-all active:scale-95 cursor-pointer disabled:opacity-50"
                             >
                               Restore
                             </button>

--- a/frontend/src/components/post/post.feature.component.tsx
+++ b/frontend/src/components/post/post.feature.component.tsx
@@ -14,7 +14,7 @@ const ExploreFeatureComponent = () => {
             className="animate-pulse relative overflow-hidden rounded-3xl border border-slate-200 bg-[#f8fafc]/90 h-[400px] flex flex-col justify-end p-8 dark:bg-slate-900/40 dark:border-slate-700/50"
           >
             {/* Cinematic Gradient overlay */}
-            <div className="absolute inset-0 bg-gradient-to-t from-slate-200/80 via-slate-100/30 to-transparent dark:from-slate-950 dark:via-slate-900/60 dark:to-transparent" />
+            <div className="absolute inset-0 bg-linear-to-t from-slate-200/80 via-slate-100/30 to-transparent dark:from-slate-950 dark:via-slate-900/60 dark:to-transparent" />
             
             {/* Title Skeleton */}
             <div className="h-9 bg-slate-300 dark:bg-slate-800 rounded-lg w-2/3 mb-3 relative z-10" />
@@ -60,7 +60,7 @@ const ExploreFeatureComponent = () => {
                   alt={post.title || "Post Image"}
                   className="w-full h-[400px] object-cover group-hover:scale-105 transition-transform duration-700 ease-out"
                 />
-            <div className="absolute inset-0 bg-gradient-to-t from-white via-white/80 to-transparent p-8 flex flex-col justify-end dark:from-slate-950 dark:via-slate-900/60 dark:to-transparent">
+            <div className="absolute inset-0 bg-linear-to-t from-white via-white/80 to-transparent p-8 flex flex-col justify-end dark:from-slate-950 dark:via-slate-900/60 dark:to-transparent">
               <h3 className="text-slate-900 text-3xl font-bold tracking-tight drop-shadow-md group-hover:text-blue-600 transition-colors dark:text-white dark:group-hover:text-blue-300">{post.title}</h3>
               <p className="text-slate-600 text-base mt-3 leading-relaxed max-w-2xl line-clamp-2 dark:text-slate-300">
                 {post.content.slice(0, 150)}...

--- a/frontend/src/components/post/post.view.list.component.tsx
+++ b/frontend/src/components/post/post.view.list.component.tsx
@@ -41,7 +41,7 @@ const ExploreViewListComponent: React.FC<IExploreViewListComponentProps> = ({
             className="animate-pulse bg-[#f8fafc]/90 border border-slate-200/60 shadow-lg rounded-[2.5rem] overflow-hidden flex flex-col h-[520px] dark:bg-slate-900/40 dark:border-white/5 dark:shadow-2xl"
           >
             <div className="relative aspect-video bg-slate-200/80 dark:bg-slate-800/50">
-              <div className="absolute inset-0 bg-gradient-to-t from-slate-100 to-transparent dark:from-[#03050C] opacity-60"></div>
+              <div className="absolute inset-0 bg-linear-to-t from-slate-100 to-transparent dark:from-[#03050C] opacity-60"></div>
               <div className="absolute top-6 left-6 h-7 w-20 bg-slate-300/50 rounded-full border border-slate-300/30 dark:bg-blue-500/10 dark:border-blue-500/10" />
             </div>
             <div className="p-6 flex-1 flex flex-col">
@@ -84,13 +84,13 @@ const ExploreViewListComponent: React.FC<IExploreViewListComponentProps> = ({
                     className="w-full h-52 object-cover group-hover:scale-110 transition-transform duration-700 ease-in-out"
                   />
                 ) : (
-                  <div className="w-full h-52 bg-gradient-to-br from-indigo-500/25 via-purple-500/25 to-blue-500/25 flex items-center justify-center relative">
+                  <div className="w-full h-52 bg-linear-to-br from-indigo-500/25 via-purple-500/25 to-blue-500/25 flex items-center justify-center relative">
                     <div className="absolute inset-0 bg-slate-950/40 backdrop-blur-sm" />
                     <i className="fas fa-book-open text-4xl text-indigo-400/80 relative z-10 animate-pulse" />
                   </div>
                 )}
 
-                <div className="absolute inset-0 bg-gradient-to-t from-gray-50 via-transparent to-transparent opacity-100 pointer-events-none dark:from-slate-900/90 dark:via-transparent dark:to-transparent"></div>
+                <div className="absolute inset-0 bg-linear-to-t from-gray-50 via-transparent to-transparent opacity-100 pointer-events-none dark:from-slate-900/90 dark:via-transparent dark:to-transparent"></div>
 
                 <div className="absolute top-4 right-4 z-10" onClick={(e) => e.stopPropagation()}>
                   <BookmarkButton

--- a/frontend/src/components/post/related.stories.view.component.tsx
+++ b/frontend/src/components/post/related.stories.view.component.tsx
@@ -33,7 +33,7 @@ const RelatedStoriesComponent: React.FC<IRelatedStoriesComponentProps> = ({
                   alt={post.title}
                   className="w-full h-40 object-cover group-hover:scale-105 transition-transform duration-500"
                 />
-              <div className="absolute inset-0 bg-gradient-to-t from-slate-900/40 to-transparent pointer-events-none"></div>
+              <div className="absolute inset-0 bg-linear-to-t from-slate-900/40 to-transparent pointer-events-none"></div>
             </div>
             <div className="p-5 flex flex-col flex-1">
               <h4 className="font-bold text-lg mb-2 text-slate-100 group-hover:text-blue-400 transition-colors line-clamp-2">

--- a/frontend/src/components/remix/StoryRemix.tsx
+++ b/frontend/src/components/remix/StoryRemix.tsx
@@ -154,7 +154,7 @@ export default function StoryRemix({ story, isLogin, onRemixComplete, onClose }:
           <button
             onClick={handleRemix}
             disabled={!selectedType || (!selectedOption && selectedType !== "gender_swap") || isRemixing}
-            className="w-full py-3 rounded-xl bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-700 hover:to-indigo-700 disabled:opacity-40 disabled:cursor-not-allowed text-white font-bold text-lg transition-all"
+            className="w-full py-3 rounded-xl bg-linear-to-r from-purple-600 to-indigo-600 hover:from-purple-700 hover:to-indigo-700 disabled:opacity-40 disabled:cursor-not-allowed text-white font-bold text-lg transition-all"
           >
             {isRemixing ? (
               <span className="flex items-center justify-center gap-2">

--- a/frontend/src/components/report-bug/ReportBug.tsx
+++ b/frontend/src/components/report-bug/ReportBug.tsx
@@ -143,7 +143,7 @@ const ReportBug = () => {
 
               {/* Form Card */}
               <div className="relative group">
-                <div className="absolute -inset-1 bg-gradient-to-r from-blue-600 to-indigo-600 rounded-[2.5rem] blur opacity-10 group-hover:opacity-20 transition duration-1000" />
+                <div className="absolute -inset-1 bg-linear-to-r from-blue-600 to-indigo-600 rounded-[2.5rem] blur opacity-10 group-hover:opacity-20 transition duration-1000" />
                 
                 <form
                   onSubmit={handleSubmit(onSubmit)}
@@ -382,7 +382,7 @@ const ReportBug = () => {
                           </>
                         )}
                       </div>
-                      <div className="absolute inset-0 bg-gradient-to-r from-blue-600 to-indigo-600 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+                      <div className="absolute inset-0 bg-linear-to-r from-blue-600 to-indigo-600 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
                     </button>
                   </div>
                 </form>

--- a/frontend/src/components/signup/signup.component.tsx
+++ b/frontend/src/components/signup/signup.component.tsx
@@ -238,7 +238,7 @@ const SignUpComponent = () => {
 
       <div className="flex w-full max-w-md flex-col justify-center py-6 relative z-10 px-2 sm:px-4 min-w-0 box-border">
         <div className="sm:mx-auto sm:w-full mb-6">
-          <h2 className="text-center text-3xl sm:text-5xl font-extrabold tracking-tight bg-clip-text text-transparent bg-gradient-to-r from-blue-400 to-indigo-400 drop-shadow-sm">
+          <h2 className="text-center text-3xl sm:text-5xl font-extrabold tracking-tight bg-clip-text text-transparent bg-linear-to-r from-blue-400 to-indigo-400 drop-shadow-sm">
             STORY SPARK AI
           </h2>
         </div>

--- a/frontend/src/components/stories/BranchingStory.tsx
+++ b/frontend/src/components/stories/BranchingStory.tsx
@@ -124,7 +124,7 @@ const BranchingStory = () => {
                     onClick={() => setGenre(item === genre ? "" : item)}
                     className={`px-3.5 py-1.5 rounded-xl text-xs font-bold uppercase tracking-wider border transition-all duration-150 cursor-pointer active:scale-[0.97] ${
                       genre === item
-                        ? "bg-gradient-to-r from-blue-600 to-indigo-600 border-transparent text-white shadow-sm"
+                        ? "bg-linear-to-r from-blue-600 to-indigo-600 border-transparent text-white shadow-sm"
                         : "bg-slate-50 border-slate-200/60 text-slate-600 hover:bg-slate-100 dark:bg-white/5 dark:border-white/5 dark:text-slate-400 dark:hover:bg-white/10"
                     }`}
                   >

--- a/frontend/src/components/stories/ContinueStoryModal.tsx
+++ b/frontend/src/components/stories/ContinueStoryModal.tsx
@@ -244,7 +244,7 @@ const ContinueStoryModal = ({ story, onClose }: ContinueStoryModalProps) => {
                 id="continue-story-generate-btn"
                 onClick={handleGenerate}
                 disabled={isLoading || !prompt.trim()}
-                className="flex-1 flex items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-indigo-500 to-violet-500 px-6 py-3 text-sm font-bold text-white shadow-lg shadow-indigo-500/20 transition-all hover:from-indigo-400 hover:to-violet-400 hover:shadow-indigo-400/30 active:scale-[0.97] disabled:cursor-not-allowed disabled:opacity-50"
+                className="flex-1 flex items-center justify-center gap-2 rounded-2xl bg-linear-to-r from-indigo-500 to-violet-500 px-6 py-3 text-sm font-bold text-white shadow-lg shadow-indigo-500/20 transition-all hover:from-indigo-400 hover:to-violet-400 hover:shadow-indigo-400/30 active:scale-[0.97] disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {isLoading ? (
                   <>

--- a/frontend/src/components/stories/GeneratedStoryTimeline.tsx
+++ b/frontend/src/components/stories/GeneratedStoryTimeline.tsx
@@ -129,7 +129,7 @@ const GeneratedStoryTimeline = ({
 
       <div className="mb-5 h-2 overflow-hidden rounded-full bg-slate-800">
         <motion.div
-          className="h-full rounded-full bg-gradient-to-r from-cyan-400 via-indigo-400 to-fuchsia-400"
+          className="h-full rounded-full bg-linear-to-r from-cyan-400 via-indigo-400 to-fuchsia-400"
           initial={{ width: 0 }}
           animate={{ width: `${progress}%` }}
           transition={{ duration: 0.35, ease: "easeOut" }}
@@ -137,7 +137,7 @@ const GeneratedStoryTimeline = ({
       </div>
 
       <div className="relative">
-        <div className="absolute left-4 top-4 hidden h-[calc(100%-2rem)] w-px bg-gradient-to-b from-cyan-400/50 via-indigo-400/30 to-transparent md:block" />
+        <div className="absolute left-4 top-4 hidden h-[calc(100%-2rem)] w-px bg-linear-to-b from-cyan-400/50 via-indigo-400/30 to-transparent md:block" />
         <div className="grid gap-3">
           {events.map((event, index) => {
             const isActive = event.id === activeEventId;

--- a/frontend/src/components/stories/StoryCircleSkeleton.tsx
+++ b/frontend/src/components/stories/StoryCircleSkeleton.tsx
@@ -3,7 +3,7 @@ import React from "react";
 const StoryCircleSkeleton = () => {
   return (
     <div className="flex flex-col items-center animate-pulse">
-      <div className="h-16 w-16 rounded-full bg-gradient-to-r from-slate-200 via-slate-300 to-slate-200" />
+      <div className="h-16 w-16 rounded-full bg-linear-to-r from-slate-200 via-slate-300 to-slate-200" />
       <div className="mt-2 h-3 w-12 rounded bg-slate-300" />
     </div>
   );

--- a/frontend/src/components/stories/StorySegment.tsx
+++ b/frontend/src/components/stories/StorySegment.tsx
@@ -23,7 +23,7 @@ const StorySegment = ({ text, choiceMade, index }: StorySegmentProps) => {
       className="w-full text-left bg-white dark:bg-[#111827]/40 border border-slate-200 dark:border-white/10 p-5 sm:p-6 rounded-2xl sm:rounded-3xl shadow-sm hover:shadow-xl transition-shadow duration-300 backdrop-blur-xl box-border"
     >
       <div className="flex items-start gap-4 w-full box-border">
-        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-blue-600 to-indigo-600 text-xs font-bold text-white select-none shadow-sm shadow-blue-500/10">
+        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-linear-to-br from-blue-600 to-indigo-600 text-xs font-bold text-white select-none shadow-sm shadow-blue-500/10">
           {index}
         </span>
         <div className="min-w-0 flex-1">

--- a/frontend/src/components/stories/stories.component.tsx
+++ b/frontend/src/components/stories/stories.component.tsx
@@ -1105,11 +1105,11 @@ useEffect(() => {
         <div className="mt-11">
           <h1 className="text-slate-900 dark:text-gray-300 text-2xl sm:text-3xl md:text-4xl font-extrabold text-center mb-12">
             âœ¨ {text.titleStart}{" "}
-            <span className="bg-clip-text text-transparent bg-gradient-to-r from-purple-300 to-blue-400">
+            <span className="bg-clip-text text-transparent bg-linear-to-r from-purple-300 to-blue-400">
         <div className="mb-12 max-w-3xl mx-auto text-center select-none">
           <h1 className="text-2xl sm:text-4xl font-extrabold text-slate-900 dark:text-white tracking-tight leading-tight">
             ✨ {text.titleStart}{" "}
-            <span className="bg-clip-text text-transparent bg-gradient-to-r from-blue-600 to-indigo-600 dark:from-blue-400 dark:to-indigo-400">
+            <span className="bg-clip-text text-transparent bg-linear-to-r from-blue-600 to-indigo-600 dark:from-blue-400 dark:to-indigo-400">
               {text.titleAccent}
             </span>{" "}
             âœ¨
@@ -1183,7 +1183,7 @@ useEffect(() => {
                           }}
                           className={`px-3.5 py-1.5 rounded-xl text-xs font-bold tracking-wide uppercase border transition-all duration-150 cursor-pointer active:scale-[0.97] ${
                             selectedGenre === genre.value
-                              ? "bg-gradient-to-r from-blue-600 to-indigo-600 border-transparent text-white shadow-md shadow-blue-500/10"
+                              ? "bg-linear-to-r from-blue-600 to-indigo-600 border-transparent text-white shadow-md shadow-blue-500/10"
                               : "bg-slate-50 border-slate-200/60 text-slate-600 hover:bg-slate-100 dark:bg-white/5 dark:border-white/5 dark:text-slate-400 dark:hover:bg-white/10 dark:hover:text-slate-200"
                           }`}
                         >
@@ -1354,7 +1354,7 @@ useEffect(() => {
                       aria-label={text.recentPrompts}
                       title={text.recentPrompts}
                       onClick={handleNextStep}
-                      className="w-full sm:w-auto bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-500 hover:to-indigo-500 text-white text-xs sm:text-sm font-bold py-3 px-6 rounded-xl shadow-md shadow-blue-500/10 transition-all duration-150 active:scale-[0.98] select-none uppercase tracking-wider flex items-center justify-center gap-2 cursor-pointer"
+                      className="w-full sm:w-auto bg-linear-to-r from-blue-600 to-indigo-600 hover:from-blue-500 hover:to-indigo-500 text-white text-xs sm:text-sm font-bold py-3 px-6 rounded-xl shadow-md shadow-blue-500/10 transition-all duration-150 active:scale-[0.98] select-none uppercase tracking-wider flex items-center justify-center gap-2 cursor-pointer"
                     >
                       <span>Next: Cast of Characters ➡️</span>
                     </button>
@@ -1528,7 +1528,7 @@ useEffect(() => {
                       disabled={loading || isOverLimit}
                       aria-busy={loading}
                       aria-disabled={loading || isOverLimit}
-                      className={`w-full sm:w-auto bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-500 hover:to-indigo-500 text-white text-xs sm:text-sm font-bold py-3 px-6 rounded-xl shadow-md shadow-blue-500/10 transition-all duration-150 active:scale-[0.98] select-none uppercase tracking-wider flex items-center justify-center gap-2 ${
+                      className={`w-full sm:w-auto bg-linear-to-r from-blue-600 to-indigo-600 hover:from-blue-500 hover:to-indigo-500 text-white text-xs sm:text-sm font-bold py-3 px-6 rounded-xl shadow-md shadow-blue-500/10 transition-all duration-150 active:scale-[0.98] select-none uppercase tracking-wider flex items-center justify-center gap-2 ${
                         loading || isOverLimit ? "opacity-50 cursor-not-allowed" : "cursor-pointer"
                       } group`}
                     >
@@ -1732,7 +1732,7 @@ useEffect(() => {
         disabled={loading || isOverLimit}
         aria-busy={loading}
         aria-disabled={loading || isOverLimit}
-        className={`rounded-lg bg-gradient-to-r from-blue-400 to-indigo-500 text-gray-200 px-6 py-3 font-semibold ${
+        className={`rounded-lg bg-linear-to-r from-blue-400 to-indigo-500 text-gray-200 px-6 py-3 font-semibold ${
           loading || isOverLimit
             ? "opacity-50 cursor-not-allowed"
             : "cursor-pointer hover:shadow-lg hover:shadow-indigo-500/50 hover:scale-105"
@@ -1759,7 +1759,7 @@ useEffect(() => {
                   disabled={loading || isOverLimit}
                   aria-busy={loading}
                   aria-disabled={loading || isOverLimit}
-                  className={`w-full sm:w-auto bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-500 hover:to-indigo-500 text-white text-xs sm:text-sm font-bold py-3 px-6 rounded-xl shadow-md shadow-blue-500/10 transition-all duration-150 active:scale-[0.98] select-none uppercase tracking-wider flex items-center justify-center gap-2 ${
+                  className={`w-full sm:w-auto bg-linear-to-r from-blue-600 to-indigo-600 hover:from-blue-500 hover:to-indigo-500 text-white text-xs sm:text-sm font-bold py-3 px-6 rounded-xl shadow-md shadow-blue-500/10 transition-all duration-150 active:scale-[0.98] select-none uppercase tracking-wider flex items-center justify-center gap-2 ${
                     loading || isOverLimit ? "opacity-50 cursor-not-allowed" : "cursor-pointer"
                   } group`}
                 >
@@ -1943,7 +1943,7 @@ useEffect(() => {
               <div className="flex flex-col gap-3">
                 <Link
                   to="/login"
-                  className="w-full bg-gradient-to-r from-blue-500 to-indigo-600 hover:from-blue-600 hover:to-indigo-700 text-white font-semibold py-3 px-4 rounded-xl transition-all shadow-lg hover:shadow-indigo-500/25"
+                  className="w-full bg-linear-to-r from-blue-500 to-indigo-600 hover:from-blue-600 hover:to-indigo-700 text-white font-semibold py-3 px-4 rounded-xl transition-all shadow-lg hover:shadow-indigo-500/25"
                 >
                   {text.login}
                 </Link>

--- a/frontend/src/components/stories/stories.view.component.tsx
+++ b/frontend/src/components/stories/stories.view.component.tsx
@@ -1341,7 +1341,7 @@ ${content}
                 <button
                   type="button"
                   id="publish-story-btn"
-                  className="rounded-xl px-4 py-2 bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-500 hover:to-indigo-500 text-white text-xs font-bold uppercase tracking-wider transition-all duration-150 active:scale-[0.98] cursor-pointer disabled:opacity-50"
+                  className="rounded-xl px-4 py-2 bg-linear-to-r from-blue-600 to-indigo-600 hover:from-blue-500 hover:to-indigo-500 text-white text-xs font-bold uppercase tracking-wider transition-all duration-150 active:scale-[0.98] cursor-pointer disabled:opacity-50"
                   onClick={handelPublishStory}
                   disabled={loading || !selectedStory}
                 >
@@ -1610,7 +1610,7 @@ ${content}
                   <button
                     type="button"
                     onClick={handleGenerateAlternateEndings}
-                    className="rounded-xl px-5 py-3 bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-500 hover:to-indigo-500 text-white text-xs font-bold uppercase tracking-wider shadow-md shadow-blue-500/10 transition-all duration-150 hover:scale-105 active:scale-[0.98] flex items-center gap-2 cursor-pointer"
+                    className="rounded-xl px-5 py-3 bg-linear-to-r from-blue-600 to-indigo-600 hover:from-blue-500 hover:to-indigo-500 text-white text-xs font-bold uppercase tracking-wider shadow-md shadow-blue-500/10 transition-all duration-150 hover:scale-105 active:scale-[0.98] flex items-center gap-2 cursor-pointer"
                   >
                     <i className="fa-solid fa-shuffle text-xs" /> Transform Endings
                   </button>
@@ -1944,7 +1944,7 @@ ${content}
           
           <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-5 w-full box-border border-b border-slate-200/60 dark:border-white/5 pb-6">
             <div className="text-left">
-              <h1 className="text-2xl sm:text-3xl font-extrabold text-slate-900 dark:text-white tracking-tight mb-3 bg-clip-text text-transparent bg-gradient-to-r from-purple-400 to-blue-500">
+              <h1 className="text-2xl sm:text-3xl font-extrabold text-slate-900 dark:text-white tracking-tight mb-3 bg-clip-text text-transparent bg-linear-to-r from-purple-400 to-blue-500">
                 {selectedStory.title}
               </h1>
               <div className="flex flex-wrap gap-2 select-none">
@@ -2037,7 +2037,7 @@ ${content}
                 <button type="button" className="rounded-xl px-3 py-2 bg-slate-50 text-slate-600 hover:bg-slate-100 dark:bg-white/5 dark:text-slate-300 dark:hover:bg-white/10 border border-slate-200/60 dark:border-transparent text-xs font-bold uppercase tracking-wider transition-all duration-150 active:scale-[0.98] cursor-pointer" onClick={() => setShowTranslator(true)}>
                   🌍 Translate
                 </button>
-                <button type="button" className="rounded-xl px-3 py-2 bg-gradient-to-r from-indigo-500 to-violet-500 hover:from-indigo-400 hover:to-violet-400 text-white border border-transparent text-xs font-bold uppercase tracking-wider transition-all duration-150 active:scale-[0.98] cursor-pointer shadow-sm" onClick={() => setShowContinueModal(true)}>
+                <button type="button" className="rounded-xl px-3 py-2 bg-linear-to-r from-indigo-500 to-violet-500 hover:from-indigo-400 hover:to-violet-400 text-white border border-transparent text-xs font-bold uppercase tracking-wider transition-all duration-150 active:scale-[0.98] cursor-pointer shadow-sm" onClick={() => setShowContinueModal(true)}>
                   ✦ Continue →
                 </button>
                 <button type="button" className={`rounded-xl px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-xs font-bold uppercase tracking-wider transition-all duration-150 active:scale-95 cursor-pointer disabled:opacity-50 ${loading ? 'opacity-70' : ''}`} onClick={handelPublishStory} disabled={loading}>
@@ -2175,7 +2175,7 @@ ${content}
                             <button
                               type="button"
                               onClick={() => handleApplyEnding(currentEndingData)}
-                              className="rounded-lg px-4 py-2 bg-gradient-to-r from-purple-500 to-indigo-600 hover:from-purple-600 hover:to-indigo-700 text-white font-bold text-sm transition-all hover:scale-105 active:scale-95 cursor-pointer shadow-md hover:shadow-purple-500/20"
+                              className="rounded-lg px-4 py-2 bg-linear-to-r from-purple-500 to-indigo-600 hover:from-purple-600 hover:to-indigo-700 text-white font-bold text-sm transition-all hover:scale-105 active:scale-95 cursor-pointer shadow-md hover:shadow-purple-500/20"
                             >
                               Apply to Story
                             </button>
@@ -2187,7 +2187,7 @@ ${content}
                         {/* Glassmorphic Anti-Gravity Scroll Control Panel Dock */}
                         <div className="bg-slate-100 dark:bg-slate-900/60 backdrop-blur-md border border-slate-200 dark:border-slate-800/80 p-3.5 rounded-xl flex flex-wrap items-center justify-between gap-4 shadow-xl select-none">
                           <div className="flex items-center gap-2">
-                            <span className="text-[11px] font-extrabold uppercase tracking-widest bg-clip-text text-transparent bg-gradient-to-r from-indigo-500 to-cyan-500 dark:from-indigo-400 dark:to-cyan-400">
+                            <span className="text-[11px] font-extrabold uppercase tracking-widest bg-clip-text text-transparent bg-linear-to-r from-indigo-500 to-cyan-500 dark:from-indigo-400 dark:to-cyan-400">
                               Anti-Gravity Engine
                             </span>
                             <span className="text-[9px] bg-indigo-100 dark:bg-indigo-500/10 text-indigo-700 dark:text-indigo-300 border border-indigo-200 dark:border-indigo-500/20 px-1.5 py-0.5 rounded-full font-bold uppercase">
@@ -2216,7 +2216,7 @@ ${content}
                               className={`px-3.5 py-2 rounded-lg font-bold text-[10px] uppercase tracking-wider transition-all duration-200 cursor-pointer flex items-center gap-1.5 ${
                                 isAntiGravityPlaying
                                   ? "bg-red-100 dark:bg-red-500/10 text-red-600 dark:text-red-400 border border-red-200 dark:border-red-500/20 hover:bg-red-200 dark:hover:bg-red-500/20 active:scale-95"
-                                  : "bg-gradient-to-r from-indigo-500 to-indigo-600 dark:from-indigo-600 dark:to-indigo-700 hover:from-indigo-600 hover:to-indigo-700 text-white shadow-md shadow-indigo-500/20 border border-indigo-500/30 active:scale-95"
+                                  : "bg-linear-to-r from-indigo-500 to-indigo-600 dark:from-indigo-600 dark:to-indigo-700 hover:from-indigo-600 hover:to-indigo-700 text-white shadow-md shadow-indigo-500/20 border border-indigo-500/30 active:scale-95"
                               }`}
                             >
                               {isAntiGravityPlaying ? (
@@ -2260,7 +2260,7 @@ ${content}
                   type="button"
                   onClick={handleGenerateAlternateEndings}
                   disabled={isGeneratingEndings}
-                  className="rounded-xl px-6 py-3 bg-gradient-to-r from-purple-500 to-indigo-500 hover:from-purple-600 hover:to-indigo-600 text-white font-bold transition-all duration-300 transform hover:scale-105 hover:shadow-lg hover:shadow-purple-500/30 flex items-center gap-2 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="rounded-xl px-6 py-3 bg-linear-to-r from-purple-500 to-indigo-500 hover:from-purple-600 hover:to-indigo-600 text-white font-bold transition-all duration-300 transform hover:scale-105 hover:shadow-lg hover:shadow-purple-500/30 flex items-center gap-2 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   Generate Alternate Endings
                 </button>
@@ -2310,7 +2310,7 @@ ${content}
         {/* ── Right Column ── */}
         <div className="col-span-1 lg:col-span-4">
           <div className="mb-5">
-            <h1 className="text-2xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-purple-400 to-blue-500">
+            <h1 className="text-2xl font-bold bg-clip-text text-transparent bg-linear-to-r from-purple-400 to-blue-500">
               Preview
             </h1>
           </div>

--- a/frontend/src/components/story-comparison/VariationSelector.tsx
+++ b/frontend/src/components/story-comparison/VariationSelector.tsx
@@ -151,7 +151,7 @@ const VariationSelector: React.FC<VariationSelectorProps> = ({
         disabled={!isReadyToCompare || isLoading}
         className={`w-full py-3 rounded-lg font-bold text-white transition-all flex items-center justify-center gap-2 ${
           isReadyToCompare && !isLoading
-            ? "bg-gradient-to-r from-indigo-500 to-purple-600 hover:from-indigo-600 hover:to-purple-700 cursor-pointer active:scale-95"
+            ? "bg-linear-to-r from-indigo-500 to-purple-600 hover:from-indigo-600 hover:to-purple-700 cursor-pointer active:scale-95"
             : "bg-gray-400 dark:bg-gray-700 cursor-not-allowed opacity-50"
         }`}
       >

--- a/frontend/src/components/story-inspiration/story_inspiration.component.tsx
+++ b/frontend/src/components/story-inspiration/story_inspiration.component.tsx
@@ -72,7 +72,7 @@ const StoryInspirationComponent: React.FC = () => {
               transition-all duration-300
             "
           >
-            <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-indigo-500 to-blue-500 flex items-center justify-center text-white shadow-lg">
+            <div className="w-9 h-9 rounded-xl bg-linear-to-br from-indigo-500 to-blue-500 flex items-center justify-center text-white shadow-lg">
               <i className="fas fa-arrow-left text-sm group-hover:-translate-x-0.5 transition-transform" />
             </div>
             <div className="text-left">
@@ -98,7 +98,7 @@ const StoryInspirationComponent: React.FC = () => {
         >
           {/* Glow */}
           <div className="absolute inset-0 flex items-center justify-center -z-10">
-            <div className="w-[900px] h-[450px] rounded-full bg-gradient-to-r from-indigo-500/20 via-blue-500/15 to-purple-500/20 blur-[130px]" />
+            <div className="w-[900px] h-[450px] rounded-full bg-linear-to-r from-indigo-500/20 via-blue-500/15 to-purple-500/20 blur-[130px]" />
           </div>
 
           {/* Badge */}
@@ -130,7 +130,7 @@ const StoryInspirationComponent: React.FC = () => {
             <span className="block text-slate-900 dark:text-white">Story</span>
             <span className="
               block text-transparent bg-clip-text
-              bg-gradient-to-r
+              bg-linear-to-r
               from-indigo-600 via-blue-600 to-purple-600
               dark:from-indigo-200 dark:via-blue-200 dark:to-purple-200
             ">
@@ -162,7 +162,7 @@ const StoryInspirationComponent: React.FC = () => {
               }
               className="
                 group px-8 py-4 rounded-2xl
-                bg-gradient-to-r from-indigo-600 to-blue-600
+                bg-linear-to-r from-indigo-600 to-blue-600
                 text-white font-bold
                 shadow-2xl shadow-indigo-500/25
                 hover:scale-[1.03]
@@ -218,7 +218,7 @@ const StoryInspirationComponent: React.FC = () => {
               >
                 <div className="absolute top-0 right-0 w-28 h-28 bg-indigo-500/10 blur-3xl rounded-full" />
                 <div className="relative z-10">
-                  <div className="w-14 h-14 rounded-2xl bg-gradient-to-br from-indigo-500 to-blue-500 text-white flex items-center justify-center mx-auto mb-5 shadow-xl shadow-indigo-500/25">
+                  <div className="w-14 h-14 rounded-2xl bg-linear-to-br from-indigo-500 to-blue-500 text-white flex items-center justify-center mx-auto mb-5 shadow-xl shadow-indigo-500/25">
                     <i className={`fas ${item.icon} text-lg`} />
                   </div>
                   <h3 className="text-4xl font-black text-slate-900 dark:text-white">{item.value}</h3>
@@ -259,7 +259,7 @@ const StoryInspirationComponent: React.FC = () => {
               </div>
               <div className="
                 px-5 py-4 rounded-2xl
-                bg-gradient-to-r from-indigo-500/10 to-blue-500/10
+                bg-linear-to-r from-indigo-500/10 to-blue-500/10
                 border border-indigo-500/10
                 min-w-[220px]
               ">
@@ -281,7 +281,7 @@ const StoryInspirationComponent: React.FC = () => {
               focus-within:border-indigo-500/40
               transition-all duration-300
             ">
-              <div className="w-12 h-12 rounded-2xl bg-gradient-to-br from-indigo-500 to-blue-500 text-white flex items-center justify-center shadow-lg shadow-indigo-500/20">
+              <div className="w-12 h-12 rounded-2xl bg-linear-to-br from-indigo-500 to-blue-500 text-white flex items-center justify-center shadow-lg shadow-indigo-500/20">
                 <i className="fas fa-search" />
               </div>
               <input
@@ -331,7 +331,7 @@ const StoryInspirationComponent: React.FC = () => {
                       transition-all duration-300
                       border backdrop-blur-xl
                       ${active
-                        ? `bg-gradient-to-r from-indigo-600 to-blue-600 text-white border-transparent shadow-xl shadow-indigo-500/25 scale-105`
+                        ? `bg-linear-to-r from-indigo-600 to-blue-600 text-white border-transparent shadow-xl shadow-indigo-500/25 scale-105`
                         : `bg-white dark:bg-white/[0.04] border-slate-200 dark:border-white/10 text-slate-800 dark:text-slate-100 hover:border-indigo-400/40 hover:text-indigo-700 dark:hover:text-indigo-200`
                       }
                     `}
@@ -365,7 +365,7 @@ const StoryInspirationComponent: React.FC = () => {
               shadow-2xl
             "
           >
-            <div className="w-24 h-24 rounded-full bg-gradient-to-br from-indigo-500 to-blue-500 text-white flex items-center justify-center mx-auto shadow-2xl shadow-indigo-500/25">
+            <div className="w-24 h-24 rounded-full bg-linear-to-br from-indigo-500 to-blue-500 text-white flex items-center justify-center mx-auto shadow-2xl shadow-indigo-500/25">
               <i className="fas fa-search-minus text-3xl" />
             </div>
             <h3 className="mt-8 text-3xl font-black text-slate-900 dark:text-white">No Inspiration Found</h3>
@@ -376,7 +376,7 @@ const StoryInspirationComponent: React.FC = () => {
               onClick={() => { setSearchQuery(""); setSelectedGenre("All"); }}
               className="
                 mt-10 px-8 py-4 rounded-2xl
-                bg-gradient-to-r from-indigo-600 to-blue-600
+                bg-linear-to-r from-indigo-600 to-blue-600
                 text-white font-bold
                 hover:scale-[1.03]
                 transition-all duration-300
@@ -416,7 +416,7 @@ const StoryInspirationComponent: React.FC = () => {
                 { step: "03", title: "Generate Your Story", desc: "Use the inspiration as a base and click \"Generate Custom Story\" to create your own.", icon: "fa-wand-magic-sparkles" },
               ].map((item) => (
                 <div key={item.step} className="flex gap-4 items-start">
-                  <div className="w-12 h-12 rounded-2xl bg-gradient-to-br from-indigo-500 to-blue-500 text-white flex items-center justify-center shadow-lg flex-shrink-0">
+                  <div className="w-12 h-12 rounded-2xl bg-linear-to-br from-indigo-500 to-blue-500 text-white flex items-center justify-center shadow-lg flex-shrink-0">
                     <i className={`fas ${item.icon} text-sm`} />
                   </div>
                   <div>
@@ -441,7 +441,7 @@ const StoryInspirationComponent: React.FC = () => {
             relative overflow-hidden
             rounded-[3rem]
             border border-white/60 dark:border-white/10
-            bg-gradient-to-br from-indigo-600 via-blue-600 to-purple-700
+            bg-linear-to-br from-indigo-600 via-blue-600 to-purple-700
             p-10 md:p-16
             text-white
             shadow-[0_25px_100px_rgba(79,70,229,0.35)]

--- a/frontend/src/components/story-inspiration/story_inspiration_card.component.tsx
+++ b/frontend/src/components/story-inspiration/story_inspiration_card.component.tsx
@@ -91,7 +91,7 @@ const StoryInspirationCard: React.FC<StoryInspirationCardProps> = ({ story }) =>
       
       {/* Zoom-in Card Cover Image */}
       <div className="relative h-44 w-full overflow-hidden bg-gray-100 dark:bg-[#0A0E17]">
-        <div className="absolute inset-0 bg-gradient-to-t from-gray-100 via-gray-100/50 to-transparent z-10 pointer-events-none dark:from-[#0B0F19] dark:via-[#0B0F19]/50 dark:to-transparent" />
+        <div className="absolute inset-0 bg-linear-to-t from-gray-100 via-gray-100/50 to-transparent z-10 pointer-events-none dark:from-[#0B0F19] dark:via-[#0B0F19]/50 dark:to-transparent" />
         <ImageFallback
             src={image}
             alt={title}
@@ -172,7 +172,7 @@ const StoryInspirationCard: React.FC<StoryInspirationCardProps> = ({ story }) =>
         {/* Generate CTA Button */}
         <button
           onClick={handleGenerateSimilar}
-          className="motion-cta w-full mt-auto py-4 rounded-xl bg-purple-100 text-purple-950 border border-purple-300 hover:bg-purple-200 hover:border-purple-400 text-base font-bold flex items-center justify-center gap-2.5 group/btn shadow-[0_4px_12px_rgba(0,0,0,0.08)] hover:shadow-lg hover:shadow-indigo-500/15 transition-all duration-300 dark:bg-gradient-to-r dark:from-blue-600/90 dark:to-indigo-600/90 dark:text-white dark:border-white/10 dark:hover:from-blue-600 dark:hover:to-indigo-600 dark:hover:border-indigo-300/40 dark:shadow-[0_4px_12px_rgba(0,0,0,0.2)] dark:hover:shadow-indigo-500/30"
+          className="motion-cta w-full mt-auto py-4 rounded-xl bg-purple-100 text-purple-950 border border-purple-300 hover:bg-purple-200 hover:border-purple-400 text-base font-bold flex items-center justify-center gap-2.5 group/btn shadow-[0_4px_12px_rgba(0,0,0,0.08)] hover:shadow-lg hover:shadow-indigo-500/15 transition-all duration-300 dark:bg-linear-to-r dark:from-blue-600/90 dark:to-indigo-600/90 dark:text-white dark:border-white/10 dark:hover:from-blue-600 dark:hover:to-indigo-600 dark:hover:border-indigo-300/40 dark:shadow-[0_4px_12px_rgba(0,0,0,0.2)] dark:hover:shadow-indigo-500/30"
         >
           <span>Generate Similar Story</span>
           <i className="motion-icon fas fa-wand-magic-sparkles text-base group-hover/btn:translate-x-1 group-hover/btn:rotate-12"></i>

--- a/frontend/src/components/story-visualizer/StoryVisualizer.tsx
+++ b/frontend/src/components/story-visualizer/StoryVisualizer.tsx
@@ -41,7 +41,7 @@ const IllustrationPreview = ({ scene }: IllustrationPreviewProps) => {
         : "AI-generated artwork will appear here when image generation is available.";
 
   return (
-    <div className="flex aspect-[4/3] min-h-64 items-center justify-center overflow-hidden rounded-2xl border border-indigo-300/20 bg-gradient-to-br from-slate-700 via-indigo-900/80 to-purple-950 p-6 text-center shadow-inner">
+    <div className="flex aspect-[4/3] min-h-64 items-center justify-center overflow-hidden rounded-2xl border border-indigo-300/20 bg-linear-to-br from-slate-700 via-indigo-900/80 to-purple-950 p-6 text-center shadow-inner">
       <div className="max-w-sm rounded-2xl border border-white/10 bg-slate-950/30 px-6 py-7 backdrop-blur-sm">
         <div className="mb-3 text-4xl" aria-hidden="true">
           Image

--- a/frontend/src/components/templates/templates.component.tsx
+++ b/frontend/src/components/templates/templates.component.tsx
@@ -31,7 +31,7 @@ const TemplateCard: React.FC<TemplateCardProps> = ({
     <div className="group relative bg-white dark:bg-white/[0.02] backdrop-blur-xl border border-slate-200 dark:border-white/10 rounded-2xl overflow-hidden shadow-lg hover:shadow-indigo-500/20 hover:border-indigo-500/50 dark:hover:border-indigo-500/50 transition-all duration-500 flex flex-col h-full transform hover:-translate-y-1">
       {/* Banner Image with Zoom Effect */}
       <div className="relative h-48 overflow-hidden w-full shrink-0 bg-slate-100 dark:bg-[#0B0F19]">
-        <div className="absolute inset-0 bg-gradient-to-t from-white via-white/40 dark:from-[#0B0F19] dark:via-[#0B0F19]/40 to-transparent z-10 pointer-events-none"></div>
+        <div className="absolute inset-0 bg-linear-to-t from-white via-white/40 dark:from-[#0B0F19] dark:via-[#0B0F19]/40 to-transparent z-10 pointer-events-none"></div>
         <ImageFallback
           src={image}
           alt={title}
@@ -206,7 +206,7 @@ const TemplatesComponent = () => {
   ];
 
   return (
-    <div className="bg-gradient-to-br animate-gradient-slow min-h-screen pb-24 relative overflow-hidden dark:bg-transparent">
+    <div className="bg-linear-to-br animate-gradient-slow min-h-screen pb-24 relative overflow-hidden dark:bg-transparent">
       {/* Background decorations */}
       <div className="absolute top-[-200px] right-[-100px] w-[600px] h-[600px] bg-blue-500/10 rounded-full blur-3xl -z-10 pointer-events-none"></div>
       <div className="absolute bottom-[20%] left-[-150px] w-[500px] h-[500px] bg-indigo-500/10 rounded-full blur-3xl -z-10 pointer-events-none"></div>
@@ -234,7 +234,7 @@ const TemplatesComponent = () => {
             </span>
             Professional Writing Templates
           </div>
-          <h1 className="text-5xl md:text-7xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-slate-900 via-indigo-800 to-indigo-600 dark:from-white dark:via-blue-100 dark:to-indigo-300 mb-8 tracking-tight drop-shadow-sm dark:drop-shadow-2xl">
+          <h1 className="text-5xl md:text-7xl font-extrabold text-transparent bg-clip-text bg-linear-to-r from-slate-900 via-indigo-800 to-indigo-600 dark:from-white dark:via-blue-100 dark:to-indigo-300 mb-8 tracking-tight drop-shadow-sm dark:drop-shadow-2xl">
             Writing Templates
           </h1>
           <p className="text-xl text-slate-600 dark:text-gray-400 max-w-xl mx-auto mb-10 leading-relaxed font-light">
@@ -243,7 +243,7 @@ const TemplatesComponent = () => {
           <div className="flex flex-col sm:flex-row items-center justify-center gap-5">
             <button 
               onClick={() => navigate('/stories')}
-              className="px-8 py-4 rounded-xl bg-gradient-to-r from-blue-600 to-indigo-600 text-white font-bold text-lg shadow-[0_0_30px_rgba(79,70,229,0.3)] hover:shadow-[0_0_40px_rgba(79,70,229,0.5)] transition-all duration-300 transform hover:-translate-y-1 w-full sm:w-auto flex items-center justify-center gap-2"
+              className="px-8 py-4 rounded-xl bg-linear-to-r from-blue-600 to-indigo-600 text-white font-bold text-lg shadow-[0_0_30px_rgba(79,70,229,0.3)] hover:shadow-[0_0_40px_rgba(79,70,229,0.5)] transition-all duration-300 transform hover:-translate-y-1 w-full sm:w-auto flex items-center justify-center gap-2"
             >
               Start Writing <i className="fas fa-magic"></i>
             </button>
@@ -263,7 +263,7 @@ const TemplatesComponent = () => {
                 <i className="fas fa-book-open"></i>
               </div>
               <h2 className="text-3xl font-bold text-slate-900 dark:text-gray-100">Story Writing</h2>
-              <div className="h-px bg-gradient-to-r from-emerald-500/50 to-transparent flex-grow ml-4"></div>
+              <div className="h-px bg-linear-to-r from-emerald-500/50 to-transparent flex-grow ml-4"></div>
             </div>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
               {storyTemplates.map((template, index) => (
@@ -279,7 +279,7 @@ const TemplatesComponent = () => {
                 <i className="fas fa-pen-nib"></i>
               </div>
               <h2 className="text-3xl font-bold text-slate-900 dark:text-gray-100">Creative Writing</h2>
-              <div className="h-px bg-gradient-to-r from-purple-500/50 to-transparent flex-grow ml-4"></div>
+              <div className="h-px bg-linear-to-r from-purple-500/50 to-transparent flex-grow ml-4"></div>
             </div>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
               {creativeTemplates.map((template, index) => (
@@ -295,7 +295,7 @@ const TemplatesComponent = () => {
                 <i className="fas fa-lightbulb"></i>
               </div>
               <h2 className="text-3xl font-bold text-slate-900 dark:text-gray-100">Writing Inspiration</h2>
-              <div className="h-px bg-gradient-to-r from-pink-500/50 to-transparent flex-grow ml-4"></div>
+              <div className="h-px bg-linear-to-r from-pink-500/50 to-transparent flex-grow ml-4"></div>
             </div>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
               {inspirationTemplates.map((template, index) => (
@@ -307,14 +307,14 @@ const TemplatesComponent = () => {
         </div>
 
         {/* CTA Section */}
-        <div className="mt-32 mb-10 relative rounded-3xl p-[1px] bg-gradient-to-b from-indigo-500/40 via-indigo-500/10 to-transparent overflow-hidden group">
+        <div className="mt-32 mb-10 relative rounded-3xl p-[1px] bg-linear-to-b from-indigo-500/40 via-indigo-500/10 to-transparent overflow-hidden group">
           <div className="absolute inset-0 bg-indigo-500/10 blur-2xl group-hover:bg-indigo-500/20 transition-all duration-700"></div>
-          <div className="relative bg-gradient-to-b from-white to-slate-50 dark:from-[#0f1423]/90 dark:to-[#0B0F19]/90 backdrop-blur-xl rounded-3xl p-12 md:p-20 border border-slate-200 dark:border-white/5 text-center overflow-hidden h-full w-full shadow-xl dark:shadow-2xl">
+          <div className="relative bg-linear-to-b from-white to-slate-50 dark:from-[#0f1423]/90 dark:to-[#0B0F19]/90 backdrop-blur-xl rounded-3xl p-12 md:p-20 border border-slate-200 dark:border-white/5 text-center overflow-hidden h-full w-full shadow-xl dark:shadow-2xl">
             <div className="absolute -top-32 right-0 w-96 h-96 bg-blue-500/20 rounded-full blur-[100px] -z-10 pointer-events-none transition-all duration-700 group-hover:bg-blue-500/30"></div>
             <div className="absolute -bottom-32 left-0 w-96 h-96 bg-indigo-500/20 rounded-full blur-[100px] -z-10 pointer-events-none transition-all duration-700 group-hover:bg-indigo-500/30"></div>
             
             <div className="relative z-10 flex flex-col items-center">
-              <h2 className="text-4xl md:text-5xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-slate-900 via-indigo-800 to-indigo-600 dark:from-white dark:via-indigo-100 dark:to-indigo-300 mb-6 tracking-tight drop-shadow-sm dark:drop-shadow-xl">
+              <h2 className="text-4xl md:text-5xl font-extrabold text-transparent bg-clip-text bg-linear-to-r from-slate-900 via-indigo-800 to-indigo-600 dark:from-white dark:via-indigo-100 dark:to-indigo-300 mb-6 tracking-tight drop-shadow-sm dark:drop-shadow-xl">
                 Your next great story starts here ✨
               </h2>
               <p className="text-xl text-slate-600 dark:text-gray-400 mb-12 max-w-2xl mx-auto font-light leading-relaxed">
@@ -322,7 +322,7 @@ const TemplatesComponent = () => {
               </p>
               <button 
                 onClick={() => navigate('/stories')}
-                className="group/btn px-10 py-4 rounded-full bg-gradient-to-r from-blue-600 to-indigo-600 text-white font-bold text-lg shadow-[0_0_30px_rgba(79,70,229,0.4)] hover:shadow-[0_0_50px_rgba(79,70,229,0.6)] hover:scale-105 transition-all duration-300 flex items-center justify-center gap-3 mx-auto border border-slate-200 dark:border-white/10"
+                className="group/btn px-10 py-4 rounded-full bg-linear-to-r from-blue-600 to-indigo-600 text-white font-bold text-lg shadow-[0_0_30px_rgba(79,70,229,0.4)] hover:shadow-[0_0_50px_rgba(79,70,229,0.6)] hover:scale-105 transition-all duration-300 flex items-center justify-center gap-3 mx-auto border border-slate-200 dark:border-white/10"
               >
                 <span>Start Creating</span>
                 <i className="fas fa-arrow-right transform group-hover/btn:translate-x-1 transition-transform"></i>

--- a/frontend/src/components/translate/StoryTranslator.tsx
+++ b/frontend/src/components/translate/StoryTranslator.tsx
@@ -159,7 +159,7 @@ export default function StoryTranslator({ story, isLogin, onClose }: Props) {
             <button
               onClick={handleTranslate}
               disabled={!selectedLanguage || isTranslating}
-              className="w-full py-3 rounded-xl bg-gradient-to-r from-emerald-600 to-teal-600 hover:from-emerald-700 hover:to-teal-700 disabled:opacity-40 disabled:cursor-not-allowed text-white font-bold text-lg transition-all mb-6"
+              className="w-full py-3 rounded-xl bg-linear-to-r from-emerald-600 to-teal-600 hover:from-emerald-700 hover:to-teal-700 disabled:opacity-40 disabled:cursor-not-allowed text-white font-bold text-lg transition-all mb-6"
             >
               {isTranslating ? (
                 <span className="flex items-center justify-center gap-2">

--- a/frontend/src/components/ui-component/floating-chat/floating_chat.component.tsx
+++ b/frontend/src/components/ui-component/floating-chat/floating_chat.component.tsx
@@ -167,7 +167,7 @@ export const FloatingChatWidget: React.FC = () => {
         <button
           onClick={toggleWidget}
           aria-label="Open Sparky Chat Assistant"
-          className="relative group flex items-center justify-center h-14 w-14 rounded-full bg-gradient-to-tr from-blue-600 via-indigo-600 to-purple-600 text-white shadow-[0_4px_20px_rgba(79,70,229,0.4)] border border-indigo-500/30 hover:scale-110 active:scale-95 transition-all duration-300 transform-gpu cursor-pointer"
+          className="relative group flex items-center justify-center h-14 w-14 rounded-full bg-linear-to-tr from-blue-600 via-indigo-600 to-purple-600 text-white shadow-[0_4px_20px_rgba(79,70,229,0.4)] border border-indigo-500/30 hover:scale-110 active:scale-95 transition-all duration-300 transform-gpu cursor-pointer"
         >
           <i className="fa-regular fa-comment-dots text-xl animate-pulse"></i>
           
@@ -191,9 +191,9 @@ export const FloatingChatWidget: React.FC = () => {
         <div className="flex flex-col h-[560px] w-[380px] rounded-3xl border border-slate-200 dark:border-slate-800 bg-white/95 dark:bg-slate-950/95 backdrop-blur-xl shadow-[0_12px_40px_rgba(2,6,23,0.3)] animate-in slide-in-from-bottom-5 duration-300 transform-gpu overflow-hidden">
           
           {/* Chat Window Header */}
-          <div className="flex items-center justify-between px-5 py-4 border-b border-slate-100 dark:border-slate-800/80 bg-gradient-to-r from-blue-600/5 to-purple-600/5">
+          <div className="flex items-center justify-between px-5 py-4 border-b border-slate-100 dark:border-slate-800/80 bg-linear-to-r from-blue-600/5 to-purple-600/5">
             <div className="flex items-center gap-3">
-              <div className="flex items-center justify-center h-9 w-9 rounded-full bg-gradient-to-tr from-indigo-500 to-purple-600 text-white shadow-lg shadow-indigo-500/20">
+              <div className="flex items-center justify-center h-9 w-9 rounded-full bg-linear-to-tr from-indigo-500 to-purple-600 text-white shadow-lg shadow-indigo-500/20">
                 <i className="fa-solid fa-robot text-sm"></i>
               </div>
               <div className="flex flex-col">

--- a/frontend/src/components/writing-assistant/RevisionSuggestionsPanel.tsx
+++ b/frontend/src/components/writing-assistant/RevisionSuggestionsPanel.tsx
@@ -169,7 +169,7 @@ export const RevisionSuggestionsPanel: React.FC<RevisionSuggestionsPanelProps> =
                       {suggestion.suggestedText && (
                         <button
                           onClick={() => onApply(suggestion)}
-                          className="flex-1 md:w-20 px-3 py-1.5 bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-500 hover:to-indigo-500 text-white rounded-xl text-[10px] font-bold uppercase tracking-wider transition-all active:scale-95 shadow-sm shadow-blue-500/10"
+                          className="flex-1 md:w-20 px-3 py-1.5 bg-linear-to-r from-blue-600 to-indigo-600 hover:from-blue-500 hover:to-indigo-500 text-white rounded-xl text-[10px] font-bold uppercase tracking-wider transition-all active:scale-95 shadow-sm shadow-blue-500/10"
                         >
                           Apply
                         </button>


### PR DESCRIPTION
### Description

TailwindCSS v4 renamed \g-gradient-to-*\ to \g-linear-to-*\. The old classes still work in v4 but produce deprecation warnings and may be removed in a future release.

This PR updates all occurrences across 78 frontend \.tsx\ files.
- \g-gradient-to-r\ ? \g-linear-to-r\
- \g-gradient-to-br\ ? \g-linear-to-br\
- \g-gradient-to-t\ ? \g-linear-to-t\
- \g-gradient-to-b\ ? \g-linear-to-b\
- \g-gradient-to-tr\ ? \g-linear-to-tr\
- \g-gradient-to-bl\ ? \g-linear-to-bl\
- \g-gradient-to-l\ ? \g-linear-to-l\

Closes #2985
