### PR TITLE
Fix: Clear stale prompt analysis data when prompt changes (#3487)

### DIFF
--- a/frontend/src/components/prompt_analysis/PromptAnalysisCard.tsx
+++ b/frontend/src/components/prompt_analysis/PromptAnalysisCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useRef, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import toast from "react-hot-toast";
 import { AlertCircle, Zap } from "lucide-react";
@@ -37,6 +37,16 @@ const PromptAnalysisCard: React.FC<PromptAnalysisCardProps> = ({
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isExpanded, setIsExpanded] = useState(false);
+  const previousPromptRef = useRef(prompt);
+
+  useEffect(() => {
+    if (prompt !== previousPromptRef.current) {
+      previousPromptRef.current = prompt;
+      setAnalysis(null);
+      setIsExpanded(false);
+      setError(null);
+    }
+  }, [prompt]);
 
   const handleAnalyze = useCallback(async () => {
     if (!prompt.trim()) {


### PR DESCRIPTION
Summary: Fixes stale analysis data in PromptAnalysisCard by clearing cached results when the prompt text changes. Uses a ref to track previous prompt value and resets analysis state on change.