### PR TITLE
Fix: Resolve case-sensitive role bug preventing admins from deleting comments

### DIFF
--- a/backend/src/app/modules/comment/comment.service.ts
+++ b/backend/src/app/modules/comment/comment.service.ts
@@ -6,6 +6,7 @@ import httpStatus from "http-status";
 import { Comment } from "./comment.model";
 import { Types } from "mongoose";
 import { Post } from "../post/post.model";
+import { ENUM_USER_ROLE } from "../../../enums/user";
 
 const createComment = async (
   payload: ICommentPayload,
@@ -100,7 +101,7 @@ const deleteComment = async (commentId: string, token: ITokenPayload) => {
   }
   // Only the comment author or an admin/super-admin can delete
   const isAuthor = comment.userId.toString() === user._id.toString();
-  const isAdmin = role === "ADMIN" || role === "SUPER_ADMIN";
+  const isAdmin = role === ENUM_USER_ROLE.ADMIN || role === ENUM_USER_ROLE.SUPER_ADMIN;
   if (!isAuthor && !isAdmin) {
     throw new ApiError(
       httpStatus.FORBIDDEN,


### PR DESCRIPTION
This PR fixes a critical authorization bug in the backend where administrators and super-administrators were unable to delete comments left by other users, effectively breaking the comment moderation system.
Closes #3222 
**Why it's needed:**
In `backend/src/app/modules/comment/comment.service.ts`, the `deleteComment` logic was verifying administrative privileges using strict equality checks against uppercase string literals (`"ADMIN"` and `"SUPER_ADMIN"`). However, the project's `ENUM_USER_ROLE` defines these roles in lowercase (e.g., `"admin"`, `"super_admin"`). 

Because of this mismatch, the `isAdmin` boolean always evaluated to `false`, causing the server to incorrectly reject valid moderation requests with a `403 FORBIDDEN` error.

**Changes made:**
- Imported the existing `ENUM_USER_ROLE` into `comment.service.ts`.
- Replaced the hardcoded uppercase strings with `ENUM_USER_ROLE.ADMIN` and `ENUM_USER_ROLE.SUPER_ADMIN` to ensure type safety and consistent case-matching.
- Successfully verified the build with the TypeScript compiler locally.

**Checklist:**
- [x] I have read the contribution guidelines.
- [x] I have tested the changes locally.
- [x] My code follows the project's style guidelines.
@ronisarkarexe please check it
