### PR TITLE
feat: add share story dropdown with copy link and social sharing

### DIFF
--- a/frontend/src/components/post/post.details.component.tsx
+++ b/frontend/src/components/post/post.details.component.tsx
@@ -117,6 +117,7 @@ const PostDetailsComponent = () => {
   const [showTree, setShowTree] = useState(false);
   const [selectedVersionForBranch, setSelectedVersionForBranch] = useState<string | null>(null);
   const [showComparison, setShowComparison] = useState(false);
+  const [showShareMenu, setShowShareMenu] = useState(false);
 
   const [updatePost, { isLoading: isUpdating }] = useUpdatePostMutation();
   const readerPreferences = useReaderPreferences();
@@ -242,6 +243,7 @@ const PostDetailsComponent = () => {
       currentUrl
     )}&text=${encodeURIComponent(currentTitle)}`;
     window.open(url, "_blank", "noopener,noreferrer");
+    setShowShareMenu(false);
   };
 
   const handleLinkedInShare = () => {
@@ -250,6 +252,7 @@ const PostDetailsComponent = () => {
       currentUrl
     )}`;
     window.open(url, "_blank", "noopener,noreferrer");
+    setShowShareMenu(false);
   };
 
   const handleEmailShare = () => {
@@ -261,7 +264,30 @@ const PostDetailsComponent = () => {
       subject
     )}&body=${encodeURIComponent(body)}`;
     window.location.href = url;
+    setShowShareMenu(false);
   };
+
+  const handleCopyLink = async () => {
+  try {
+    await navigator.clipboard.writeText(window.location.href);
+    toast.success("Link copied to clipboard!");
+    setShowShareMenu(false);
+  } catch {
+    toast.error("Failed to copy link.");
+  }
+};
+
+  const handleWhatsAppShare = () => {
+  const currentUrl = window.location.href;
+  const currentTitle = post?.title || "Check out this story!";
+
+  const url = `https://wa.me/?text=${encodeURIComponent(
+    `${currentTitle} ${currentUrl}`
+  )}`;
+
+  window.open(url, "_blank", "noopener,noreferrer");
+  setShowShareMenu(false);
+};
 
   const handleDelete = async () => {
     if (
@@ -508,17 +534,46 @@ const PostDetailsComponent = () => {
                   />
                 )}
               </div>
-              <div className="flex items-center space-x-4">
-                <button className="text-gray-600 hover:text-custom">
-                  <i className="fab fa-twitter"></i>
-                </button>
-                <button className="text-gray-600 hover:text-custom">
-                  <i className="fab fa-linkedin"></i>
-                </button>
-                <button className="text-gray-600 hover:text-custom">
-                  <i className="far fa-envelope"></i>
-                </button>
-              </div>
+              <div className="relative">
+  <button
+    onClick={() => setShowShareMenu(!showShareMenu)}
+    className="px-3 py-2 rounded bg-slate-700 text-white hover:bg-slate-600 transition"
+  >
+    🔗 Share
+  </button>
+
+  {showShareMenu && (
+    <div className="absolute right-0 mt-2 w-48 bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-lg shadow-lg z-50">
+      <button
+        onClick={handleCopyLink}
+        className="block w-full text-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-slate-700"
+      >
+        📋 Copy Link
+      </button>
+
+      <button
+        onClick={handleTwitterShare}
+        className="block w-full text-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-slate-700"
+      >
+        🐦 Share on X
+      </button>
+
+      <button
+        onClick={handleWhatsAppShare}
+        className="block w-full text-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-slate-700"
+      >
+        💬 WhatsApp
+      </button>
+
+      <button
+        onClick={handleEmailShare}
+        className="block w-full text-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-slate-700"
+      >
+        ✉️ Email
+      </button>
+    </div>
+  )}
+</div>
             </div>
 
             {id && (


### PR DESCRIPTION
## Related Issue

Closes #3486

## Description

Added a Share Story dropdown on the story details page.

### Features

* Copy link to clipboard
* Share on X (Twitter)
* Share on WhatsApp
* Share via Email
* Success toast after copying link
* Dropdown share menu

### Notes

* Existing StoryMetaTags component is already used for social previews and metadata.
* Changes are limited to post.details.component.tsx.

## Testing

* Verified Share button opens dropdown menu.
* Verified Copy Link copies current story URL.
* Verified X/Twitter sharing opens share intent.
* Verified WhatsApp sharing opens share intent.
* Verified Email sharing opens mail client.
