### PR TITLE
fix: align branching story API response type with backend structure

### DIFF
--- a/frontend/src/redux/apis/branching.story.api.ts
+++ b/frontend/src/redux/apis/branching.story.api.ts
@@ -12,6 +12,13 @@ export interface BranchingStoryRequest {
   genre?: string;
 }
 
+export interface BranchingStoryApiResponse {
+  success: boolean;
+  statusCode: number;
+  message: string;
+  data: BranchingStoryResponse;
+}
+
 const branchingStoryApi = baseApi.injectEndpoints({
   endpoints: (build) => ({
     createBranchingStory: build.mutation({
@@ -20,10 +27,7 @@ const branchingStoryApi = baseApi.injectEndpoints({
         method: "POST",
         data,
       }),
-      transformResponse: (response: {
-        data: BranchingStoryResponse;
-        message: string;
-      }) => {
+      transformResponse: (response: BranchingStoryApiResponse) => {
         return { data: response.data, message: response.message };
       },
     }),


### PR DESCRIPTION
## What this PR does

The branching story feature was broken because the backend returned `{ story, provider, fallbackUsed }` while the frontend expected `{ data: { storySegment, choices, segmentIndex }, message }`.

The backend fix was already applied in commit `954fc879` to return the correct `sendResponse`-wrapped JSON. This PR completes the fix by correcting the frontend type annotations to match the actual response shape.

### Changes

**Frontend type fix (branching.story.api.ts)**
- Add `BranchingStoryApiResponse` interface that accurately mirrors the backend's `sendResponse` return type (`success`, `statusCode`, `message`, `data`)
- Update `transformResponse` to use the correct interface instead of a mismatched inline type

## Related issue

Closes #1746

## Type of change

- [x] Bug fix

## Screenshots

N/A — type-only change.

## Checklist

- [ ] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.