### PR TITLE
feat(frontend): add dynamic story mood indicator badge (#1828)

### DIFF
--- a/frontend/src/components/stories/stories.view.component.tsx
+++ b/frontend/src/components/stories/stories.view.component.tsx
@@ -80,6 +80,84 @@ const buildSentenceSegments = (content: string): StorySentenceSegment[] => {
   return segments;
 };
 
+const detectStoryMood = (content: string) => {
+  const lowercase = content.toLowerCase();
+  
+  const moodKeywords = {
+    Happy: {
+      emoji: "😊",
+      words: ["happy", "joy", "smile", "laugh", "glad", "cheerful", "delighted", "celebrat", "sunshine", "peace", "content", "love", "wonderful", "positive"],
+      colorClass: "text-amber-300",
+      bgClass: "bg-amber-900/60",
+      borderClass: "border-amber-700/50"
+    },
+    Suspense: {
+      emoji: "😨",
+      words: ["shadow", "mysteri", "mystery", "whisper", "dark", "silence", "sudden", "fear", "dread", "tense", "tension", "escape", "warning", "danger", "trap", "alert", "nervous", "heartbeat", "chill"],
+      colorClass: "text-orange-300",
+      bgClass: "bg-orange-900/60",
+      borderClass: "border-orange-700/50"
+    },
+    Sad: {
+      emoji: "💔",
+      words: ["sad", "tears", "tear", "cry", "weep", "grief", "grieve", "loss", "lost", "lonely", "pain", "sorrow", "mourn", "broken", "empty", "tragic", "regret"],
+      colorClass: "text-cyan-300",
+      bgClass: "bg-cyan-900/60",
+      borderClass: "border-cyan-700/50"
+    },
+    Action: {
+      emoji: "🔥",
+      words: ["run", "fight", "battle", "sword", "strike", "clash", "weapon", "burst", "speed", "explod", "explosion", "chase", "leap", "attack", "defense", "power"],
+      colorClass: "text-rose-300",
+      bgClass: "bg-rose-900/60",
+      borderClass: "border-rose-700/50"
+    },
+    Fantasy: {
+      emoji: "✨",
+      words: ["magic", "spell", "wizard", "witch", "elf", "dwarf", "fairy", "dragon", "portal", "crystal", "kingdom", "cast", "wand", "sparkle", "enchant", "dream", "myth", "legend"],
+      colorClass: "text-purple-300",
+      bgClass: "bg-purple-900/60",
+      borderClass: "border-purple-700/50"
+    }
+  };
+
+  const scores: Record<string, number> = {
+    Happy: 0,
+    Suspense: 0,
+    Sad: 0,
+    Action: 0,
+    Fantasy: 0
+  };
+
+  for (const [mood, data] of Object.entries(moodKeywords)) {
+    data.words.forEach(word => {
+      const regex = new RegExp(`\\b${word}`, 'g');
+      const matches = lowercase.match(regex);
+      if (matches) {
+        scores[mood] += matches.length;
+      }
+    });
+  }
+
+  let maxMood = "Fantasy"; // default fallback mood
+  let maxScore = 0;
+
+  for (const [mood, score] of Object.entries(scores)) {
+    if (score > maxScore) {
+      maxScore = score;
+      maxMood = mood;
+    }
+  }
+
+  return {
+    label: maxMood,
+    emoji: moodKeywords[maxMood as keyof typeof moodKeywords].emoji,
+    colorClass: moodKeywords[maxMood as keyof typeof moodKeywords].colorClass,
+    bgClass: moodKeywords[maxMood as keyof typeof moodKeywords].bgClass,
+    borderClass: moodKeywords[maxMood as keyof typeof moodKeywords].borderClass
+  };
+};
+
 const StoriesViewComponent: React.FC<StoriesComponentProps> = ({
   stories,
   isLogin,
@@ -762,6 +840,15 @@ if (isLoading) {
                 <span className="inline-flex items-center rounded-full bg-blue-900/60 text-blue-300 border border-blue-700/50 py-1 px-3 text-xs font-semibold">
                   Γëí╞Æ├«├ë {selectedStory.language || "English"}
                 </span>
+                {(() => {
+                  const mood = detectStoryMood(selectedStory.content);
+                  return (
+                    <span className={`inline-flex items-center rounded-full ${mood.bgClass} ${mood.colorClass} border ${mood.borderClass} py-1 px-3 text-xs font-semibold gap-1`}>
+                      <span>{mood.emoji}</span>
+                      <span>Mood: {mood.label}</span>
+                    </span>
+                  );
+                })()}
                 {selectedStory.emotions && selectedStory.emotions.length > 0 && (
                   <span className="inline-flex items-center rounded-full bg-emerald-900/60 text-emerald-300 border border-emerald-700/50 py-1 px-3 text-xs font-semibold">
                     Γëí╞Æ├┐├¿ {selectedStory.emotions.join(", ")}


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Open or link a related issue when there is one (`Closes #123`, `Fixes #45`, or write **None** under Related issue below).
- **Description:** Fill in **What this PR does** so a reviewer can understand the change without your local context.
- **Screenshots:** Add screenshots or a short recording when they help (UI changes, confusing flows, or non-code proof). If not needed, say so in the checklist.

## Screenshot (when helpful)

N/A (Visual badge matches styling of existing category and language badges in the selected story header details container).

## What this PR does

This PR introduces a client-side keyword-based sentiment analyzer that computes mood scores from a story's content. 

The dominant mood (e.g. Happy 😊, Suspense 😨, Sad 💔, Action 🔥, Fantasy ✨) is displayed dynamically as a visual badge in the header details container in `stories.view.component.tsx`. The badge updates in real time if the story text is changed (such as applying alternate endings).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #1828

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.