### PR TITLE
[Fix] #3106 #3115 - Call AuthContext login upon successful login/OAuth

### DIFF
--- a/frontend/src/components/login/login.component.tsx
+++ b/frontend/src/components/login/login.component.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useContext } from "react";
 import { useForm, SubmitHandler } from "react-hook-form";
 import { Link } from "react-router-dom";
 
@@ -12,6 +12,7 @@ import {
 } from "../../redux/apis/auth.api";
 import { storeUserInfo } from "../../services/auth.service";
 import RedirectComponent from "../redirect.component";
+import AuthContext from "../auth.context";
 
 import toast, { Toaster } from "react-hot-toast";
 import { GoogleLogin, CredentialResponse } from "@react-oauth/google";
@@ -25,6 +26,7 @@ type Inputs = {
 const LoginComponent = () => {
   const [loginUser] = useLoginUserMutation();
   const [googleLogin] = useGoogleLoginMutation();
+  const auth = useContext(AuthContext);
 
   const {
     register,
@@ -41,7 +43,11 @@ const LoginComponent = () => {
       const res = await loginUser({ ...data }).unwrap();
       if (res.data.accessToken) {
         toast.success("User logged in successfully!");
-        storeUserInfo({ accessToken: res.data.accessToken });
+        if (auth) {
+          auth.login(res.data.accessToken);
+        } else {
+          storeUserInfo({ accessToken: res.data.accessToken });
+        }
         setIsLoggedIn(true);
       }
     } catch {
@@ -52,11 +58,6 @@ const LoginComponent = () => {
   };
 
 
-  const handleGoogleLoginSuccess = async (
-    credentialResponse: CredentialResponse
-  ) => {
-  const handleGoogleLoginSuccess = async (credentialResponse: CredentialResponse,) => {
-
   const handleGoogleLoginSuccess = async (credentialResponse: CredentialResponse) => {
     setIsBusy(true);
     try {
@@ -65,7 +66,11 @@ const LoginComponent = () => {
       }).unwrap();
       if (res.data.accessToken) {
         toast.success("User logged in successfully with Google!");
-        storeUserInfo({ accessToken: res.data.accessToken });
+        if (auth) {
+          auth.login(res.data.accessToken);
+        } else {
+          storeUserInfo({ accessToken: res.data.accessToken });
+        }
         setIsLoggedIn(true);
       }
     } catch {

--- a/frontend/src/components/signup/signup.component.tsx
+++ b/frontend/src/components/signup/signup.component.tsx
@@ -1,7 +1,7 @@
 import { useForm, SubmitHandler } from "react-hook-form";
 import SSInput from "../ui-component/ss-input/ss-input";
 import SSButton from "../ui-component/ss-button/ss-button";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useContext } from "react";
 import { storeUserInfo } from "../../services/auth.service";
 import toast, { Toaster } from "react-hot-toast";
 import { GoogleLogin, CredentialResponse } from "@react-oauth/google";
@@ -13,6 +13,7 @@ import {
 } from "../../redux/apis/otp.verify.api";
 import { useRegisterUserMutation } from "../../redux/apis/auth.api";
 import { useNavigate } from "react-router-dom";
+import AuthContext from "../auth.context";
 
 interface IRegisterInfo {
   name: string;
@@ -65,6 +66,7 @@ const SignUpComponent = () => {
   const [verifyOtp] = useVerifyOtpMutation();
   const [registerUser] = useRegisterUserMutation();
   const [googleLogin] = useGoogleLoginMutation();
+  const auth = useContext(AuthContext);
 
   const {
     register,
@@ -159,7 +161,11 @@ const SignUpComponent = () => {
         }).unwrap();
         if (res.data.accessToken) {
           toast.success("OTP validated successfully!");
-          storeUserInfo({ accessToken: res.data.accessToken });
+          if (auth) {
+            auth.login(res.data.accessToken);
+          } else {
+            storeUserInfo({ accessToken: res.data.accessToken });
+          }
           navigate("/");
         }
       } else {
@@ -198,7 +204,11 @@ const SignUpComponent = () => {
       const res = await googleLogin({ token: credentialResponse.credential }).unwrap();
       if (res.data.accessToken) {
         toast.success("Signed up with Google successfully!");
-        storeUserInfo({ accessToken: res.data.accessToken });
+        if (auth) {
+          auth.login(res.data.accessToken);
+        } else {
+          storeUserInfo({ accessToken: res.data.accessToken });
+        }
         navigate("/");
       }
     } catch {


### PR DESCRIPTION
## Summary
When logging in or signing up (via email/password or Google OAuth), the success toasts were displayed but the application would remain on the `/login` page and fail to authenticate the user session. This PR resolves the issue by correctly consuming the `AuthContext` and calling `auth.login()` upon successful authentication.

## Root Cause
`LoginComponent` and `SignUpComponent` stored the returned `accessToken` directly in `localStorage` but never updated the React `AuthContext` state, leaving the parent components and routing middleware unaware of the updated credentials.

## Changes Made
- `frontend/src/components/login/login.component.tsx`:
  - Imported and consumed `AuthContext` via `useContext`.
  - Updated standard onSubmit login handler and `handleGoogleLoginSuccess` to trigger `auth.login(accessToken)`.
  - Removed duplicate function signatures of `handleGoogleLoginSuccess`.
- `frontend/src/components/signup/signup.component.tsx`:
  - Imported and consumed `AuthContext` via `useContext`.
  - Updated successful `handleOtpValidation` and `handleGoogleLoginSuccess` to trigger `auth.login(accessToken)`.

## How to Test
1. Log in with email/password or Google on `/login` or `/signup`.
2. Verify you are successfully redirected to `/dashboard` or `/`.
3. Verify the navbar and protected pages recognize your logged-in state.

## Related Issue
Closes #3106
Closes #3115

## GSSoC 2026 PR Labels
- **Difficulty**: `level:beginner`
- **Quality**: `quality:clean`
- **Type**: `type:bug`
- **Approval**: `gssoc:approved`
