### PR TITLE
fix: remove write-on-read DB update from getStreak to keep GET endpoint side-effect-free

### DIFF
--- a/backend/src/app/modules/gamification/writing_streak.service.ts
+++ b/backend/src/app/modules/gamification/writing_streak.service.ts
@@ -124,10 +124,6 @@ const getStreak = async (userId: string) => {
 
     if (diffDays > 1) {
       currentStreak = 0;
-      // Update in DB dynamically
-      await User.findByIdAndUpdate(userId, {
-        "writingStreak.currentStreak": 0,
-      });
     }
   }
 


### PR DESCRIPTION
### Related Issue
Closes #3515

### Description of Changes
- Removed the `User.findByIdAndUpdate` call from inside `getStreak` in `writing_streak.service.ts`.
- `getStreak` now only reads data — streak resets are computed in-memory for the response without mutating the DB.
- The authoritative streak reset write remains in `updateStreakAndUnlocks`, which is the correct write path.