### PR TITLE
feat: add copy story button to workspace

### DIFF
--- a/frontend/src/components/story/StoryWorkspace.tsx
+++ b/frontend/src/components/story/StoryWorkspace.tsx
@@ -23,6 +23,27 @@ const StoryWorkspace = () => {
   );
   const [workspaceMode, setWorkspaceMode] = useState<"editor" | "network">("editor");
 
+  const handleCopyStory = async () => {
+  if (!currentStory) {
+    toast.error("No story available to copy.");
+    return;
+  }
+
+  try {
+    const storyText = (currentStory.chapters || [])
+  .map(
+    (chapter) => `${chapter.title}\n\n${chapter.content}`
+  )
+  .join("\n\n-----------------------------------\n\n");
+
+    await navigator.clipboard.writeText(storyText);
+    toast.success("Story copied to clipboard!");
+  } catch (error) {
+    console.error(error);
+    toast.error("Failed to copy story.");
+  }
+};
+
   const handleExportMarkdown = () => {
     if (!currentStory) {
       toast.error("No story available to export.");
@@ -156,6 +177,12 @@ const StoryWorkspace = () => {
                 🕸️ Character Network
               </button>
             </div>
+            <button
+              onClick={handleCopyStory}
+              className="bg-zinc-700 hover:bg-zinc-600 text-white px-4 py-2 rounded shadow transition flex items-center gap-2 font-semibold cursor-pointer text-sm"
+              >
+                📋 Copy Story
+            </button>
             <button
               onClick={handleExportMarkdown}
               className="bg-zinc-700 hover:bg-zinc-600 text-white px-4 py-2 rounded shadow transition flex items-center gap-2 font-semibold cursor-pointer text-sm"


### PR DESCRIPTION
## Related Issue

Closes #606

## Changes Made

* Added a "Copy Story" button in the Story Workspace.
* Implemented clipboard functionality using the Clipboard API.
* Added success and error toast notifications.
* Copies all story chapters including titles and content.

## Testing

* Verified the Copy Story button appears alongside existing export options.
* Confirmed story content is copied to the clipboard.
* Confirmed success/error toast notifications work as expected.
