### PR TITLE
fix: remove duplicate WritingStreakService.updateStreakAndUnlocks call in createPost

### DIFF
--- a/backend/src/app/modules/post/post.service.ts
+++ b/backend/src/app/modules/post/post.service.ts
@@ -127,8 +127,6 @@ const createPost = async (payload: IPostPayload, token: ITokenPayload) => {
       if (updatedUser && updatedUser.postsCount === 1) {
         GamificationService.awardBadge(String(user._id), "First Story").catch(console.error);
       }
-     
-      WritingStreakService.updateStreakAndUnlocks(String(user._id)).catch(console.error);
     }
     return res;
   } catch (error) {


### PR DESCRIPTION
### Related Issue
Closes #3522

### Description of Changes
- Removed the duplicate `WritingStreakService.updateStreakAndUnlocks` call on line 131 of `post.service.ts`.
- The streak update now happens exactly once per post creation, preventing double streak increments and unnecessary DB writes.