### PR TITLE
fix(collab): replace stale in-memory room references in Yjs socket events (#3258)

### DIFF
--- a/backend/src/socket/collab.socket.ts
+++ b/backend/src/socket/collab.socket.ts
@@ -161,36 +161,50 @@ export const setupCollabSocket = (io: Server) => {
     });
 
     // Yjs document updates
-socket.on("collab:yjs-update", ({ roomId, update }) => {
-  const room = rooms.get(roomId);
+    socket.on("collab:yjs-update", async ({ roomId, update }) => {
+      try {
+        const userId = socket.data.userId;
+        const room = await CollabRoom.findOne({ roomId });
+        if (!room) {
+          socket.emit("collab:error", { message: "Room not found" });
+          return;
+        }
 
-  if (!room) {
-    socket.emit("collab:error", {
-      message: "Room not found",
+        const participant = room.participants.find((p) => p.userId === userId);
+        if (!participant) {
+          socket.emit("collab:error", { message: "You are not a participant of this room" });
+          return;
+        }
+
+        socket.to(roomId).emit("collab:yjs-update", { update });
+      } catch (error) {
+        logger.error("Error in Yjs update", error);
+        socket.emit("collab:error", { message: "Failed to broadcast update" });
+      }
     });
-    return;
-  }
 
-  socket.to(roomId).emit("collab:yjs-update", {
-    update,
-  });
-});
+    // Awareness / cursor updates
+    socket.on("collab:awareness", async ({ roomId, awareness }) => {
+      try {
+        const userId = socket.data.userId;
+        const room = await CollabRoom.findOne({ roomId });
+        if (!room) {
+          socket.emit("collab:error", { message: "Room not found" });
+          return;
+        }
 
-// Awareness / cursor updates
-socket.on("collab:awareness", ({ roomId, awareness }) => {
-  const room = rooms.get(roomId);
+        const participant = room.participants.find((p) => p.userId === userId);
+        if (!participant) {
+          socket.emit("collab:error", { message: "You are not a participant of this room" });
+          return;
+        }
 
-  if (!room) {
-    socket.emit("collab:error", {
-      message: "Room not found",
+        socket.to(roomId).emit("collab:awareness", { awareness });
+      } catch (error) {
+        logger.error("Error in Yjs awareness", error);
+        socket.emit("collab:error", { message: "Failed to broadcast awareness" });
+      }
     });
-    return;
-  }
-
-  socket.to(roomId).emit("collab:awareness", {
-    awareness,
-  });
-});
 
     // AI continues the story
     socket.on("collab:ai_continue", async ({ roomId }) => {


### PR DESCRIPTION
## 📌 Description

This PR fixes a critical realtime collaboration bug where Yjs synchronization events (`collab:yjs-update` and `collab:awareness`) could crash the Socket.IO server due to stale references to a removed in-memory `rooms` map.

Previously, the collaborative room lifecycle was migrated to MongoDB persistence, but the Yjs event handlers still attempted to access room state through `rooms.get(roomId)`, which no longer exists.

This caused:

- runtime `ReferenceError` crashes
- broken Yjs document synchronization
- failed awareness/cursor updates
- realtime collaborative editing failures

This implementation replaces the stale in-memory dependency with database-backed room validation while preserving the existing socket contract.

---

## 🔗 Related Issue

Closes #3258

---

## ✨ What This PR Does

### 🛠 Removes Stale `rooms` Dependency

Replaced:

```text
rooms.get(roomId)
```

with MongoDB room lookups.

This ensures:

- room state is fetched from the current source of truth
- removed in-memory references are no longer used
- runtime crashes are eliminated

---

### 👥 Participant Authorization Validation

Added participant validation before allowing Yjs events to broadcast.

This ensures:

- only room participants can emit updates
- unauthorized socket events are blocked safely
- room-level integrity is preserved

---

### 🔄 Yjs Update Stability

Protected:

```text
collab:yjs-update
```

and:

```text
collab:awareness
```

against invalid room access and runtime failures.

This preserves:

- document synchronization
- cursor awareness
- collaborative editing stability

---

### 🚨 Error Handling Improvements

Added guarded error handling for:

- missing rooms
- unauthorized users
- failed database lookups
- unexpected socket failures

Errors now return through:

```text
collab:error
```

instead of crashing the websocket process.

---

## 🧪 Validation & Testing

### Verified Scenarios

| Scenario | Status |
|---|---|
| Valid participant Yjs update | ✅ |
| Valid participant awareness update | ✅ |
| Invalid roomId handling | ✅ |
| Unauthorized participant blocked | ✅ |
| Socket server remains stable | ✅ |
| Yjs sync preserved | ✅ |
| Awareness sync preserved | ✅ |

---

## ⚡ Impact

- No frontend changes
- No event name changes
- No payload changes
- No schema changes
- Fully backward compatible
- Realtime stability improved

Modified file:

```text
backend/src/socket/collab.socket.ts
```

---

## ✅ Checklist

- [x] Bug fix
- [x] Tested locally
- [x] Self-reviewed changes
- [x] Related issue linked
- [x] Removed stale room references
- [x] Added participant validation
- [x] Added safe error handling
- [x] No breaking changes introduced

---

## 🚀 Notes for Reviewers

This fix intentionally keeps the change isolated to the Yjs socket event layer.

It removes the stale in-memory room dependency introduced after the MongoDB room migration and restores safe realtime synchronization without changing the frontend socket API or collaborative editing flow.