### PR TITLE
fix: clear stale analysis state when switching stories (closes #3487)

### DIFF
--- a/frontend/src/components/CharacterNetwork.tsx
+++ b/frontend/src/components/CharacterNetwork.tsx
@@ -33,7 +33,7 @@ interface CharacterNetworkProps {
 }
 
 const CharacterNetwork = ({ storyId }: CharacterNetworkProps) => {
-  const { data: networkData, isLoading, error, refetch } = useGetCharacterNetworkQuery(storyId);
+  const { data: networkData, isLoading, isFetching, error, refetch } = useGetCharacterNetworkQuery(storyId);
 
   // Filter States
   const [search, setSearch] = useState("");
@@ -46,6 +46,17 @@ const CharacterNetwork = ({ storyId }: CharacterNetworkProps) => {
 
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
+
+  // Reset all local state when the story changes to prevent stale data flash
+  useEffect(() => {
+    setSearch("");
+    setSelectedTypes([]);
+    setMinStrength(1);
+    setSelectedNodeId(null);
+    setSelectedEdgeId(null);
+    setNodes([]);
+    setEdges([]);
+  }, [storyId, setNodes, setEdges]);
 
   // Clear filters
   const handleClearFilters = useCallback(() => {
@@ -207,7 +218,7 @@ const CharacterNetwork = ({ storyId }: CharacterNetworkProps) => {
     setSelectedEdgeId(null);
   }, []);
 
-  if (isLoading) {
+  if (isLoading || isFetching) {
     return (
       <div className="flex flex-col flex-1 items-center justify-center bg-[#101319] text-indigo-300 py-20">
         <i className="fas fa-spinner fa-spin text-3xl mb-3"></i>

--- a/frontend/src/components/prompt_analysis/PromptAnalysisCard.tsx
+++ b/frontend/src/components/prompt_analysis/PromptAnalysisCard.tsx
@@ -69,6 +69,13 @@ const PromptAnalysisCard: React.FC<PromptAnalysisCardProps> = ({
     }
   }, [prompt, language, genre, tone, onAnalysisComplete]);
 
+  // Clear stale results when the prompt changes (e.g. navigating to a different story)
+  React.useEffect(() => {
+    setAnalysis(null);
+    setError(null);
+    setIsExpanded(false);
+  }, [prompt]);
+
   // Auto-analyze if enabled and prompt is provided
   React.useEffect(() => {
     if (autoAnalyze && prompt.trim() && !analysis && !isLoading) {


### PR DESCRIPTION
## Summary
Fixes #3487 - AI story analysis panel shows stale results when selecting different stories.

## Root Cause
When navigating from one story's analysis to another:
- `CharacterNetwork` did not reset local filter/selection/graph state when `storyId` changed. RTK Query fetched new data but old `networkData` was still rendered briefly.
- - `PromptAnalysisCard` kept analysis results when the `prompt` prop changed.
## Changes

### `frontend/src/components/CharacterNetwork.tsx`
- Added `useEffect` keyed on `storyId` that immediately clears all local state (search, selectedTypes, minStrength, selectedNodeId, selectedEdgeId, nodes, edges) when story changes.
- - Changed `if (isLoading)` -> `if (isLoading || isFetching)` so loading spinner shows during RTK Query re-fetches triggered by story switches.
### `frontend/src/components/prompt_analysis/PromptAnalysisCard.tsx`
- Added `useEffect` keyed on `prompt` that resets `analysis`, `error`, and `isExpanded` when the prompt changes.
## Files Changed
- `frontend/src/components/CharacterNetwork.tsx`
- - `frontend/src/components/prompt_analysis/PromptAnalysisCard.tsx`