### PR TITLE
fix(post): decrement original author postsCount instead of admin on delete (#3259)

### DIFF
--- a/backend/src/app/modules/post/post.service.ts
+++ b/backend/src/app/modules/post/post.service.ts
@@ -506,7 +506,7 @@ const deletePost = async (postId: string, token: ITokenPayload) => {
 
   if (post.isPublished) {
     await User.findByIdAndUpdate(
-      user._id,
+      post.author,
       { $inc: { postsCount: -1 } }
     );
   }


### PR DESCRIPTION
## 📌 Description

This PR fixes a critical data integrity bug in the post deletion lifecycle where deleting a published story decremented the `postsCount` of the user performing the deletion instead of the original post author.

Previously, when an administrator or moderator deleted another user's published post, the system incorrectly updated the authenticated moderator’s profile statistics, causing profile corruption and incorrect author metrics.

This fix ensures the decrement operation targets the actual story author while preserving the existing moderation and soft-delete flow.

---

## 🔗 Related Issue

Closes #3259

---

## ✨ What This PR Does

### Correct Author Stats Decrement

Fixed the `deletePost()` lifecycle by replacing:

```text
user._id
```

with:

```text
post.author
```

This ensures:

- the original author’s `postsCount` is decremented
- moderator/admin profile stats remain unchanged
- post ownership metrics stay consistent

---

### Prevents Silent Profile Corruption

Before:

- admin deleting someone else's post reduced admin stats
- original author stats remained stale
- profile counters could become negative

After:

- only the real author loses the published post count
- admin/moderator profiles stay intact
- profile metrics remain accurate

---

### Preserves Existing Delete Flow

This fix does NOT modify:

- soft-delete behavior
- authorization logic
- moderation permissions
- delete API responses

It only corrects the update target.

---

## 🧪 Validation & Testing

### Verified Scenarios

| Scenario | Status |
|---|---|
| Author deletes own published post | ✅ |
| Admin deletes another user's published post | ✅ |
| Unpublished post deletion | ✅ |
| Already deleted post handling | ✅ |
| Soft delete flow preserved | ✅ |
| Profile stats remain correct | ✅ |

---

## ⚡ Impact

- No API changes
- No schema changes
- No frontend changes
- Fully backward compatible
- Minimal isolated backend fix

Modified file:

```text
backend/src/app/modules/post/post.service.ts
```

---

## ✅ Checklist

- [x] Bug fix
- [x] Tested locally
- [x] Self-reviewed changes
- [x] Related issue linked
- [x] Fixed incorrect decrement target
- [x] Preserved moderation flow
- [x] Preserved soft delete logic
- [x] No breaking changes introduced

---

## 🚀 Notes for Reviewers

This is a small but critical integrity fix.

It resolves silent user profile corruption caused during administrative post deletion by ensuring post ownership statistics remain consistent across moderation workflows.