### PR TITLE
fix: move rate limiter after CORS to prevent preflight quota consumption and remove dead Cookie from allowedHeaders

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -17,14 +17,6 @@ const app: Application = express();
 app.set("trust proxy", 1);
 app.use(helmet());
 
-const limiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  max: 100,
-  message: "Too many requests, please try again later.",
-});
-
-app.use(limiter);
-
 const defaultCorsOrigins =
   process.env.NODE_ENV === "development"
     ? ["http://localhost:4001", "http://localhost:4002"]
@@ -50,9 +42,18 @@ app.use(
     },
     credentials: true,
     methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-    allowedHeaders: ["Content-Type", "Authorization", "X-Requested-With", "Cookie"],
+    allowedHeaders: ["Content-Type", "Authorization", "X-Requested-With"],
   })
 );
+
+// Rate limiter — placed after CORS so OPTIONS preflight requests are
+// never counted against the limit before CORS has a chance to respond.
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100,
+  message: "Too many requests, please try again later.",
+});
+app.use(limiter);
 
 // ─── 1. FIXED: ENFORCED HARDENED PAYLOAD LIMITS TO PREVENT DoS ───
 app.use(express.json({ limit: "2mb" }));


### PR DESCRIPTION
## Summary
Two fixes in app.ts — one corrects middleware ordering so CORS
preflight requests are never rate-limited, the other removes a dead
and misleading entry from allowedHeaders.

## Bug 1— Rate limiter before CORS
Moved the rateLimit middleware registration to after the CORS block.
OPTIONS preflight requests now receive proper CORS headers regardless
of traffic volume. Rate limiting still applies to all subsequent
non-preflight requests as intended.

## Bug 2 — Dead Cookie in allowedHeaders
Removed "Cookie" from the allowedHeaders array. It is a browser-
forbidden header that can never appear in a CORS preflight and has
no effect. Cookie transmission is handled by credentials: true.

## Changes
- backend/src/app.ts

Closes #3345 