### PR TITLE
feat(home): add scrolling picture carousel to fill empty right-side space

### DIFF
--- a/frontend/src/components/home/home.component.tsx
+++ b/frontend/src/components/home/home.component.tsx
@@ -13,6 +13,7 @@ import PersonalizedRecommendationsComponent from "./personalized_recommendations
 import { isLoggedIn } from "../../services/auth.service";
 import BackToTop from "../ScrollToTopButton";
 import StoryInspirationHomeCard from "./story_inspiration_card/StoryInspirationHomeCard";
+import PictureCarouselComponent from "./picture_carousel/picture_carousel.component";
 
 const containerVariants = {
   hidden: { opacity: 0 },
@@ -57,6 +58,7 @@ const HomeComponent = () => {
 
         <aside className="col-span-12 lg:col-span-4 min-w-0 w-full box-border">
           <div className="space-y-6 lg:sticky lg:top-24 w-full box-border">
+            <PictureCarouselComponent />
             {isLogin && <FeatureProfileComponent />}
             {isLogin && <PersonalizedRecommendationsComponent />}
             <StoryInspirationHomeCard />

--- a/frontend/src/components/home/picture_carousel/picture_carousel.component.tsx
+++ b/frontend/src/components/home/picture_carousel/picture_carousel.component.tsx
@@ -1,0 +1,74 @@
+import { useMemo } from "react";
+
+interface CarouselImage {
+    src: string;
+    alt: string;
+}
+
+// Decorative placeholder images. Swap these for real story-cover URLs
+// or curated assets whenever the project has a source for them.
+const CAROUSEL_IMAGES: CarouselImage[] = [
+    { src: "https://picsum.photos/seed/story-spark-1/240/160", alt: "" },
+    { src: "https://picsum.photos/seed/story-spark-2/240/160", alt: "" },
+    { src: "https://picsum.photos/seed/story-spark-3/240/160", alt: "" },
+    { src: "https://picsum.photos/seed/story-spark-4/240/160", alt: "" },
+    { src: "https://picsum.photos/seed/story-spark-5/240/160", alt: "" },
+    { src: "https://picsum.photos/seed/story-spark-6/240/160", alt: "" },
+];
+
+const PictureCarouselComponent = () => {
+    // Duplicate the list so the marquee loop wraps seamlessly at 50% scroll.
+    const trackImages = useMemo(
+        () => [...CAROUSEL_IMAGES, ...CAROUSEL_IMAGES],
+        []
+    );
+
+    return (
+        <div className="relative w-full overflow-hidden rounded-2xl border border-slate-200 bg-white p-4 shadow-sm transition-colors duration-300 dark:border-slate-800 dark:bg-slate-900">
+            <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                From the Community
+            </h3>
+
+            <div className="group relative overflow-hidden rounded-xl">
+                {/* Edge fades so the loop point doesn't look abrupt */}
+                <div className="pointer-events-none absolute inset-y-0 left-0 z-10 w-8 bg-gradient-to-r from-white to-transparent dark:from-slate-900" />
+                <div className="pointer-events-none absolute inset-y-0 right-0 z-10 w-8 bg-gradient-to-l from-white to-transparent dark:from-slate-900" />
+
+                {/* Purely decorative, so it's hidden from assistive tech */}
+                <div
+                    aria-hidden="true"
+                    className="picture-carousel-track flex w-max gap-3 group-hover:[animation-play-state:paused]"
+                >
+                    {trackImages.map((image, index) => (
+                        <img
+                            key={`${image.src}-${index}`}
+                            src={image.src}
+                            alt={image.alt}
+                            loading="lazy"
+                            className="h-24 w-36 flex-shrink-0 rounded-lg object-cover sm:h-28 sm:w-40"
+                        />
+                    ))}
+                </div>
+            </div>
+
+            <style>{`
+        .picture-carousel-track {
+          animation: picture-carousel-scroll 25s linear infinite;
+        }
+
+        @keyframes picture-carousel-scroll {
+          from { transform: translateX(0); }
+          to { transform: translateX(-50%); }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+          .picture-carousel-track {
+            animation: none;
+          }
+        }
+      `}</style>
+        </div>
+    );
+};
+
+export default PictureCarouselComponent;


### PR DESCRIPTION
## Related issue
Closes #2114

## What this PR does
Adds a horizontally auto-scrolling picture carousel to the home page sidebar, filling the empty space next to the "Latest Post" section described in the issue — especially noticeable for logged-out users, where the sidebar previously skipped both `FeatureProfileComponent` and `PersonalizedRecommendationsComponent` and left a large gap above `StoryInspirationHomeCard`.

### New component
`frontend/src/components/home/picture_carousel/picture_carousel.component.tsx`

- Renders a row of images that scrolls continuously and loops seamlessly (the image list is duplicated and the track translates by exactly 50%, so the wrap point is invisible).
- Pauses on hover, so users can stop and look at an image without it sliding away mid-glance.
- Respects `prefers-reduced-motion`: the animation is disabled entirely for users who've set that preference.
- Marked `aria-hidden="true"` since it's purely decorative filler, not informational content, so it doesn't add noise for screen reader users.
- Uses placeholder images from picsum.photos for now (clearly commented in the file) — happy to swap these for real story-cover images or curated assets if maintainers have a preferred source.
- Built with plain Tailwind + a small scoped `<style>` block for the marquee keyframes — no new dependencies added. (`framer-motion`-style variant objects already exist unused in `home.component.tsx`; I left those untouched since they aren't wired to anything and are out of scope for this change.)

### Layout integration
In `home.component.tsx`:
- Added one import for the new component.
- Inserted `<PictureCarouselComponent />` as the first item in the sidebar's `space-y-6` container, so it's always visible regardless of login state.

No other lines were changed.

## How this addresses the acceptance criteria
- **Fills the empty space** — sits directly in the previously sparse area of the sidebar.
- **Responsive** — the sidebar is `col-span-4` on desktop (`lg:`) and `col-span-12` (full width, stacked below the main column) on smaller screens; a horizontal scrolling strip works naturally at both, so no separate mobile/desktop logic was needed.
- **Light/dark theme** — uses the same `slate` palette and `dark:` class conventions already used throughout `home.component.tsx` (borders, background, text colors all have light/dark pairs).

## How this was tested
Ran `npm run dev -w frontend` and manually checked:
- Home page in logged-out state (sidebar previously had the most visible gap) and logged-in state.
- Light mode and dark mode toggle.
- Resized down to mobile width to confirm the carousel reflows to full width and keeps scrolling smoothly.
- Hovered over the carousel to confirm it pauses, then resumes on mouse-leave.
- Enabled "reduce motion" in OS accessibility settings and confirmed the animation stops entirely.

Also ran `npx eslint` scoped to just the two touched files (`picture_carousel.component.tsx` and `home.component.tsx`) since the project's frontend lint currently fails on `main` due to pre-existing errors in unrelated files — both touched files lint clean.

## Screenshot
<!-- Add a screenshot/recording here showing the carousel in light + dark mode before opening the PR -->

## Checklist
- [x] New feature
- [x] Tested locally (manual, see above)
- [x] Self-reviewed changes
- [x] Related issue linked
- [x] Fully responsive (mobile/tablet/desktop)
- [x] Light and dark theme support
- [x] Accessible (reduced-motion respected, decorative content marked `aria-hidden`)
- [x] No new dependencies
- [x] No breaking changes introduced