### PR TITLE
[Fix] #3040 - Prevent streak fabrication and trigger streak updates server-side

### DIFF
--- a/backend/src/__tests__/gamificationEndpoints.test.ts
+++ b/backend/src/__tests__/gamificationEndpoints.test.ts
@@ -86,28 +86,4 @@ describe("Gamification Endpoints Controllers", () => {
       data: { achievements: mockAchievementsList },
     });
   });
-
-  it("updateWritingStreak should call update service and return updated streak status", async () => {
-    const fakeUser = { _id: "user_abc", email: "test@example.com" };
-    (User.findOne as jest.Mock).mockResolvedValueOnce(fakeUser);
-
-    const mockStreak = {
-      currentStreak: 3,
-      longestStreak: 5,
-      totalWritingDays: 13,
-      lastActiveDate: new Date(),
-    };
-    (WritingStreakService.getStreak as jest.Mock).mockResolvedValueOnce(mockStreak);
-
-    const mockNext = jest.fn();
-    await UserController.updateWritingStreak(mockReq as Request, mockRes as Response, mockNext);
-
-    expect(WritingStreakService.updateStreakAndUnlocks).toHaveBeenCalledWith("user_abc");
-    expect(sendResponse).toHaveBeenCalledWith(mockRes, {
-      statusCode: 200,
-      success: true,
-      message: "Writing streak updated successfully!",
-      data: mockStreak,
-    });
-  });
 });

--- a/backend/src/app/modules/post/post.service.ts
+++ b/backend/src/app/modules/post/post.service.ts
@@ -14,6 +14,7 @@ import paginationHelper from "../../../utils/pagination_helper";
 import { postSearchFields } from "./post.constant";
 import { SortOrder, Types } from "mongoose";
 import { GamificationService } from "../gamification/gamification.service";
+import { WritingStreakService } from "../gamification/writing_streak.service";
 import { escapeRegex } from "../../../utils/regex.util";
 const MAX_SEARCH_TERM_LENGTH = 100;
 
@@ -114,6 +115,7 @@ const createPost = async (payload: IPostPayload, token: ITokenPayload) => {
         { new: true }
       );
       GamificationService.addXp(String(user._id), 50, "CREATED_POST").catch(console.error);
+      WritingStreakService.updateStreakAndUnlocks(String(user._id)).catch(console.error);
       if (updatedUser && updatedUser.postsCount === 1) {
         GamificationService.awardBadge(String(user._id), "First Story").catch(console.error);
       }
@@ -549,6 +551,7 @@ const remixStory = async (postId: string, prompt: string, token: ITokenPayload) 
       user._id,
       { $inc: { postsCount: 1 } }
     );
+    WritingStreakService.updateStreakAndUnlocks(String(user._id)).catch(console.error);
   }
 
   return res;
@@ -587,6 +590,7 @@ const translateStory = async (postId: string, language: string, token: ITokenPay
       user._id,
       { $inc: { postsCount: 1 } }
     );
+    WritingStreakService.updateStreakAndUnlocks(String(user._id)).catch(console.error);
   }
 
   return res;

--- a/backend/src/app/modules/user/user.controller.ts
+++ b/backend/src/app/modules/user/user.controller.ts
@@ -174,22 +174,6 @@ const getAchievements = catchAsync(async (req: Request, res: Response) => {
   });
 });
 
-const updateWritingStreak = catchAsync(async (req: Request, res: Response) => {
-  const token = await getToken(req);
-  const user = await User.findOne({ email: token.email });
-  if (!user) {
-    throw new ApiError(httpStatus.BAD_REQUEST, "User not found!");
-  }
-  await WritingStreakService.updateStreakAndUnlocks(String(user._id));
-  const result = await WritingStreakService.getStreak(String(user._id));
-  sendResponse(res, {
-    statusCode: httpStatus.OK,
-    success: true,
-    message: "Writing streak updated successfully!",
-    data: result,
-  });
-});
-
 export const UserController = {
   getAllUsers,
   getUser,
@@ -203,5 +187,4 @@ export const UserController = {
   getFollowStatus,
   getWritingStreak,
   getAchievements,
-  updateWritingStreak,
 };

--- a/backend/src/app/modules/user/user.router.ts
+++ b/backend/src/app/modules/user/user.router.ts
@@ -122,15 +122,5 @@ router.get(
   UserController.getAchievements
 );
 
-router.post(
-  "/me/streak/update",
-  auth(
-    ENUM_USER_ROLE.USER,
-    ENUM_USER_ROLE.WRITER,
-    ENUM_USER_ROLE.ADMIN,
-    ENUM_USER_ROLE.SUPER_ADMIN
-  ),
-  UserController.updateWritingStreak
-);
 
 export const UserRouter = router;

--- a/frontend/src/redux/apis/gamification.api.ts
+++ b/frontend/src/redux/apis/gamification.api.ts
@@ -20,19 +20,10 @@ const gamificationApi = baseApi.injectEndpoints({
       transformResponse: (response: { data: { achievements: Achievement[] } }) => response.data,
       providesTags: [tagTypes.user, tagTypes.post],
     }),
-    updateWritingStreak: build.mutation<WritingStreak, undefined>({
-      query: () => ({
-        url: "/users/me/streak/update",
-        method: "POST",
-      }),
-      transformResponse: (response: { data: WritingStreak }) => response.data,
-      invalidatesTags: [tagTypes.user, tagTypes.post],
-    }),
   }),
 });
 
 export const {
   useGetWritingStreakQuery,
   useGetAchievementsQuery,
-  useUpdateWritingStreakMutation,
 } = gamificationApi;


### PR DESCRIPTION
## Summary
Currently, writing streaks and achievements could be fabricated by hitting the `POST /api/v1/users/me/streak/update` endpoint directly, and writing activity was not linked to streak updates. This PR resolves the issue by removing the client-facing update endpoint and instead calling `WritingStreakService.updateStreakAndUnlocks` automatically server-side whenever a post/story is created, remixed, or translated.

## Changes Made
- `backend/src/app/modules/user/user.router.ts`: Removed `/me/streak/update` route definition.
- `backend/src/app/modules/user/user.controller.ts`: Removed `updateWritingStreak` controller handler.
- `backend/src/app/modules/post/post.service.ts`: Imported `WritingStreakService` and integrated `updateStreakAndUnlocks` inside `createPost`, `remixStory`, and `translateStory`.
- `frontend/src/redux/apis/gamification.api.ts`: Cleaned up the unused `updateWritingStreak` mutation from the Redux API wrapper.
- `backend/src/__tests__/gamificationEndpoints.test.ts`: Removed the unit test verifying the deleted controller function.

## Related Issue
Closes #3040

## GSSoC 2026 PR Labels
- **Difficulty**: `level:intermediate`
- **Quality**: `quality:clean`
- **Type**: `type:bug`
- **Approval**: `gssoc:approved`
