### PR TITLE
fix: add fixed height to card image container to prevent badge misalignment

### DIFF
--- a/frontend/src/components/post/post.view.list.component.tsx
+++ b/frontend/src/components/post/post.view.list.component.tsx
@@ -48,7 +48,7 @@ const ExploreViewListComponent: React.FC<IExploreViewListComponentProps> = ({
               onClick={() => navigate(`/post/${story._id}`)}
               className="cursor-pointer bg-gray-50 text-slate-900 backdrop-blur-xl border border-gray-200 rounded-3xl shadow-lg hover:shadow-2xl hover:shadow-blue-500/10 hover:-translate-y-2 transition-all duration-300 overflow-hidden group flex flex-col h-full dark:bg-slate-900/60 dark:text-white dark:border-slate-800"
             >
-              <div className="relative overflow-hidden bg-slate-200 dark:bg-slate-800">
+              <div className="relative overflow-hidden bg-slate-200 dark:bg-slate-800 h-52">
                 {!imageErrors[story._id] && story.imageURL ? (
                   <ImageFallback
                     src={story.imageURL}


### PR DESCRIPTION
## Related Issue
Closes #1651

## Description of Changes
Added `h-52` to the image container div in `ExploreViewListComponent` to enforce consistent fixed height across all story cards.

**Root Cause:**
The image container div had no fixed height, causing cards with different content to vary in image section size. This made the `absolute` positioned Story Type and Language badges appear at different vertical positions.

**Fix:**
Added `h-52` class to `<div className="relative overflow-hidden bg-slate-200 dark:bg-slate-800">` ensuring all cards have consistent image container height.

## Type of Change
- [x] Bug fix (UI/Design)