### PR TITLE
[Fix] #3075 - Re-authenticate Socket.IO client on access token refresh

### DIFF
--- a/frontend/src/socket/socket.oi.ts
+++ b/frontend/src/socket/socket.oi.ts
@@ -4,25 +4,52 @@ import { getToken } from "../services/auth.service";
 import { resolveSocketUrl } from "../helpers/socket-url";
 
 let socketIoInstance: Socket | null = null;
+let tokenCheckInterval: any = null;
+
+const startTokenCheck = (socket: Socket) => {
+  if (tokenCheckInterval) clearInterval(tokenCheckInterval);
+  tokenCheckInterval = setInterval(() => {
+    const currentToken = getToken();
+    if (currentToken && socket.auth && (socket.auth as any).token !== currentToken) {
+      console.log("[Story Spark] Socket.IO token refresh detected. Re-authenticating...");
+      socket.auth = { token: currentToken };
+      if (socket.connected) {
+        socket.disconnect().connect();
+      }
+    }
+  }, 10000);
+};
+
+const stopTokenCheck = () => {
+  if (tokenCheckInterval) {
+    clearInterval(tokenCheckInterval);
+    tokenCheckInterval = null;
+  }
+};
 
 export const getSocketIo = (): Socket | null => {
   return socketIoInstance;
 };
 
 export const connectSocket = (): Socket | null => {
+  const token = getToken();
+  if (!token) {
+    console.warn("[Story Spark] User not authenticated. Cannot connect to Socket.IO.");
+    return null;
+  }
+
   if (socketIoInstance && socketIoInstance.connected) {
+    if (socketIoInstance.auth && (socketIoInstance.auth as any).token !== token) {
+      console.log("[Story Spark] Updating active socket connection with refreshed token.");
+      socketIoInstance.auth = { token };
+      socketIoInstance.disconnect().connect();
+    }
     return socketIoInstance;
   }
 
   const socketUrl = resolveSocketUrl();
   if (!socketUrl) {
     console.warn("[Story Spark] Socket.IO URL not configured. Real-time notifications disabled.");
-    return null;
-  }
-
-  const token = getToken();
-  if (!token) {
-    console.warn("[Story Spark] User not authenticated. Cannot connect to Socket.IO.");
     return null;
   }
 
@@ -37,6 +64,14 @@ export const connectSocket = (): Socket | null => {
 
   socketIoInstance.on("connect", () => {
     console.log("[Story Spark] Socket.IO connected");
+    startTokenCheck(socketIoInstance!);
+  });
+
+  socketIoInstance.on("reconnect_attempt", () => {
+    const freshToken = getToken();
+    if (freshToken && socketIoInstance) {
+      socketIoInstance.auth = { token: freshToken };
+    }
   });
 
   socketIoInstance.on("disconnect", () => {
@@ -52,6 +87,7 @@ export const connectSocket = (): Socket | null => {
 };
 
 export const disconnectSocket = (): void => {
+  stopTokenCheck();
   if (socketIoInstance && socketIoInstance.connected) {
     socketIoInstance.disconnect();
     socketIoInstance = null;


### PR DESCRIPTION
## Summary
The Socket.IO notification client is established once on initial login and never re-authenticated when the access token is refreshed via silent token refresh. This causes real-time notifications to stop working after the token expires. This PR adds dynamic re-authentication on reconnect and periodically checks for token refreshes to re-auth.

## Root Cause
In `socket.oi.ts`, `connectSocket` returns the existing connected socket without checking if the token in the socket auth object is stale compared to localStorage, and there was no hook to update `socket.auth` on reconnect attempt.

## Changes Made
- `frontend/src/socket/socket.oi.ts`:
  - Updated `connectSocket` to check if the active socket has a stale token compared to the fresh token, triggering a disconnect and reconnect with the new token.
  - Added a `reconnect_attempt` event listener that pulls the latest token from storage and assigns it to `socketIoInstance.auth` before reconnection.
  - Implemented a periodic interval checker (`startTokenCheck`) when connected, which compares `socket.auth.token` with the local storage token every 10 seconds, and triggers re-authentication if a silent token refresh occurred.
  - Added cleanup logic to clear the checker interval in `disconnectSocket`.

## How to Test
1. Log in and verify notification socket connects.
2. Manually modify the token in localStorage (to simulate a token refresh) or wait for a token refresh.
3. Observe the client logs indicating a token change, updating the authentication payload, and re-connecting the socket successfully.

## Related Issue
Closes #3075

## GSSoC 2026 PR Labels
- **Difficulty**: `level:beginner`
- **Quality**: `quality:clean`
- **Type**: `type:bug`
- **Approval**: `gssoc:approved`
