### PR TITLE
feat(explore): add persistent mark as read checkbox

### DIFF
--- a/frontend/src/components/post/post.view.list.component.tsx
+++ b/frontend/src/components/post/post.view.list.component.tsx
@@ -16,6 +16,37 @@ const ExploreViewListComponent: React.FC<IExploreViewListComponentProps> = ({
 }) => {
   const navigate = useNavigate();
   const [imageErrors, setImageErrors] = useState<Record<string, boolean>>({});
+  const [readStories, setReadStories] = useState<Record<string, boolean>>(() => {
+    const readMap: Record<string, boolean> = {};
+    try {
+      for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        if (key && key.startsWith("story-read-")) {
+          const storyId = key.replace("story-read-", "");
+          readMap[storyId] = localStorage.getItem(key) === "true";
+        }
+      }
+    } catch (e) {
+      console.error("Error reading localStorage", e);
+    }
+    return readMap;
+  });
+
+  const handleToggleRead = (storyId: string) => {
+    setReadStories((prev) => {
+      const newValue = !prev[storyId];
+      try {
+        if (newValue) {
+          localStorage.setItem(`story-read-${storyId}`, "true");
+        } else {
+          localStorage.removeItem(`story-read-${storyId}`);
+        }
+      } catch (e) {
+        console.error("Error updating localStorage", e);
+      }
+      return { ...prev, [storyId]: newValue };
+    });
+  };
 
   const handleImageError = (storyId: string) => {
     setImageErrors((prev) => ({ ...prev, [storyId]: true }));
@@ -92,14 +123,32 @@ const ExploreViewListComponent: React.FC<IExploreViewListComponentProps> = ({
 
                 <div className="absolute inset-0 bg-gradient-to-t from-gray-50 via-transparent to-transparent opacity-100 pointer-events-none dark:from-slate-900/90 dark:via-transparent dark:to-transparent"></div>
 
-                <div className="absolute top-4 right-4 z-10" onClick={(e) => e.stopPropagation()}>
+                <div className="absolute top-4 right-4 z-10 flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
+                  <label className="flex items-center gap-1.5 backdrop-blur-md bg-white/10 dark:bg-black/25 border border-white/20 hover:bg-white/25 px-2.5 py-1.5 rounded-full shadow-lg cursor-pointer select-none transition-all duration-300">
+                    <input
+                      type="checkbox"
+                      className="sr-only"
+                      checked={!!readStories[story._id]}
+                      onChange={() => handleToggleRead(story._id)}
+                    />
+                    <div className={`w-3.5 h-3.5 rounded border flex items-center justify-center transition-all ${
+                      readStories[story._id]
+                        ? "bg-indigo-600 border-indigo-500 text-white"
+                        : "border-white/40 bg-transparent text-transparent"
+                    }`}>
+                      <i className="fas fa-check text-[8px]"></i>
+                    </div>
+                    <span className="text-[10px] font-extrabold uppercase tracking-wider text-white">
+                      Read
+                    </span>
+                  </label>
                   <BookmarkButton
                     storyId={story._id}
                     className="backdrop-blur-md bg-white/10 dark:bg-black/20 border border-white/20 hover:bg-white/30 p-2 !rounded-full shadow-lg hover:scale-110 transition-all duration-300"
                   />
                 </div>
 
-                <div className="absolute top-4 left-4 flex gap-1.5 flex-wrap max-w-[80%]">
+                <div className="absolute top-4 left-4 flex gap-1.5 flex-wrap max-w-[55%]">
                   <span className="inline-flex items-center px-2 py-0.5 bg-indigo-600 border border-indigo-500/50 text-white text-[9px] font-bold uppercase tracking-wider rounded-full shadow-lg max-w-[120px] truncate">
                     {story.tag}
                   </span>


### PR DESCRIPTION
## Screenshot (when helpful)

N/A

---

## What this PR does

Adds a **"Mark as Read"** checkbox to story cards in the Explore section.

### Changes made:

* Added a "Mark as Read" checkbox alongside the bookmark action.
* Persisted read status using localStorage.
* Restored saved read states when the component loads.
* Prevented checkbox interactions from triggering story navigation.
* Adjusted layout spacing to ensure the new control fits cleanly within the card UI.

This allows users to keep track of stories they have already read and retain that status across visits.

---

## Type of change

* [ ] Bug fix
* [x] New feature
* [ ] Code refactor
* [ ] Documentation update

---

## Related issue

Closes #957

---

## More screenshots (optional)

N/A

---

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have done a self-review of the code.
