### PR TITLE
fix(backend): handle guest limit duplicate key error and return 403 F…

### DIFF
--- a/backend/src/app/modules/ai_model/__tests__/quota.service.test.ts
+++ b/backend/src/app/modules/ai_model/__tests__/quota.service.test.ts
@@ -126,6 +126,17 @@ describe("guest quota", () => {
     await expect(reserveGuestQuota("guest-1")).rejects.toBeInstanceOf(ApiError);
   });
 
+  it("rejects with 403 Forbidden when findOneAndUpdate throws a duplicate key error", async () => {
+    const duplicateKeyError = new Error("Duplicate key");
+    (duplicateKeyError as any).code = 11000;
+    mockedGuestUsage.findOneAndUpdate.mockRejectedValue(duplicateKeyError);
+
+    await expect(reserveGuestQuota("guest-1")).rejects.toMatchObject({
+      statusCode: httpStatus.FORBIDDEN,
+      message: "You have reached the maximum limit of 3 story generations.",
+    });
+  });
+
   it("refunds guest quota on rollback", async () => {
     mockedGuestUsage.findOneAndUpdate.mockResolvedValue({
       requestCount: 1,

--- a/backend/src/app/modules/ai_model/quota.service.ts
+++ b/backend/src/app/modules/ai_model/quota.service.ts
@@ -112,20 +112,30 @@ export const refundUserQuota = async (email: string): Promise<void> => {
  * Atomically reserves one guest free-generation slot (persisted in MongoDB).
  */
 export const reserveGuestQuota = async (guestId: string): Promise<void> => {
-  const reserved = await GuestUsage.findOneAndUpdate(
-    { guestId, requestCount: { $lt: FREE_GUEST_LIMIT } },
-    {
-      $inc: { requestCount: 1 },
-      $set: { lastRequestAt: new Date() },
-    },
-    { new: true, upsert: true, setDefaultsOnInsert: true }
-  );
-
-  if (!reserved) {
-    throw new ApiError(
-      httpStatus.FORBIDDEN,
-      "You have reached the maximum limit of 3 story generations."
+  try {
+    const reserved = await GuestUsage.findOneAndUpdate(
+      { guestId, requestCount: { $lt: FREE_GUEST_LIMIT } },
+      {
+        $inc: { requestCount: 1 },
+        $set: { lastRequestAt: new Date() },
+      },
+      { new: true, upsert: true, setDefaultsOnInsert: true }
     );
+
+    if (!reserved) {
+      throw new ApiError(
+        httpStatus.FORBIDDEN,
+        "You have reached the maximum limit of 3 story generations."
+      );
+    }
+  } catch (error: any) {
+    if (error.code === 11000 || (error.name === "MongoServerError" && error.code === 11000)) {
+      throw new ApiError(
+        httpStatus.FORBIDDEN,
+        "You have reached the maximum limit of 3 story generations."
+      );
+    }
+    throw error;
   }
 };
 


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Open or link a related issue when there is one (`Closes #123`, `Fixes #45`, or write **None** under Related issue below).
- **Description:** Fill in **What this PR does** so a reviewer can understand the change without your local context.
- **Screenshots:** Add screenshots or a short recording when they help (UI changes, confusing flows, or non-code proof). If not needed, say so in the checklist.

## Screenshot (when helpful)

N/A (Backend logic fix - local unit tests verified successfully).

## What this PR does

This PR wraps the database upsert query in `reserveGuestQuota` with a try-catch block. When a guest attempts a 4th story generation, MongoDB throws a duplicate key error (code `11000`) instead of returning a null result because of the unique index on `guestId`. 

We now catch this specific error and return a clear `403 Forbidden` API error with the message "You have reached the maximum limit of 3 story generations.", resolving the database leak and returning the intended user-facing message. A unit test has been added to prevent regression.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #1288

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.