### PR TITLE
feat: add reading progress tracker with continue reading banner

### DIFF
--- a/frontend/src/components/story/StoryViewer.tsx
+++ b/frontend/src/components/story/StoryViewer.tsx
@@ -7,118 +7,115 @@ interface Props {
   storyId: string;
 }
 
-const StoryViewer: React.FC<Props> = ({
-  chapters,
-  storyId,
-}) => {
+const StoryViewer: React.FC<Props> = ({ chapters, storyId }) => {
   const [progress, setProgress] = useState(0);
+  const [showResumeBanner, setShowResumeBanner] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
-
   const storageKey = `story-progress-${storyId}`;
 
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
-
     const savedProgress = localStorage.getItem(storageKey);
-
     if (savedProgress) {
       const progressValue = Number(savedProgress);
-
       setProgress(progressValue);
-
-      setTimeout(() => {
-        const maxScroll =
-          container.scrollHeight - container.clientHeight;
-
-        container.scrollTop =
-          (progressValue / 100) * maxScroll;
-      }, 100);
+      if (progressValue > 0 && progressValue < 100) {
+        setShowResumeBanner(true);
+      }
     }
   }, [storageKey]);
 
   useEffect(() => {
     const container = containerRef.current;
-    
     if (!container) return;
 
     const handleScroll = () => {
-      const maxScroll =
-        container.scrollHeight - container.clientHeight;
-
+      const maxScroll = container.scrollHeight - container.clientHeight;
       if (maxScroll <= 0) return;
-
-      const currentProgress =
-        (container.scrollTop / maxScroll) * 100;
-
-      const rounded = Math.min(
-        100,
-        Math.max(0, Math.round(currentProgress))
-      );
-
+      const currentProgress = (container.scrollTop / maxScroll) * 100;
+      const rounded = Math.min(100, Math.max(0, Math.round(currentProgress)));
       setProgress(rounded);
-
-      localStorage.setItem(
-        storageKey,
-        rounded.toString()
-      );
+      localStorage.setItem(storageKey, rounded.toString());
+      if (rounded === 100) {
+        localStorage.removeItem(storageKey);
+      }
     };
 
-    container.addEventListener(
-      "scroll",
-      handleScroll
-    );
-
-    return () =>
-      container.removeEventListener(
-        "scroll",
-        handleScroll
-      );
+    container.addEventListener("scroll", handleScroll);
+    return () => container.removeEventListener("scroll", handleScroll);
   }, [storageKey]);
+
+  const handleResume = () => {
+    const container = containerRef.current;
+    if (!container) return;
+    const savedProgress = localStorage.getItem(storageKey);
+    if (savedProgress) {
+      const progressValue = Number(savedProgress);
+      const maxScroll = container.scrollHeight - container.clientHeight;
+      container.scrollTo({
+        top: (progressValue / 100) * maxScroll,
+        behavior: "smooth",
+      });
+    }
+    setShowResumeBanner(false);
+  };
 
   return (
     <div
       ref={containerRef}
       className="flex-1 overflow-y-auto px-8 py-10 bg-zinc-950"
     >
+      {showResumeBanner && (
+        <div className="sticky top-0 z-20 bg-indigo-900/90 backdrop-blur-md rounded-lg p-3 mb-4 flex justify-between items-center">
+          <span className="text-sm text-indigo-200">
+            You left off at {progress}% — continue where you stopped?
+          </span>
+          <div className="flex gap-2">
+            <button
+              onClick={handleResume}
+              className="px-3 py-1 bg-indigo-500 hover:bg-indigo-600 text-white text-sm rounded-md transition-colors"
+            >
+              Continue Reading
+            </button>
+            <button
+              onClick={() => setShowResumeBanner(false)}
+              className="px-3 py-1 bg-zinc-700 hover:bg-zinc-600 text-white text-sm rounded-md transition-colors"
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
+      )}
+
       <div className="sticky top-0 z-10 bg-zinc-950/90 backdrop-blur-md rounded-lg p-4 mb-8">
         <div className="w-full h-3 bg-zinc-800 rounded-full overflow-hidden">
           <div
             className="h-full bg-indigo-500 transition-all duration-300"
-            style={{
-              width: `${progress}%`,
-            }}
+            style={{ width: `${progress}%` }}
           />
         </div>
-
         <div className="flex justify-between items-center mt-2">
-  <span className="text-sm text-zinc-400">
-    Reading Progress
-  </span>
-
-  <span className="text-sm font-medium text-indigo-400">
-    {progress}%
-  </span>
-</div>
-      </div>
-      <div className="max-w-4xl mx-auto">
-      {chapters.map((chapter) => (
-        <div key={chapter.id} className="mb-16">
-          <h1 className="text-4xl font-extrabold tracking-tight text-white mb-6">
-            {chapter.title}
-          </h1>
-          <h1 className="text-4xl font-extrabold tracking-tight text-white mb-6">
-            {chapter.title}
-          </h1>
-
-<ReadingTimeBadge text={chapter.content} />
-
-          <p className="text-lg text-zinc-300 whitespace-pre-line leading-9">
-            {chapter.content}
-          </p>
-          <hr className="border-zinc-800 mt-10" />
+          <span className="text-sm text-zinc-400">Reading Progress</span>
+          <span className="text-sm font-medium text-indigo-400">
+            {progress === 100 ? "Completed! ??" : `${progress}%`}
+          </span>
         </div>
-      ))}
+      </div>
+
+      <div className="max-w-4xl mx-auto">
+        {chapters.map((chapter) => (
+          <div key={chapter.id} className="mb-16">
+            <h1 className="text-4xl font-extrabold tracking-tight text-white mb-6">
+              {chapter.title}
+            </h1>
+            <ReadingTimeBadge text={chapter.content} />
+            <p className="text-lg text-zinc-300 whitespace-pre-line leading-9">
+              {chapter.content}
+            </p>
+            <hr className="border-zinc-800 mt-10" />
+          </div>
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
## Before you open this PR

- **Issue:** #3367 
- **Description:** Implemented reading progress tracking with a continue reading banner and progress bar.

## Screenshot (when helpful)

<!-- Drag & drop or paste. For non-UI work, you can use tests output, logs, or API responses. Write “N/A” in the checklist if you skip this section. -->

N/A

## What this PR does

<!-- Short summary: what problem does this solve, and how? -->

The story viewer had no way to track or resume reading progress.

This PR:
- Adds a progress bar showing reading percentage
- Adds a "Continue Reading" banner when returning to a partially read story
- Smooth scrolls to last saved position on resume
- Shows "Completed! 🎉" message when story is fully read
- Auto-clears saved progress when story is finished
- Fixes duplicate chapter title rendering bug

## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [x] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

<!-- Example: Closes #123 or Fixes #45. Use “None” if there is no issue. -->
Fixes #3367 


## More screenshots (optional)

<!-- Extra before/after images, flows, or recordings for reviewers. -->



## Checklist

- [ ] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.