### PR TITLE
fix: remove user-scalable=no from viewport meta in login and signup p…

### DIFF
--- a/login.html
+++ b/login.html
@@ -2,7 +2,7 @@
 <html class="dark" lang="en">
 <head>
     <meta charset="utf-8"/>
-    <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" name="viewport"/>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <title>Login | StorySparkAI</title>
     <meta name="description" content="Sign in or create an account for StorySparkAI — turn your imagination into fully illustrated multi-variation AI stories."/>
     

--- a/signup.html
+++ b/signup.html
@@ -2,7 +2,7 @@
 <html class="dark" lang="en">
 <head>
     <meta charset="utf-8"/>
-    <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" name="viewport"/>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <title>Create Account | Story Spark AI</title>
     <meta name="description" content="Sign in or create an account for Story Spark AI — turn your imagination into fully illustrated multi-variation AI stories."/>
 


### PR DESCRIPTION
## What this PR does
Removes `maximum-scale=1.0` and `user-scalable=no` from the viewport meta tag in login.html and signup.html pages.

## Type of change
- [x] Bug fix

## Related issue
Closes #2468 

## Screenshot (when helpful)
N/A — meta tag change, not a visual UI change.

## Checklist
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.