### PR TITLE
Fix: Long story titles overflow on story cards in mobile view

### DIFF
--- a/frontend/src/components/cards/CardCollection.tsx
+++ b/frontend/src/components/cards/CardCollection.tsx
@@ -68,7 +68,7 @@ const CardCollection: React.FC<CardCollectionProps> = ({
               }`}
             >
               <StoryTradingCard story={story} compact />
-              <p className="mt-2 line-clamp-1 text-xs font-bold text-slate-200">
+              <p className="mt-2 line-clamp-2 break-words text-xs font-bold text-slate-200 overflow-hidden text-ellipsis">
                 {story.title}
               </p>
               <p className="text-[10px] uppercase tracking-wider text-slate-500">

--- a/frontend/src/components/cards/StoryTradingCard.tsx
+++ b/frontend/src/components/cards/StoryTradingCard.tsx
@@ -247,7 +247,7 @@ const StoryTradingCard: React.FC<StoryTradingCardProps> = ({
               <p className="text-[10px] font-black uppercase tracking-[0.28em] text-white/50">
                 StorySpark Card
               </p>
-              <h3 className="line-clamp-1 text-lg font-black text-white">
+              <h3 className="line-clamp-2 break-words text-lg font-black text-white overflow-hidden text-ellipsis">
                 {story.title}
               </h3>
             </div>

--- a/frontend/src/components/dashboard/posts/published_stories.component.tsx
+++ b/frontend/src/components/dashboard/posts/published_stories.component.tsx
@@ -195,7 +195,7 @@ const PublishedStoriesComponent: React.FC = () => {
                     onClick={() => navigate(`/post/${story._id}`)}
                     className="text-left"
                   >
-                    <h3 className="line-clamp-2 text-lg font-black text-slate-900 transition hover:text-blue-600 dark:text-white dark:hover:text-blue-300">
+                    <h3 className="line-clamp-2 break-words text-lg font-black text-slate-900 transition hover:text-blue-600 dark:text-white dark:hover:text-blue-300 overflow-hidden text-ellipsis">
                       {story.title}
                     </h3>
                   </button>

--- a/frontend/src/components/home/community_spotlight/community_spotlight.component.tsx
+++ b/frontend/src/components/home/community_spotlight/community_spotlight.component.tsx
@@ -190,7 +190,7 @@ const CommunitySpotlightComponent = () => {
                       <p className="mb-1 text-xs font-semibold uppercase tracking-[0.14em] text-slate-500 dark:text-gray-500">
                         Top story
                       </p>
-                      <h4 className="line-clamp-2 text-base font-semibold leading-6 text-slate-900 transition-colors group-hover:text-blue-600 dark:text-gray-100 dark:group-hover:text-blue-300">
+                      <h4 className="line-clamp-2 break-words text-base font-semibold leading-6 text-slate-900 transition-colors group-hover:text-blue-600 dark:text-gray-100 dark:group-hover:text-blue-300 overflow-hidden text-ellipsis">
                         {writer.topPost.title}
                       </h4>
                     </div>
@@ -255,7 +255,7 @@ const CommunitySpotlightComponent = () => {
                           </p>
                         </div>
                       </div>
-                      <h4 className="mb-2 text-base sm:text-lg font-bold text-slate-900 dark:text-slate-100 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors tracking-tight line-clamp-1">
+                      <h4 className="mb-2 line-clamp-2 break-words text-base sm:text-lg font-bold text-slate-900 dark:text-slate-100 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors tracking-tight overflow-hidden text-ellipsis">
                         {post.title}
                       </h4>
                       <p className="line-clamp-3 text-xs sm:text-sm text-slate-600 dark:text-slate-400 font-medium leading-relaxed">

--- a/frontend/src/components/home/feature/feature.component.tsx
+++ b/frontend/src/components/home/feature/feature.component.tsx
@@ -110,7 +110,7 @@ const FeatureComponent = () => {
                       </div>
                     </div>
 
-                    <h3 className="text-xl font-bold text-slate-900 dark:text-slate-100 mb-2 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors tracking-tight line-clamp-1">
+                    <h3 className="text-xl font-bold text-slate-900 dark:text-slate-100 mb-2 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors tracking-tight line-clamp-2 break-words overflow-hidden text-ellipsis">
                       {post.title}
                     </h3>
 

--- a/frontend/src/components/post/post.view.list.component.tsx
+++ b/frontend/src/components/post/post.view.list.component.tsx
@@ -112,7 +112,7 @@ const ExploreViewListComponent: React.FC<IExploreViewListComponentProps> = ({
               </div>
 
               <div className="px-6 py-5 flex-1 flex flex-col relative z-10">
-                <h3 className="font-extrabold text-xl mb-3 text-slate-900 group-hover:text-indigo-600 transition-colors line-clamp-2 dark:text-white dark:group-hover:text-indigo-400">
+                <h3 className="font-extrabold text-xl mb-3 text-slate-900 group-hover:text-indigo-600 transition-colors line-clamp-2 break-words overflow-hidden text-ellipsis dark:text-white dark:group-hover:text-indigo-400">
                   {story.title}
                 </h3>
 

--- a/frontend/src/components/post/related.stories.view.component.tsx
+++ b/frontend/src/components/post/related.stories.view.component.tsx
@@ -36,7 +36,7 @@ const RelatedStoriesComponent: React.FC<IRelatedStoriesComponentProps> = ({
               <div className="absolute inset-0 bg-gradient-to-t from-slate-900/40 to-transparent pointer-events-none"></div>
             </div>
             <div className="p-5 flex flex-col flex-1">
-              <h4 className="font-bold text-lg mb-2 text-slate-100 group-hover:text-blue-400 transition-colors line-clamp-2">
+              <h4 className="font-bold text-lg mb-2 text-slate-100 group-hover:text-blue-400 transition-colors line-clamp-2 break-words overflow-hidden text-ellipsis">
                 {post.title}
               </h4>
               <p className="text-sm text-slate-400 line-clamp-3 leading-relaxed">


### PR DESCRIPTION
## Screenshot (when helpful)

N/A – UI change not demonstrated with screenshots yet.

## What this PR does
issue #3252 
Fixes an issue where very long story titles could overflow their containers on mobile devices and break the story card layout.

The update adds proper text handling using wrapping and line clamping to ensure titles remain within card boundaries. Overflow is prevented while maintaining consistent card heights and readability across different screen sizes.

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

## Related issue

Fixes #<issue-number>

## More screenshots (optional)

N/A

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.
