### PR TITLE
Solve back to home issue

### DIFF
--- a/frontend/src/components/back_home/back_to_top.component.tsx
+++ b/frontend/src/components/back_home/back_to_top.component.tsx
@@ -26,7 +26,7 @@ const BackToTop = () => {
     <button
       onClick={scrollToTop}
       aria-label="Back to top"
-      className="fixed bottom-36 right-6 z-50 flex items-center justify-center w-11 h-11 rounded-full bg-indigo-600 hover:bg-indigo-500 dark:bg-indigo-500 dark:hover:bg-indigo-400 text-white shadow-lg transition-all duration-300 ease-in-out hover:scale-110 hover:shadow-indigo-500/40 hover:shadow-xl"
+      className="fixed bottom-82 right-6 z-50 flex items-center justify-center w-11 h-11 rounded-full bg-indigo-600 hover:bg-indigo-500 dark:bg-indigo-500 dark:hover:bg-indigo-400 text-white shadow-lg transition-all duration-300 ease-in-out hover:scale-110 hover:shadow-indigo-500/40 hover:shadow-xl"
     >
       <ChevronUp className="w-5 h-5" strokeWidth={2.5} />
     </button>


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Open or link a related issue when there is one (`Closes #123`, `Fixes #45`, or write **None** under Related issue below).
- **Description:** Fill in **What this PR does** so a reviewer can understand the change without your local context.
- **Screenshots:** Add screenshots or a short recording when they help (UI changes, confusing flows, or non-code proof). If not needed, say so in the checklist.

## Screenshot (when helpful)
Befor Fix The issue 

<img width="1920" height="1080" alt="Screenshot 2026-06-08 113353" src="https://github.com/user-attachments/assets/b9346809-db2d-4406-8d8e-98de302d9506" />

after fix the issue
<img width="1920" height="1080" alt="Screenshot 2026-06-13 131332" src="https://github.com/user-attachments/assets/00967b05-546e-49a1-8a64-50e6a94a9c19" />



## What this PR does

This PR solve the Overlap Issue of "Back To Home buttom and chat options"



## Type of change
- [ *] Bug fix


## Related issue

#2619 



## Checklist

- [* ] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [ *] I have filled in the related issue number when there is one.
- [* ] I have tested my changes.
- [* ] I have done a self-review of the code.
