### PR TITLE
Add word count badge to preview sidebar

### DIFF
--- a/0fed516_utf8.tsx
+++ b/0fed516_utf8.tsx
@@ -1044,6 +1044,11 @@ if (isLoading) {
                     <div className="inline-flex items-center rounded-full bg-slate-700 py-1 px-2.5 text-xs font-medium text-slate-300 shadow-sm gap-1">
                       ΓÅ▒∩╕Å {calculateReadingTime(selectedStory.content)} min read
                     </div>
+
+                    <div className="inline-flex items-center rounded-full bg-slate-700 py-1 px-2.5 text-xs font-medium text-slate-300 shadow-sm gap-1">
+  📝 {getWordCount(selectedStory.content).toLocaleString()} words
+</div>
+
                   </div>
                   <div>
                     <BookmarkButton storyId={selectedStory.uuid} />


### PR DESCRIPTION
## What this PR does

This PR adds a **word count badge** in the preview sidebar next to the existing reading time indicator.

It uses the existing utility `getWordCount(selectedStory.content)` to calculate the total number of words in the story and displays it in a readable format using `.toLocaleString()`.

After this change, the preview sidebar now shows:
- ⏱️ Reading time (already existing)
- 📝 Word count (newly added)

This helps writers quickly understand both reading time and exact word count for better content tracking and submission requirements.

---

## Type of change

- [ ] Bug fix  
- [x] New feature  
- [ ] Code refactor  
- [ ] Documentation update  

---

## Related issue

Fixes #3342 

---

## Screenshot (when helpful)

N/A (UI change is simple and can be verified directly in preview sidebar)

---

## Checklist

- [x] I have added screenshots or noted N/A  
- [x] I have linked the related issue when applicable  
- [x] I have tested my changes  
- [x] I have done a self-review of the code  