### PR TITLE
[Fix] #3070 - Delete orphaned comments when a post is deleted

### DIFF
--- a/backend/src/app/modules/post/post.service.ts
+++ b/backend/src/app/modules/post/post.service.ts
@@ -5,6 +5,7 @@ import { IPost, IPostPayload, IPostSearchFields } from "./post.interface";
 import httpStatus from "http-status";
 import { Post } from "./post.model";
 import { Bookmark } from "../bookmark/bookmark.model";
+import { Comment } from "../comment/comment.model";
 import { StoryVersionService } from "../story_version/story_version.service";
 import {
   IGenericResponse,
@@ -512,6 +513,7 @@ const deletePost = async (postId: string, token: ITokenPayload) => {
   }
 
   await Bookmark.deleteMany({ storyId: postId });
+  await Comment.deleteMany({ postId });
 
   return post;
 };


### PR DESCRIPTION
## Summary
When a post was deleted, the `deletePost` function in `post.service.ts` cleaned up associated bookmarks but did not delete the post's comments. This caused orphaned comment documents to remain in the database indefinitely, referencing a soft-deleted post that users can no longer see or access.

## Root Cause
`deletePost` in `backend/src/app/modules/post/post.service.ts` called `Bookmark.deleteMany({ storyId: postId })` but had no corresponding `Comment.deleteMany({ postId })` call, leaving all comments associated with the deleted post as orphaned documents.

## Changes Made
- `backend/src/app/modules/post/post.service.ts`: Added `import { Comment }` from the comment model and added `await Comment.deleteMany({ postId })` immediately after the existing `Bookmark.deleteMany` cleanup in the `deletePost()` function.

## How to Test
1. Create a post and add several comments to it
2. Delete the post via the API endpoint
3. Query the `comments` collection directly in MongoDB: `db.comments.find({ postId: <deleted-post-id> })`
4. Expected: no documents returned (comments cleaned up)
5. Previously: comments remained in the collection as orphaned documents

## Related Issue
Closes #3070

## Screenshots
N/A - backend service change, no UI impact