### PR TITLE
[Docs] #3065 - Fix npm/pnpm inconsistency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@
 
 ### Local development (monorepo)
 
-**Prerequisites:** Node.js **18.18+**, npm **9+**, MongoDB URI for the API.
+**Prerequisites:** Node.js **18.18+**, pnpm **8+**, MongoDB URI for the API.
 
 1. **Clone the repository**
 
@@ -102,9 +102,9 @@
 6. **Production builds**
 
    ```bash
-   npm run build
-   npm run start:backend    # requires `npm run build:backend` first
-   npm run start:frontend   # serves built static app (preview)
+   pnpm run build
+   pnpm run start:backend    # requires `pnpm run build:backend` first
+   pnpm run start:frontend   # serves built static app (preview)
    ```
 
 ### Deploying on Vercel
@@ -241,9 +241,8 @@ VITE_GOOGLE_CLIENT_ID=your-google-client-id
 
 
 <a id="contributing"></a>
-## Troubleshooting 🛠️
 
-Running into issues during setup? Here are the most common errors and how to fix them.
+## Contributing 👨‍💻
 
 ---
 
@@ -302,10 +301,10 @@ Once the update completes, click **Try Again** in Docker Desktop. If the issue p
 ```bash
 pnpm install
 ```
-Then commit the updated `package-lock.json` before rebuilding your Docker image:
+Then commit the updated `pnpm-lock.yaml` before rebuilding your Docker image:
 ```bash
-git add package-lock.json
-git commit -m "chore: regenerate package-lock.json"
+git add pnpm-lock.yaml
+git commit -m "chore: regenerate pnpm-lock.yaml"
 ```
 
 ---


### PR DESCRIPTION
## Summary
The README contained mixed references to `npm` and `pnpm` commands, which was confusing for new contributors. Since the project uses pnpm workspaces (`pnpm-workspace.yaml`), all CLI instructions should use pnpm consistently. Additionally, the README had a duplicate "Troubleshooting" section header and an incorrect reference to `package-lock.json` (which doesn't exist in a pnpm project) in the Docker troubleshooting section.

## Root Cause
`README.md` was updated piecemeal by multiple contributors, leading to `npm` references remaining in the prerequisites and production build commands despite the project having migrated to pnpm. A duplicate section header and wrong lockfile name also crept in.

## Changes Made
- `README.md`:
  - Changed prerequisites from "npm 9+" to "pnpm 8+" to match the project's actual package manager
  - Replaced `npm run build`, `npm run start:backend`, `npm run start:frontend` with `pnpm run ...` equivalents in the production builds section
  - Removed the duplicate "Troubleshooting 🛠️" heading that shadowed the "Contributing 👨‍💻" section
  - Fixed Docker troubleshooting to reference `pnpm-lock.yaml` instead of `package-lock.json`

## How to Test
1. Read through the Local Development section — all commands should now consistently use `pnpm`
2. Verify the Contributing section header appears correctly without a duplicate Troubleshooting heading above it
3. Check the Docker troubleshooting step references `pnpm-lock.yaml`

## Related Issue
Closes #3065

## GSSoC 2026 PR Labels
- **Difficulty**: `level:beginner`
- **Quality**: `quality:clean`
- **Type**: `type:docs`
- **Approval**: `gssoc:approved`
