### PR TITLE
feat: add TXT story export option

### DIFF
--- a/frontend/src/components/stories/stories.view.component.tsx
+++ b/frontend/src/components/stories/stories.view.component.tsx
@@ -205,7 +205,7 @@ const buildSentenceSegments = (content: string): StorySentenceSegment[] => {
   return segments;
 };
 
-const getSafeFileName = (title: string, extension: "md" | "docx" | "pdf"): string => {
+const getSafeFileName = (title: string, extension: "md" | "docx" | "pdf" | "txt"): string => {
   const safeTitle = (title || "story")
     .trim()
     .replace(/[^a-z0-9]+/gi, "_")
@@ -954,6 +954,45 @@ const handleExportMarkdown = () => {
       toast.error("Failed to export Markdown.");
     }
   };
+const handleExportTXT = () => {
+  if (!selectedStory) {
+    toast.error("No story available to export.");
+    return;
+  }
+
+  if (!selectedStory.content?.trim()) {
+    toast.error("Story content is empty. Cannot export.");
+    return;
+  }
+
+  try {
+    const title = selectedStory.title || "Story";
+    const content = selectedStory.content || "";
+
+    const txtContent = `${title}\n\n${content}`;
+
+    const blob = new Blob([txtContent], {
+      type: "text/plain;charset=utf-8;",
+    });
+
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+
+    link.href = url;
+    link.setAttribute("download", getSafeFileName(title, "txt"));
+
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+
+    URL.revokeObjectURL(url);
+
+    toast.success("TXT downloaded!");
+  } catch (error) {
+    console.error(error);
+    toast.error("Failed to export TXT.");
+  }
+};
 
   const handleExportDOCX = async () => {
     if (!selectedStory) {
@@ -1341,6 +1380,12 @@ if (isLoading) {
                       </button>
                       <button onClick={() => handleExport("epub")} className="w-full text-left px-4 py-2 text-sm font-semibold text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700 rounded-lg flex items-center gap-2 cursor-pointer">
                         <span>📘</span> Kindle EPUB
+                      </button>
+                      <button
+                        onClick={handleExportTXT}
+                        className="w-full text-left px-4 py-2 text-sm font-semibold text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700 rounded-lg flex items-center gap-2 cursor-pointer"
+                      >
+                        <span>📄</span> TXT
                       </button>
                       <button onClick={handleExportMarkdown} className="w-full text-left px-4 py-2 text-sm font-semibold text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700 rounded-lg flex items-center gap-2 cursor-pointer">
                         <span>⬇️</span> Markdown


### PR DESCRIPTION
## Issue

Closes #3419

## What this PR does

This PR adds support for exporting generated stories as plain text (`.txt`) files.

### Changes made

- Added a **TXT export** option to the story export dropdown.
- Implemented `handleExportTXT()` to generate and download stories as `.txt` files.
- Updated filename handling to support the `.txt` extension.
- Preserves story title and content in a clean, readable text format.

### PDF Export Review

Issue #3419 requests both PDF and TXT export functionality. After reviewing the codebase, I found that **PDF export functionality was already implemented**, including PDF generation and export options in the story view page. Therefore, this PR focuses on implementing the missing **TXT export** functionality required by the issue.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update

## Testing

- [x] Verified TypeScript compilation using `npx tsc --noEmit`
- [x] Confirmed the TXT export handler is connected to the export dropdown menu
- [x] Verified that PDF export functionality already exists in the codebase
### Screenshots

N/A

### Checklist

- [x] Added TXT export functionality
- [x] Updated filename handling for `.txt`
- [x] Verified TypeScript compilation
- [x] Self-reviewed the changes