### PR TITLE
fix: replace fa-sparkles with fa-infinity icon in Writing Possibiliti…

### DIFF
--- a/frontend/src/components/story-inspiration/story_inspiration.component.tsx
+++ b/frontend/src/components/story-inspiration/story_inspiration.component.tsx
@@ -201,7 +201,7 @@ const StoryInspirationComponent: React.FC = () => {
             {[
               { value: inspirationData.length, label: "Story Inspirations", icon: "fa-book-open" },
               { value: genres.length - 1, label: "Creative Genres", icon: "fa-layer-group" },
-              { value: "∞", label: "Writing Possibilities", icon: "fa-sparkles" },
+              { value: "∞", label: "Writing Possibilities", icon: "fa-infinity" },
             ].map((item, index) => (
               <motion.div
                 key={index}


### PR DESCRIPTION
## What this PR does
Fixes the missing/broken icon in the "Writing Possibilities" 
stat card on the Stories page. The `fa-sparkles` icon is a 
Font Awesome Pro icon not available in the free version, 
causing it to render as a broken symbol. Replaced it with 
`fa-infinity` which is free and semantically appropriate.

## Type of change
- [x] Bug fix

## Related issue
Fixes #3208

## Screenshot (when helpful)
**Before:** Writing Possibilities card shows broken ∞ text symbol
**After:** Writing Possibilities card shows proper infinity icon ∞

Before Changes:
<img width="1709" height="983" alt="Screenshot 2026-06-14 at 1 31 26 PM" src="https://github.com/user-attachments/assets/7622bccf-1f55-46c6-92c3-1206ba1c37c6" />

After Changes:
<img width="1709" height="983" alt="Screenshot 2026-06-14 at 1 32 35 PM" src="https://github.com/user-attachments/assets/0ecbbff8-014a-4fb5-9ecc-adac03753da8" />


## More screenshots (optional)
N/A

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.