### PR TITLE
fix: re-throw ApiError in approveWriterApplication to preserve original HTTP status codes

### DIFF
--- a/backend/src/app/modules/user/user.service.ts
+++ b/backend/src/app/modules/user/user.service.ts
@@ -155,6 +155,9 @@ const approveWriterApplication = async (email: string) => {
     );
     return result;
   } catch (error) {
+    if (error instanceof ApiError) {
+      throw error;
+    }
     if (error instanceof Error) {
       throw new ApiError(httpStatus.BAD_REQUEST, error.message);
     } else {


### PR DESCRIPTION
### Related Issue
Closes #3511 

### Description of Changes
- Added an `instanceof ApiError` guard in the `catch` block of `approveWriterApplication` in `user.service.ts`.
- `ApiError` instances are now re-thrown without modification, preserving their original HTTP status codes.
- Generic errors are still wrapped in `400 BAD_REQUEST` as before.