### PR TITLE
fix: resolve BOLA vulnerabilities in draft story access

### DIFF
--- a/backend/src/app/modules/bookmark/bookmark.service.ts
+++ b/backend/src/app/modules/bookmark/bookmark.service.ts
@@ -5,6 +5,7 @@ import httpStatus from "http-status";
 import { Bookmark } from "./bookmark.model";
 import { Post } from "../post/post.model";
 import { Types } from "mongoose";
+import { verifyPostAccess } from "../post/post.utils";
 
 const toggleBookmark = async (storyId: string, token: ITokenPayload) => {
   const { email } = token;
@@ -19,6 +20,8 @@ const toggleBookmark = async (storyId: string, token: ITokenPayload) => {
   if (!post) {
     throw new ApiError(httpStatus.BAD_REQUEST, "Story not found!");
   }
+
+  verifyPostAccess(post, user);
 
   const existingBookmark = await Bookmark.findOne({
     userId: user._id,
@@ -61,7 +64,7 @@ const getBookmarks = async (
       },
     },
     { $unwind: "$story" },
-    { $match: { "story.isDeleted": { $ne: true } } },
+    { $match: { "story.isDeleted": { $ne: true }, "story.isPublished": true } },
     { $count: "count" }
   ]);
   const total = totalAgg[0]?.count || 0;
@@ -78,7 +81,7 @@ const getBookmarks = async (
       },
     },
     { $unwind: "$story" },
-    { $match: { "story.isDeleted": { $ne: true } } },
+    { $match: { "story.isDeleted": { $ne: true }, "story.isPublished": true } },
     { $sort: { createdAt: -1 } },
     { $skip: skip },
     { $limit: limit },
@@ -130,6 +133,12 @@ const checkBookmarkStatus = async (storyId: string, token: ITokenPayload) => {
     throw new ApiError(httpStatus.BAD_REQUEST, "User not found!");
   }
 
