### PR TITLE
Feat: Add share story button with Web Share API and clipboard fallback (#3486)

### DIFF
--- a/frontend/src/components/story/StoryViewer.tsx
+++ b/frontend/src/components/story/StoryViewer.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { Chapter } from "../../types/story.types";
 import ReadingTimeBadge from "../ReadingTimeBadge";
+import toast from "react-hot-toast";
 
 interface Props {
   chapters: Chapter[];
@@ -61,6 +62,22 @@ const StoryViewer: React.FC<Props> = ({ chapters, storyId }) => {
     setShowResumeBanner(false);
   };
 
+  const handleShare = async () => {
+    const url = window.location.href;
+    const title = document.title || "StorySparkAI Story";
+
+    if (navigator.share) {
+      try {
+        await navigator.share({ title, url });
+      } catch {
+        // user cancelled share dialog
+      }
+    } else {
+      await navigator.clipboard.writeText(url);
+      toast.success("Link copied to clipboard!");
+    }
+  };
+
   return (
     <div
       ref={containerRef}
@@ -69,7 +86,7 @@ const StoryViewer: React.FC<Props> = ({ chapters, storyId }) => {
       {showResumeBanner && (
         <div className="sticky top-0 z-20 bg-indigo-900/90 backdrop-blur-md rounded-lg p-3 mb-4 flex justify-between items-center">
           <span className="text-sm text-indigo-200">
-            You left off at {progress}% — continue where you stopped?
+            You left off at {progress}% ï¿½ continue where you stopped?
           </span>
           <div className="flex gap-2">
             <button
@@ -97,9 +114,21 @@ const StoryViewer: React.FC<Props> = ({ chapters, storyId }) => {
         </div>
         <div className="flex justify-between items-center mt-2">
           <span className="text-sm text-zinc-400">Reading Progress</span>
-          <span className="text-sm font-medium text-indigo-400">
-            {progress === 100 ? "Completed! ??" : `${progress}%`}
-          </span>
+          <div className="flex items-center gap-3">
+            <button
+              onClick={handleShare}
+              className="text-sm text-indigo-400 hover:text-indigo-300 transition-colors flex items-center gap-1 cursor-pointer"
+              title="Share this story"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z" />
+              </svg>
+              Share
+            </button>
+            <span className="text-sm font-medium text-indigo-400">
+              {progress === 100 ? "Completed! ðŸŽ‰" : `${progress}%`}
+            </span>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
Summary: Adds a Share button to the StoryViewer component that uses the native Web Share API on supported devices and falls back to copying the URL to the clipboard. Includes a toast notification for clipboard fallback.