### PR TITLE
fix: verify JWT before blacklist lookup, use ApiError for revoked tokens, attach fresh DB user to req.user and reject non-Bearer schemes in auth middleware

### DIFF
--- a/backend/src/app/middleware/auth.middleware.ts
+++ b/backend/src/app/middleware/auth.middleware.ts
@@ -77,9 +77,6 @@ const auth =
           );
         }
 
-        // Bug #111 Fix: Attach the fresh DB user to req.user instead of the
-        // raw JWT payload so controllers always get up-to-date role, email,
-        // and profile data rather than values frozen at token issuance time.
         (req as any).user = user;
 
         next();

--- a/backend/src/app/middleware/auth.middleware.ts
+++ b/backend/src/app/middleware/auth.middleware.ts
@@ -10,74 +10,82 @@ import { USER_STATUS } from "../../enums/user_status";
 
 const auth =
   (...requiredRole: string[]) =>
-  async (req: Request, res: Response, next: NextFunction) => {
-    try {
-      const authHeader = (req.headers.authorization || "") as string;
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const authHeader = (req.headers.authorization || "") as string;
 
-      const token = authHeader.startsWith("Bearer ")
-        ? authHeader.slice(7).trim()
-        : authHeader.trim();
+        if (!authHeader.startsWith("Bearer ")) {
+          throw new ApiError(
+            httpStatus.UNAUTHORIZED,
+            "You are not authorized to access"
+          );
+        }
 
-      if (!token) {
-        throw new ApiError(
-          httpStatus.UNAUTHORIZED,
-          "You are not authorized to access"
+        const token = authHeader.slice(7).trim();
+
+        if (!token) {
+          throw new ApiError(
+            httpStatus.UNAUTHORIZED,
+            "You are not authorized to access"
+          );
+        }
+
+        const verifiedUser = JwtHelpers.verifyToken(
+          token,
+          config.jwt.secret as Secret
         );
+.
+        const isBlacklisted = await TokenBlacklist.findOne({ token });
+
+        if (isBlacklisted) {
+          throw new ApiError(
+            httpStatus.UNAUTHORIZED,
+            "Token has been revoked. Please log in again."
+          );
+        }
+
+        const user = await User.findById((verifiedUser as any)._id);
+
+        if (!user) {
+          throw new ApiError(
+            httpStatus.UNAUTHORIZED,
+            "User not found"
+          );
+        }
+
+        if (user.tokenVersion !== (verifiedUser as any).tokenVersion) {
+          throw new ApiError(
+            httpStatus.UNAUTHORIZED,
+            "Token is invalid or expired"
+          );
+        }
+
+        if (user.status !== USER_STATUS.ACTIVE) {
+          throw new ApiError(
+            httpStatus.FORBIDDEN,
+            "Your account is not active"
+          );
+        }
+
+        if (
+          requiredRole.length &&
+          !requiredRole.includes((verifiedUser as any).role)
+        ) {
+          throw new ApiError(
+            httpStatus.FORBIDDEN,
+            "Forbidden"
+          );
+        }
+
+        // Bug #111 Fix: Attach the fresh DB user to req.user instead of the
+        // raw JWT payload so controllers always get up-to-date role, email,
+        // and profile data rather than values frozen at token issuance time.
+        (req as any).user = user;
+
+        next();
+      } catch (err) {
+        next(err);
       }
-
-      // Query the TokenBlacklist collection using the incoming token
-      const isBlacklisted = await TokenBlacklist.findOne({ token });
-      if (isBlacklisted) {
-        return res.status(401).json({
-          message: "Token has been revoked. Please log in again.",
-        });
-      }
-
-      // verify token
-      const verifiedUser = JwtHelpers.verifyToken(
-        token,
-        config.jwt.secret as Secret
-      );
-
-      const user = await User.findById((verifiedUser as any)._id);
-
-      if (!user) {
-        throw new ApiError(
-          httpStatus.UNAUTHORIZED,
-          "User not found"
-        );
-      }
-
-      if (user.tokenVersion !== (verifiedUser as any).tokenVersion) {
-        throw new ApiError(
-          httpStatus.UNAUTHORIZED,
-          "Token is invalid or expired"
-        );
-      }
-
-      if (user.status !== USER_STATUS.ACTIVE) {
-        throw new ApiError(
-          httpStatus.FORBIDDEN,
-          "Your account is not active"
-        );
-      }
-
-      if (
-        requiredRole.length &&
-        !requiredRole.includes((verifiedUser as any).role)
-      ) {
-        throw new ApiError(
-          httpStatus.FORBIDDEN,
-          "Forbidden"
-        );
-      }
-
-      (req as any).user = verifiedUser;
-
-      next();
-    } catch (err) {
-      next(err);
-    }
-  };
+    };
 
 export default auth;


### PR DESCRIPTION
## Summary
Four security and correctness fixes in auth.middleware.ts covering
middleware execution order, error response consistency, stale data
exposure, and auth scheme validation.

## Bug 1 — JWT verified before blacklist DB query
Moved JwtHelpers.verifyToken above the TokenBlacklist.findOne call.
Invalid or forged tokens are now rejected synchronously with no DB
cost. The blacklist is only queried after the signature is confirmed.

## Bug 2 — ApiError thrown for blacklisted tokens
Replaced res.status(401).json() with throw new ApiError so the
rejection flows through globalErrorHandler and produces the same
standardised response shape as all other auth errors.

## Bug 3 — Fresh DB user attached to req.user
Changed (req as any).user = verifiedUser to (req as any).user = user
so controllers always receive up-to-date profile data rather than
values frozen at token issuance time.

## Bug 4 — Non-Bearer schemes rejected explicitly
Replaced the silent fallback with an explicit check that throws 401
immediately when the Authorization header does not start with Bearer.

## Changes
- backend/src/app/middleware/auth.middleware.ts — all four fixes applied

Closes #3350 