### PR TITLE
fix(post): decrement post author's postsCount instead of deleting user's ID

### DIFF
--- a/backend/src/app/modules/post/post.service.ts
+++ b/backend/src/app/modules/post/post.service.ts
@@ -506,7 +506,7 @@ const deletePost = async (postId: string, token: ITokenPayload) => {
 
   if (post.isPublished) {
     await User.findByIdAndUpdate(
-      user._id,
+      post.author,
       { $inc: { postsCount: -1 } }
     );
   }


### PR DESCRIPTION
## Related issue
Closes #3259

## What this PR does
Fixes a data integrity bug in `deletePost()` where deleting a published story always decremented the **logged-in user's** `postsCount`, instead of the **original post author's** `postsCount`.

This only showed up when the deleting user was different from the author — i.e. when an admin or moderator deleted someone else's published post. In that case:
- The admin/moderator's own `postsCount` was incorrectly decremented (even though they never owned that post).
- The actual author's `postsCount` was left unchanged, leaving stale/incorrect profile stats.
- Repeated admin deletions could push an admin's `postsCount` into negative numbers.

### The fix
In `backend/src/app/modules/post/post.service.ts`, inside `deletePost()`:

```diff
  if (post.isPublished) {
    await User.findByIdAndUpdate(
-     user._id,
+     post.author,
      { $inc: { postsCount: -1 } }
    );
  }
```

`user._id` is the person performing the delete action (could be the author, an admin, or a super_admin). `post.author` is the actual owner of the content. The decrement should always target the latter.

No other logic was touched:
- Authorization checks earlier in the function still correctly use `user._id` (these determine *who is allowed* to delete, which is unrelated to *whose stats get updated*).
- `post.deletedBy = user._id` is untouched — that's correctly tracking who performed the moderation action, separate from the stats bug.
- Soft-delete behavior, bookmark cleanup, and the delete API response are all unchanged.

## How this was tested
Manually verified the reproduction steps from the issue, since `post.service.ts` currently has no existing automated test coverage:

1. User A registers, creates, and publishes a post (`postsCount: 1`).
2. Admin B deletes User A's post via the delete endpoint.
3. Checked both users directly in MongoDB:
   - User A's `postsCount` correctly drops to `0`.
   - Admin B's `postsCount` remains unchanged.

Also verified: an author deleting their own post still works as before (no regression there, since `user._id === post.author` in that case).

## Note on build/lint checks
`npm run build -w backend` (`tsc`) currently fails on `main` with 30 pre-existing TypeScript errors across 10 unrelated files (`newsletter.controller.ts`, `user.interface.ts`, `collab.socket.ts`, etc.). Confirmed via `git stash` that these errors exist identically with this fix removed — none involve `post.service.ts` or this change. Flagging so it isn't mistaken for something this PR introduced.

The root-level `npm run lint` similarly fails due to ~48 pre-existing ESLint/parsing errors in unrelated frontend files. Backend has no `lint` script configured.

## Screenshot
N/A — backend-only data fix, verified via manual MongoDB inspection (see "How this was tested" above).

## Checklist
- [x] Bug fix
- [x] Tested locally (manual reproduction steps, see above)
- [x] Self-reviewed changes
- [x] Related issue linked
- [x] Fixed incorrect decrement target (`user._id` → `post.author`)
- [x] Preserved authorization/moderation logic
- [x] Preserved soft-delete logic
- [x] No breaking changes introduced
- [x] No API, schema, or frontend changes