### PR TITLE
fix: remove orphan <ExploreViewListComponent> from Generated Drafts tab (#3330)

### DIFF
--- a/frontend/src/components/post/bookmarks.component.tsx
+++ b/frontend/src/components/post/bookmarks.component.tsx
@@ -126,23 +126,6 @@ const BookmarksComponent = () => {
                 </p>
               </div>
               {activeTab === "posts" && allPosts.length > 0 && (
-                <div className="flex items-center space-x-4">
-                  <label className="text-sm font-semibold text-slate-500 uppercase tracking-wider dark:text-gray-400">Show</label>
-                  <select
-                    className="!rounded-xl border border-slate-200 text-sm focus:ring-2 focus:ring-indigo-500/20 bg-white text-slate-700 py-1.5 px-3 outline-none transition-all cursor-pointer shadow-sm hover:border-slate-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300"
-                    value={size}
-                    onChange={(e) => {
-                      setSize(Number(e.target.value));
-                      setPage(1);
-                    }}
-                  >
-                    <option value={10}>10</option>
-                    <option value={25}>25</option>
-                    <option value={50}>50</option>
-                    <option value={100}>100</option>
-                  </select>
-                  <span className="text-sm font-semibold text-slate-500 uppercase tracking-wider dark:text-gray-400">entries</span>
-              {allPosts.length > 0 && (
                 <div className="flex flex-wrap items-center gap-4">
                   <div className="flex items-center space-x-2">
                     <label className="text-sm font-semibold text-slate-500 uppercase tracking-wider dark:text-gray-400">Sort By</label>
@@ -179,7 +162,6 @@ const BookmarksComponent = () => {
                   </div>
                 </div>
               )}
-            </div>
 
             {/* Tabs for Published vs Generated */}
             <div className="flex gap-4 mb-8 border-b border-slate-200/50 dark:border-slate-700/50 pb-3">
@@ -231,7 +213,7 @@ const BookmarksComponent = () => {
                   </div>
                 ) : (
                   <ExploreViewListComponent
-                    posts={filteredPosts}
+                    posts={sortedPosts}
                     isLoading={isLoading}
                   />
                 )
@@ -262,10 +244,6 @@ const BookmarksComponent = () => {
                     ))}
                   </div>
                 )
-                <ExploreViewListComponent
-                  posts={sortedPosts}
-                  isLoading={isLoading}
-                />
               )}
             </div>
 


### PR DESCRIPTION
In `bookmarks.component.tsx` (lines ~258-269), an `<ExploreViewListComponent>` was placed outside the ternary branches but still inside the `activeTab === 'generated'` block, causing published-story bookmarks (`sortedPosts`) to always render below the Generated Drafts tab content.
**Changes:**
- Removed orphan `<ExploreViewListComponent>` from the generated tab block
- Fixed duplicate/broken Sort By + Show entries header (leftover merge artifact)
- Updated posts tab to use `sortedPosts` instead of `filteredPosts` so client-side sorting is correctly applied
Fixes #3330
## Screenshot (when helpful)
N/A — logic/render fix, no UI layout changes.
## What this PR does
The `Generated Drafts` tab was incorrectly rendering a full `<ExploreViewListComponent posts={sortedPosts}>` below the session story trading cards on every render, leaking published-story bookmarks into the wrong tab. This PR removes the 4 orphan lines and also fixes a broken duplicate Sort By + Show header left from a prior merge conflict.
## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
## Related issue
Fixes #3330
## More screenshots (optional)
N/A
## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.