### PR TITLE
Improve: Add standalone typecheck script to package.json (#2187)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "npx tsx watch src/server.ts",
     "build": "tsc",
+    "typecheck": "tsc --noEmit",
     "start": "node dist/server.js",
     "test": "jest --runInBand"
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build": "npm run build -w story-spark-ai-backend && npm run build -w story-spark-ai-frontend",
     "build:backend": "npm run build -w story-spark-ai-backend",
     "build:frontend": "npm run build -w story-spark-ai-frontend",
-    "typecheck": "npm run build",
+    "typecheck": "npm run typecheck -w story-spark-ai-backend && npm run typecheck -w story-spark-ai-frontend",
     "start:backend": "npm run start -w story-spark-ai-backend",
     "start:frontend": "npm run start -w story-spark-ai-frontend",
     "lint": "npm run lint -w story-spark-ai-frontend"


### PR DESCRIPTION
Fixes #2187

### Summary
This PR addresses the issue where running `npm run typecheck` incorrectly ran the entire Vite build process, making it slow and cumbersome to verify types during development. 

### Changes Made:
- **Root `package.json`**: Updated the `"typecheck"` script to execute the fast typechecking commands concurrently across both the frontend and backend workspaces (`npm run typecheck -w story-spark-ai-backend && npm run typecheck -w story-spark-ai-frontend`) instead of invoking the heavy `npm run build`.
- **Backend `package.json`**: Added a dedicated `"typecheck": "tsc --noEmit"` script so it can be invoked by the root command.
- *(Note: `frontend/package.json` already contained the correct `"typecheck": "tsc -b --noEmit"` script)*.

### Testing:
- Running `npm run typecheck` from the root directory now strictly checks for TypeScript types without building any assets, returning feedback in seconds.