### PR TITLE
Fix/topics not reset on new story

### DIFF
--- a/frontend/src/components/stories/stories.view.component.tsx
+++ b/frontend/src/components/stories/stories.view.component.tsx
@@ -310,6 +310,7 @@ const [, setShowRemix] = useState<boolean>(false);
     lastSavedContentRef.current = "";
     hasSavedSessionRef.current = false;
     savedPostIdRef.current = null;
+    setTopics(topicsData);
   }, [stories]);
 
   useEffect(() => {

--- a/frontend/src/components/stories/stories.view.component.tsx
+++ b/frontend/src/components/stories/stories.view.component.tsx
@@ -757,14 +757,14 @@ if (isLoading) {
               </h1>
               <div className="flex flex-wrap gap-2">
                 <span className="inline-flex items-center rounded-full bg-purple-900/60 text-purple-300 border border-purple-700/50 py-1 px-3 text-xs font-semibold">
-                  Γëí╞Æ├ä┬í {selectedStory.tag}
+                🎭 {selectedStory.tag}
                 </span>
                 <span className="inline-flex items-center rounded-full bg-blue-900/60 text-blue-300 border border-blue-700/50 py-1 px-3 text-xs font-semibold">
-                  Γëí╞Æ├«├ë {selectedStory.language || "English"}
+                🌐 {selectedStory.language || "English"}
                 </span>
                 {selectedStory.emotions && selectedStory.emotions.length > 0 && (
                   <span className="inline-flex items-center rounded-full bg-emerald-900/60 text-emerald-300 border border-emerald-700/50 py-1 px-3 text-xs font-semibold">
-                    Γëí╞Æ├┐├¿ {selectedStory.emotions.join(", ")}
+                    💫 {selectedStory.emotions.join(", ")}
                   </span>
                 )}
               </div>
@@ -809,7 +809,7 @@ if (isLoading) {
                   onClick={handleCopyStory}
                   disabled={!selectedStory}
                 >
-                  {isCopied ? "Γ£ô Copied" : "≡ƒôï Copy"}
+                  {isCopied ? "✔ Copied" : "📋 Copy"}
                 </button>
                 <button
                   type="button"
@@ -817,7 +817,7 @@ if (isLoading) {
                   onClick={handleExportPDF}
                   disabled={!selectedStory}
                 >
-                  ≡ƒôä Export PDF
+                  📄 Export PDF
                 </button>
                 <button
                   type="button"
@@ -825,7 +825,7 @@ if (isLoading) {
                   onClick={handleExportMarkdown}
                   disabled={!selectedStory}
                 >
-                  Γ¼ç∩╕Å Export as Markdown
+                  ✏️ Export as Markdown
                 </button>
                 <button
                   type="button"
@@ -833,15 +833,14 @@ if (isLoading) {
                   onClick={() => setShowWorldMap(true)}
                   disabled={!selectedStory}
                 >
-                  Γëí╞Æ├╣ΓòæΓê⌐Γòò├à World Map
+                 🗺️ World Map
                 </button>
                 <button
                   type="button"
                   className="rounded-lg px-4 py-2 bg-fuchsia-700 text-slate-200 font-semibold cursor-pointer hover:bg-fuchsia-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                   onClick={() => setShowRemix(true)}
                   disabled={!selectedStory}
-                >
-                  Γëí╞Æ├╢├ç Remix
+                >🔀 Remix Γëí╞Æ├╢├ç Remix
                 </button>
                 <button
                   type="button"
@@ -1139,7 +1138,7 @@ if (isLoading) {
                               <details className="group border border-slate-800 rounded-lg overflow-hidden bg-slate-950/20">
                                 <summary className="list-none flex items-center justify-between p-3 text-xs font-bold text-slate-400 hover:text-slate-200 cursor-pointer select-none">
                                   <span>PREVIEW FULL STORY WITH THIS ENDING</span>
-                                  <span className="transition-transform duration-200 group-open:rotate-180">Γû╝</span>
+                                  <span className="transition-transform duration-200 group-open:rotate-180">▼</span>
                                 </summary>
                                 <div className="p-4 border-t border-slate-800/80 text-xs text-slate-400 leading-relaxed max-h-56 overflow-y-auto whitespace-pre-wrap">
                                   {currentEndingData.fullStory}
@@ -1199,10 +1198,10 @@ if (isLoading) {
                       {selectedStory.tag.toUpperCase()}
                     </div>
                     <div className="inline-flex items-center rounded-full bg-indigo-600 py-1 px-3 text-xs font-semibold text-white shadow-sm">
-                      Γëí╞Æ├«├ë {(selectedStory.language || "English").toUpperCase()}
+                    🌐 {(selectedStory.language || "English").toUpperCase()}
                     </div>
                     <div className="inline-flex items-center rounded-full bg-slate-700 py-1 px-2.5 text-xs font-medium text-slate-300 shadow-sm gap-1">
-                      ╬ô├àΓûÆΓê⌐Γòò├à {calculateReadingTime(selectedStory.content)} min read
+                    ⏱️ {calculateReadingTime(selectedStory.content)} min read
                     </div>
                   </div>
                   <div>


### PR DESCRIPTION
FIXES #3341 
## What this PR does
When a new story is generated, custom topics added and defaults toggled off
during the previous session were never cleared — they bled into the new story.
Added `setTopics(topicsData)` inside the `useEffect([stories])` block to reset
topics back to defaults on every new generation.

## Steps to reproduce
1. Generate a story, add a custom topic e.g. `#dragonlore`, deselect a default e.g. `#adventure`
2. Generate a second unrelated story
3. Observe — `#dragonlore` and deselected `#adventure` are still present
4. Publishing at this point tags the post incorrectly

## Fix
One line added in `useEffect([stories])`:
`setTopics(topicsData);`

## Type of change
- [x] Bug fix

## Checklist
- [x] Tested locally — topics reset correctly on each new generation
- [x] Self-reviewed
- [x] N/A — logic fix, no screenshot needed