### PR TITLE
fix: add min(1) constraints to storyContext and selectedChoice in branching story Zod schema to prevent empty string bypass

### DIFF
--- a/backend/src/routes/stories.ts
+++ b/backend/src/routes/stories.ts
@@ -9,13 +9,17 @@ const router = express.Router();
 
 const branchingStorySchema = z.object({
   body: z.object({
-    storyContext: z.string({ required_error: "storyContext is required!" }).max(8000),
+    storyContext: z
+      .string({ required_error: "storyContext is required!" })
+      .min(1, "storyContext cannot be empty")
+      .max(8000, "storyContext must not exceed 8000 characters"),
 
     selectedChoice: z
       .string({ required_error: "selectedChoice is required!" })
+      .min(1, "selectedChoice cannot be empty")
       .max(500, "selectedChoice must not exceed 500 characters"),
 
-    genre: z.string().max(120).optional(),
+    genre: z.string().min(1, "genre cannot be empty").max(120).optional(),
   }),
 });
 


### PR DESCRIPTION
## Summary
Fixes the branching story Zod schema in stories.ts where storyContext
and selectedChoice accepted empty strings despite being declared as
required, allowing blank inputs to reach the AI generation controller.

## Problem
z.string() with only max() allows empty strings. required_error only
fires when the field is absent from the body entirely — it does not
prevent "" from passing validation. Empty inputs wasted AI API credits
and caused unpredictable controller behaviour.

## Fix
Added .min(1) to storyContext and selectedChoice with clear error
messages. Added .min(1) to the optional genre field for consistency.

## Changes
- backend/src/routes/stories.ts

Closes #3348 