### PR TITLE
Fix: Prevent confirm password validation during OTP verification

### DIFF
--- a/frontend/src/components/signup/signup.component.tsx
+++ b/frontend/src/components/signup/signup.component.tsx
@@ -134,10 +134,7 @@ const otpPayload = {
           setExpiredAt(new Date(expiresAt).getTime());
           toast.success("OTP sent to your email");
           setRegisterInfo(user);
-          unregister("confirmPassword");
-          unregister("password");
-          unregister("name");
-          unregister("email");
+          
           setShowOtpField(true);
           setCooldown(60);
         }


### PR DESCRIPTION
## Screenshot (when helpful)

N/A – This change fixes form validation logic during OTP verification and does not introduce any UI changes.

## What this PR does

### Problem

Users encountered a false validation error stating **"Confirm Password is required"** during OTP verification, even when the Confirm Password field had already been filled correctly during signup.

### Root Cause

The signup flow was unregistering form fields (`confirmPassword`, `password`, `name`, and `email`) after OTP generation. This caused React Hook Form to lose the stored values and trigger validation errors during OTP verification.

### Solution

* Removed unnecessary field unregistration during OTP generation.
* Preserved form state while transitioning from the signup form to the OTP verification screen.
* Ensured Confirm Password validation is not triggered incorrectly during OTP verification.

### Result

Users can now complete OTP verification without receiving false **"Confirm Password is required"** validation errors.

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

## Related issue

Fixes #2108

## More screenshots (optional)

N/A

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.


Created a cleaner PR