+  const post = await Post.findOne({ _id: storyId, isDeleted: { $ne: true } });
+  if (!post) {
+    throw new ApiError(httpStatus.BAD_REQUEST, "Story not found!");
+  }
+  verifyPostAccess(post, user);
+
   const bookmark = await Bookmark.findOne({
     userId: user._id,
     storyId: new Types.ObjectId(storyId),
@@ -144,6 +153,12 @@ const deleteBookmark = async (storyId: string, token: ITokenPayload) => {
   if (!user) {
     throw new ApiError(httpStatus.BAD_REQUEST, "User not found!");
   }
+
+  const post = await Post.findOne({ _id: storyId, isDeleted: { $ne: true } });
+  if (!post) {
+    throw new ApiError(httpStatus.BAD_REQUEST, "Story not found!");
+  }
+  verifyPostAccess(post, user);
 
   const deletedBookmark = await Bookmark.findOneAndDelete({
     userId: user._id,

--- a/backend/src/app/modules/comment/__tests__/comment.service.test.ts
+++ b/backend/src/app/modules/comment/__tests__/comment.service.test.ts
@@ -62,6 +62,8 @@ const session = {
 const buildPost = (commentsCount = 0) => ({
   _id: postId,
   commentsCount,
+  isPublished: true,
+  author: userId,
 });
 
 describe("CommentService.createComment", () => {

--- a/backend/src/app/modules/comment/comment.controller.ts
+++ b/backend/src/app/modules/comment/comment.controller.ts
@@ -19,7 +19,15 @@ const createComment = catchAsync(async (req: Request, res: Response) => {
 
 const getCommentsByPostId = catchAsync(async (req: Request, res: Response) => {
   const postId = routeParam(req.params.postId);
-  const result = await CommentService.getCommentsByPostId(postId);
+
+  let token = null;
+  try {
+    token = await getToken(req);
+  } catch (error) {
+    // Guest or unauthenticated request
+  }
+
+  const result = await CommentService.getCommentsByPostId(postId, token);
   sendResponse(res, {
     statusCode: httpStatus.OK,
     success: true,

--- a/backend/src/app/modules/comment/comment.service.ts
+++ b/backend/src/app/modules/comment/comment.service.ts
@@ -8,6 +8,7 @@ import { startSession, Types } from "mongoose";
 import { Post } from "../post/post.model";
 import { ENUM_USER_ROLE } from "../../../enums/user";
 import { assertContentSafe } from "../../../utils/contentModeration";
+import { verifyPostAccess } from "../post/post.utils";
 
 const createComment = async (
   payload: ICommentPayload,
@@ -25,6 +26,8 @@ const createComment = async (
   if (!post) {
     throw new ApiError(httpStatus.BAD_REQUEST, "Post not found!");
   }
+
+  verifyPostAccess(post, user);
 
   // Content moderation — block inappropriate comments before persisting
   try {
@@ -92,7 +95,17 @@ const createComment = async (
   }
 };
 
-const getCommentsByPostId = async (postId: string) => {
+const getCommentsByPostId = async (postId: string, token?: ITokenPayload | null) => {
+  const post = await Post.findOne({ _id: postId, isDeleted: { $ne: true } });
+  if (!post) {
+    throw new ApiError(httpStatus.NOT_FOUND, "Post not found!");
+  }
+  let user = null;
+  if (token && token.email) {
+    user = await User.findOne({ email: token.email });
+  }
+  verifyPostAccess(post, user);
+
   return await Comment.find({ postId }).populate("userId", "name profile.avatar").sort({ createdAt: -1 });
 };
 
@@ -113,6 +126,7 @@ const toggleCommentLike = async (commentId: string, token: ITokenPayload) => {
   if (!post) {
     throw new ApiError(httpStatus.NOT_FOUND, "Post not found!");
   }
+  verifyPostAccess(post, user);
   
   // Replace the read-modify-write likes toggle with atomic MongoDB operators.
   const isCurrentlyLiked = await Comment.exists({
@@ -140,6 +154,16 @@ const deleteComment = async (commentId: string, token: ITokenPayload) => {
   if (!comment) {
     throw new ApiError(httpStatus.NOT_FOUND, "Comment not found!");
   }
+
+  const post = await Post.findOne({
+    _id: comment.postId,
+    isDeleted: { $ne: true },
+  });
+  if (!post) {
+    throw new ApiError(httpStatus.NOT_FOUND, "Post not found!");
+  }
+  verifyPostAccess(post, user);
+
   // Only the comment author or an admin/super-admin can delete
   const isAuthor = comment.userId.toString() === user._id.toString();
   const isAdmin = role === ENUM_USER_ROLE.ADMIN || role === ENUM_USER_ROLE.SUPER_ADMIN;

--- a/backend/src/app/modules/post/post.controller.ts
+++ b/backend/src/app/modules/post/post.controller.ts
@@ -92,12 +92,12 @@ const getSinglePost = catchAsync(async (req: Request, res: Response) => {
   
   let token = null;
   try {
-    token = getToken(req);
+    token = await getToken(req);
   } catch (error) {
     // Guest or unauthenticated request
   }
 
-  const result = await PostService.getSinglePost(id);
+  const result = await PostService.getSinglePost(id, token);
   sendResponse(res, {
     statusCode: httpStatus.OK,
     success: true,

--- a/backend/src/app/modules/post/post.service.ts
+++ b/backend/src/app/modules/post/post.service.ts
@@ -17,6 +17,7 @@ import { SortOrder, Types } from "mongoose";
 import { GamificationService } from "../gamification/gamification.service";
 import { WritingStreakService } from "../gamification/writing_streak.service";
 import { escapeRegex } from "../../../utils/regex.util";
+import { verifyPostAccess } from "./post.utils";
 
 const MAX_SEARCH_TERM_LENGTH = 100;
 
@@ -378,6 +379,13 @@ const getSinglePost = async (id: string, token?: ITokenPayload | null) => {
   if (!postById) {
     throw new ApiError(httpStatus.NOT_FOUND, "Post not found!");
   }
+
+  let user = null;
+  if (token && token.email) {
+    user = await User.findOne({ email: token.email });
+  }
+  verifyPostAccess(postById, user);
+
   return postById;
 };
 
@@ -410,10 +418,12 @@ const toggleBookmark = async (postId: string, token: ITokenPayload) => {
     throw new ApiError(httpStatus.BAD_REQUEST, "User not found!");
   }
 
-  const postExists = await Post.exists({ _id: postId, isDeleted: { $ne: true } });
-  if (!postExists) {
+  const post = await Post.findOne({ _id: postId, isDeleted: { $ne: true } });
+  if (!post) {
     throw new ApiError(httpStatus.BAD_REQUEST, "Post not found!");
   }
+
+  verifyPostAccess(post, user);
 
   const isBookmarked = await Post.exists({
     _id: postId,
@@ -548,6 +558,8 @@ const remixStory = async (postId: string, prompt: string, token: ITokenPayload) 
     throw new ApiError(httpStatus.NOT_FOUND, "Original story post not found!");
   }
 
+  verifyPostAccess(originalPost, user);
+
   const remixedContent = `[AI Remixed Version based on prompt: "${safePrompt}"]\n\n${originalPost.content}`;
 
   const res = await Post.create({
@@ -586,6 +598,8 @@ const translateStory = async (postId: string, language: string, token: ITokenPay
   if (!originalPost) {
     throw new ApiError(httpStatus.NOT_FOUND, "Original story post not found!");
   }
+
+  verifyPostAccess(originalPost, user);
 
   const translatedContent = `[Translated to ${safeLanguage}]\n\n${originalPost.content}`;
 

--- a/backend/src/app/modules/post/post.utils.ts
+++ b/backend/src/app/modules/post/post.utils.ts
@@ -1,0 +1,18 @@
+import httpStatus from "http-status";
+import ApiError from "../../../errors/api_error";
+import { ENUM_USER_ROLE } from "../../../enums/user";
+
+export const verifyPostAccess = (post: any, user?: any) => {
+  if (post.isPublished) return;
+
+  if (!user) {
+    throw new ApiError(httpStatus.FORBIDDEN, "Access to this draft is forbidden.");
+  }
+
+  const isAuthor = post.author && user._id && post.author.toString() === user._id.toString();
+  const isAdmin = user.role === ENUM_USER_ROLE.ADMIN || user.role === ENUM_USER_ROLE.SUPER_ADMIN;
+
+  if (!isAuthor && !isAdmin) {
+    throw new ApiError(httpStatus.FORBIDDEN, "Access to this draft is forbidden.");
+  }
+};

--- a/backend/src/app/modules/reaction/reaction.service.ts
+++ b/backend/src/app/modules/reaction/reaction.service.ts
@@ -5,6 +5,7 @@ import httpStatus from "http-status";
 import { Reaction } from "./reaction.model";
 import { Types } from "mongoose";
 import { Post } from "../post/post.model";
+import { verifyPostAccess } from "../post/post.utils";
 
 type ReactionType = "like" | "love" | "laugh" | "angry" | "sad";
 
@@ -32,6 +33,8 @@ const toggleReaction = async (
   if (!post) {
     throw new ApiError(httpStatus.BAD_REQUEST, "Post not found!");
   }
+  
+  verifyPostAccess(post, user);
 
   // Check existing reaction
   const existingReaction = await Reaction.findOne({


### PR DESCRIPTION
## Screenshot

N/A – Backend authorization and security changes only.

## What this PR does

This PR addresses authorization issues related to unpublished draft stories.

The existing implementation validated that posts existed and were not deleted, but several code paths did not consistently enforce draft ownership checks before allowing access or interaction with draft content.

This PR introduces centralized draft-access authorization validation and applies it across affected services to ensure that:

* Unpublished drafts are only accessible to their author.
* Admin and Super Admin roles retain appropriate access.
* Unauthorized users cannot access unpublished draft content.
* Related interactions such as story retrieval, remixing, translation, comments, bookmarks, and reactions follow the same authorization rules.

The goal is to prevent Broken Object Level Authorization (BOLA/IDOR) issues involving unpublished draft stories while maintaining existing behavior for published content.

## Type of change

* [x] Bug fix

## Related issue

Fixes #2614

## More screenshots (optional)

N/A

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.
