### PR TITLE
fix : Duplicate .contact-submit-btn and .contact-btn-gradient

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1040,11 +1040,9 @@ html.dark .contact-input::placeholder { color: rgba(148, 163, 184, 0.78); }
     0 0 0 1px rgba(139, 92, 246, 0.3),
     0 12px 32px rgba(99, 102, 241, 0.28),
     0 0 50px rgba(139, 92, 246, 0.14);
+    filter: brightness(1.1);
 }
 
-.contact-submit-btn:not(:disabled):hover .contact-btn-gradient {
-  filter: brightness(1.1);
-}
 
 .contact-submit-btn:not(:disabled):active {
   transform: translate3d(0, 0, 0) scale(0.98);


### PR DESCRIPTION
These selectors are defined once under the "Submitting State Custom Transitions" section and then redefined later under the "Submit button" section.

Having duplicate definitions for the same selectors increases maintenance complexity and can lead to inconsistencies when future changes are applied to one block but not the other. Some properties are duplicated while others differ slightly between the two definitions.

This makes the source harder to maintain and debug.