### PR TITLE
docs: clarify TTS settings require narration restart

### DIFF
--- a/frontend/src/components/AudioPlayer.tsx
+++ b/frontend/src/components/AudioPlayer.tsx
@@ -336,7 +336,9 @@ const AudioPlayer = forwardRef<AudioPlayerHandle, AudioPlayerProps>(
                   </div>
                 </div>
               </div>
-
+               <p className="mt-3 text-xs text-slate-500 dark:text-slate-400">
+  Changes to voice, pitch, volume, and playback speed are applied when narration is restarted.
+</p>
               <div className="space-y-2">
                 <label
                   htmlFor={languageSelectId}


### PR DESCRIPTION


## Screenshot (when helpful)

N/A – Added an informational note to clarify existing SpeechSynthesis behavior.



## What this PR does

Adds a clarification note in the Audio Player settings panel informing users that changes to voice, pitch, volume, and playback speed are applied when narration is restarted.

This helps reduce confusion when users modify narration settings during active playback or after pausing, as browser SpeechSynthesis implementations may not immediately apply those changes to an already created utterance.

## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [x] Documentation update

## Related issue

Fixes #3125

## More screenshots (optional)

N/A



## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
