### PR TITLE
fix: remove hardcoded static content from React root div in index.html

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -49,12 +49,7 @@
     </div>
   </div>
 </noscript>
-    <div id="root">
-      <h1 class="ds-heading">
-        <span>Story</span>
-        <span>Inspiration Hub</span>
-      </h1>
-    </div>
+    <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
 
   </body>


### PR DESCRIPTION
## Screenshot (when helpful)

N/A

## What this PR does

Removed hardcoded static HTML content from inside the React root div in index.html. React replaces everything inside #root on mount — the static content caused a brief flash of unstyled "Story Inspiration Hub" text before the actual app loaded.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Fixes #3279 

## More screenshots (optional)

N/A — this is a code-only change. The static content 
inside #root div is replaced by React on mount anyway, but causes a brief flash before React loads.

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
