### PR TITLE
feat: add rate limiting to refresh-token endpoint

### DIFF
--- a/backend/src/app/middleware/ip.rate-limiter.ts
+++ b/backend/src/app/middleware/ip.rate-limiter.ts
@@ -139,4 +139,16 @@ export const newsletterRateLimiter = createRateLimiter({
   actionLabel: "newsletter subscription",
 });
 
+/**
+ * Refresh Token: 10 attempts per 15 minutes, 15-minute block
+ * (prevents token rotation abuse)
+ */
+export const refreshTokenRateLimiter = createRateLimiter({
+  windowMs: 15 * 60 * 1000,  // 15 minutes
+  maxRequests: 10,
+  blockTimeMs: 15 * 60 * 1000, // 15 minutes
+  keyPrefix: "refresh_token",
+  actionLabel: "token refresh",
+});
+
 export default ipRateLimiter;

--- a/backend/src/app/modules/auth/auth.router.ts
+++ b/backend/src/app/modules/auth/auth.router.ts
@@ -8,6 +8,7 @@ import {
   loginRateLimiter,
   forgotPasswordRateLimiter,
   resetPasswordRateLimiter,
+  refreshTokenRateLimiter,
   ipRateLimiter,
 } from "../../middleware/ip.rate-limiter";
 
@@ -33,7 +34,7 @@ router.post(
 );
 
 // Refresh Token API route
-router.post("/refresh-token", AuthController.refreshToken);
+router.post("/refresh-token", refreshTokenRateLimiter, AuthController.refreshToken);
 
 // Logout API route
 router.post("/logout", AuthController.logout);


### PR DESCRIPTION
### Description

The \/refresh-token\ endpoint was the only auth route without rate limiting, leaving it vulnerable to token rotation abuse.

### Changes

- Added \efreshTokenRateLimiter\ to \ip.rate-limiter.ts\ � 10 requests per 15-minute sliding window, 15-minute block
- Applied the limiter to \POST /refresh-token\ in the auth router

### Rate limiter config

| Parameter | Value |
|-----------|-------|
| \windowMs\ | 15 minutes |
| \maxRequests\ | 10 |
| \lockTimeMs\ | 15 minutes |
| \keyPrefix\ | \efresh_token\ |
| \ctionLabel\ | \	oken refresh\ |

Closes #2986
