### PR TITLE
fix: resolve explore page input overflow issue

### DIFF
--- a/frontend/src/components/post/post.component.tsx
+++ b/frontend/src/components/post/post.component.tsx
@@ -107,7 +107,7 @@ export const ExploreComponent = () => {
         {/* Main Layout */}
         <div className="flex flex-col md:flex-row gap-8">
           {/* Sidebar */}
-          <div className="w-full md:w-64 flex-shrink-0">
+          <div className="w-full md:w-64 md:min-w-64 flex-shrink-0">
             <div className="sticky top-4 bg-gray-50 border border-gray-200 text-slate-900 backdrop-blur-xl rounded-2xl p-6 shadow-xl z-10 transition-colors duration-300 dark:bg-slate-900/50 dark:border-none dark:text-white">
               <div className="flex justify-between items-center mb-4">
                 <h3 className="text-lg font-bold text-slate-900 dark:text-white">
@@ -211,8 +211,8 @@ export const ExploreComponent = () => {
           {/* Content */}
           <div className="flex-1 flex flex-col min-h-[70vh]">
             <div className={`${featuredPost ? "mb-6" : ""}`}>
-              <div className="flex justify-between items-center">
-                <div className="flex space-x-4 items-center overflow-x-auto">
+              <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+                <div className="flex flex-wrap gap-4 items-center">
                   <h2
                     onClick={() => setFeaturedPost(false)}
                     className={`text-3xl font-extrabold mb-6 cursor-pointer transition-all duration-300 ${


### PR DESCRIPTION
Hi maintainers,

The failing CI checks appear to be unrelated to this PR.

This contribution only updates:

`frontend/src/components/post/post.component.tsx`

to improve responsive behavior and prevent overflow issues on the Explore page.

The reported failures originate from unrelated files, including:

Frontend:

* `src/components/stories/stories.component.tsx`
* `src/components/story-map/StoryWorldMap.tsx`
* `src/hooks/useSpeechSynthesis.ts`

Backend:

* `src/app/modules/ai_model/*`
* `src/app/modules/newsletter/*`
* `src/socket/*`
* `src/utils/*`

Additionally, the lint workflow reports an outdated lockfile (`ERR_PNPM_OUTDATED_LOCKFILE`) involving backend dependency changes.

These files were not modified as part of this contribution.

Thank you for your review.
