### PR TITLE
fix(footer): add right padding to legal links container to prevent scroll-to-top button overlap

### DIFF
--- a/frontend/src/components/footer/footer.component.tsx
+++ b/frontend/src/components/footer/footer.component.tsx
@@ -317,7 +317,7 @@ const FooterComponent: React.FC = () => {
             </span>
           </div>
 
-          <div className="flex flex-wrap items-center justify-center gap-x-2.5 gap-y-1">
+          <div className="flex flex-wrap items-center justify-center gap-x-2.5 gap-y-1 pr-20">
             {legalLinks.map(({ label, to }, i) => (
               <React.Fragment key={label}>
                 <Link


### PR DESCRIPTION
Fixes #3198

The legal links container in the footer bottom bar sits flush-right due
to the parent's `justify-between` layout. The fixed `ScrollToTopButton`
(right: 1.5rem, bottom: 6rem, z-index: 9999, 56px wide) overlaps
whichever link lands at the rightmost position.

Added `pr-20` (5rem / 80px) to the legal links container div in
`footer.component.tsx` line 320. This reserves enough right-side space
to keep all four links clear of the button on all viewport widths.

No reordering, no logic changes, no other files touched.

## Type of change
- [x] Bug fix

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.