### PR TITLE
feat: Add edge case and error handling tests for character network extraction and controller [ GSSOC'26 ]

### DIFF
--- a/backend/src/__tests__/characterNetwork.test.ts
+++ b/backend/src/__tests__/characterNetwork.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, jest, beforeEach } from "@jest/globals";
 import { extractCharacterNetworkOffline } from "../app/modules/story_version/character_network.utils";
 import { Request, Response } from "express";
 import { StoryVersionController } from "../app/modules/story_version/story_version.controller";
@@ -14,6 +15,8 @@ jest.mock("../shared/send_response", () => ({
   __esModule: true,
   default: jest.fn(),
 }));
+
+// ── Offline extraction ────────────────────────────────────────────────────────
 
 describe("Character Network Extraction Logic", () => {
   it("should extract characters and relationships offline correctly", () => {
@@ -33,11 +36,56 @@ describe("Character Network Extraction Logic", () => {
     expect(rel.target === "elena" || rel.target === "merlin").toBe(true);
     expect(rel.interactionCount).toBeGreaterThan(0);
   });
+
+  // ── NEW: edge cases ─────────────────────────────────────────────────────────
+
+  it("should return empty characters and relationships for empty story", () => {
+    const result = extractCharacterNetworkOffline("");
+    expect(result.characters).toHaveLength(0);
+    expect(result.relationships).toHaveLength(0);
+  });
+
+  it("should return empty relationships for single character story", () => {
+    const story = "Merlin walked alone through the dark forest.";
+    const result = extractCharacterNetworkOffline(story);
+    const merlin = result.characters.find(c => c.name === "Merlin");
+    expect(merlin).toBeDefined();
+    expect(result.relationships).toHaveLength(0);
+  });
+
+  it("should set higher importanceScore for character with more appearances", () => {
+    const story = "Merlin cast a spell. Merlin opened the gate. Merlin spoke to Elena.";
+    const result = extractCharacterNetworkOffline(story);
+    const merlin = result.characters.find(c => c.name === "Merlin");
+    const elena  = result.characters.find(c => c.name === "Elena");
+    expect(merlin!.importanceScore).toBeGreaterThan(elena!.importanceScore);
+  });
+
+  it("should not produce duplicate characters", () => {
+    const story = "Merlin spoke. Merlin laughed. Merlin left.";
+    const result = extractCharacterNetworkOffline(story);
+    const names = result.characters.map(c => c.name.toLowerCase());
+    const unique = new Set(names);
+    expect(names.length).toBe(unique.size);
+  });
+
+  it("should not produce duplicate relationships between same pair", () => {
+    const story = "Merlin met Elena. Elena met Merlin. Merlin and Elena talked again.";
+    const result = extractCharacterNetworkOffline(story);
+    const pairs = result.relationships.map(r =>
+      [r.source, r.target].sort().join("-")
+    );
+    const unique = new Set(pairs);
+    expect(pairs.length).toBe(unique.size);
+  });
 });
+
+// ── Controller ────────────────────────────────────────────────────────────────
 
 describe("Character Network Controller", () => {
   let mockReq: Partial<Request>;
   let mockRes: Partial<Response>;
+  let mockNext: jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -46,6 +94,7 @@ describe("Character Network Controller", () => {
       user: { _id: "user123" } as any,
     };
     mockRes = {};
+    mockNext = jest.fn();
   });
 
   it("should retrieve character network and send successful response", async () => {
@@ -55,7 +104,6 @@ describe("Character Network Controller", () => {
     };
     (StoryVersionService.getCharacterNetwork as jest.Mock).mockResolvedValueOnce(mockData);
 
-    const mockNext = jest.fn();
     await StoryVersionController.getCharacterNetwork(mockReq as Request, mockRes as Response, mockNext);
 
     expect(StoryVersionService.getCharacterNetwork).toHaveBeenCalledWith("656b856b3e34a6efc023dabc", "user123");
@@ -65,5 +113,52 @@ describe("Character Network Controller", () => {
       message: "Character relationship network retrieved successfully!",
       data: mockData,
     });
+  });
+
+  // ── NEW: error handling ─────────────────────────────────────────────────────
+
+  it("should call next with error when service throws", async () => {
+    const err = new Error("DB connection failed");
+    (StoryVersionService.getCharacterNetwork as jest.Mock).mockRejectedValueOnce(err);
+
+    await StoryVersionController.getCharacterNetwork(mockReq as Request, mockRes as Response, mockNext);
+
+    expect(mockNext).toHaveBeenCalledWith(err);
+    expect(sendResponse).not.toHaveBeenCalled();
+  });
+
+  it("should call next with error when story version not found", async () => {
+    const err = new Error("Story version not found");
+    (StoryVersionService.getCharacterNetwork as jest.Mock).mockRejectedValueOnce(err);
+
+    await StoryVersionController.getCharacterNetwork(mockReq as Request, mockRes as Response, mockNext);
+
+    expect(mockNext).toHaveBeenCalledWith(err);
+  });
+
+  it("should call service with correct storyId and userId", async () => {
+    (StoryVersionService.getCharacterNetwork as jest.Mock).mockResolvedValueOnce({
+      characters: [],
+      relationships: [],
+    });
+
+    mockReq.params = { id: "abc123" };
+    mockReq.user   = { _id: "userXYZ" } as any;
+
+    await StoryVersionController.getCharacterNetwork(mockReq as Request, mockRes as Response, mockNext);
+
+    expect(StoryVersionService.getCharacterNetwork).toHaveBeenCalledWith("abc123", "userXYZ");
+  });
+
+  it("should return empty network when story has no characters", async () => {
+    const emptyData = { characters: [], relationships: [] };
+    (StoryVersionService.getCharacterNetwork as jest.Mock).mockResolvedValueOnce(emptyData);
+
+    await StoryVersionController.getCharacterNetwork(mockReq as Request, mockRes as Response, mockNext);
+
+    expect(sendResponse).toHaveBeenCalledWith(mockRes, expect.objectContaining({
+      statusCode: 200,
+      data: emptyData,
+    }));
   });
 });


### PR DESCRIPTION
## What this PR does

Expands `character_network.test.ts` with 9 new test cases covering gaps in extraction logic and controller error handling.

**Changes:**
- 5 new offline extraction tests: empty story, single char, importance scoring, duplicate char guard, duplicate relationship guard
- 4 new controller tests: service error → `next(err)`, not-found → `next(err)`, correct args, empty network → 200
- `mockNext` moved to shared `beforeEach` scope

## Type of change

- [x] New feature

## Related issue

Closes #3186 

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.