### PR TITLE
fix: clean up duplicate code blocks in SSInput component and fix password field padding

### DIFF
--- a/frontend/src/components/ui-component/ss-input/ss-input.tsx
+++ b/frontend/src/components/ui-component/ss-input/ss-input.tsx
@@ -32,10 +32,9 @@ const SSInput = <T extends FieldValues>({
   validation,
   error,
   autoComplete,
-  autoFocus
+  autoFocus,
 }: SSInputProps<T>) => {
-  const [showPassword, setShowPassword] = useState(false);
-
+  const [showLocalPassword, setShowLocalPassword] = useState(false);
 
   const isPasswordType = type === "password";
   const inputType = isPasswordType
@@ -56,33 +55,9 @@ const SSInput = <T extends FieldValues>({
       <div className="relative w-full min-w-0 max-w-full box-border">
         {icon && (
           <span className="absolute left-4 top-1/2 -translate-y-1/2 flex items-center justify-center text-slate-400 dark:text-slate-500 z-10 pointer-events-none">
-
-  const inputType =
-    type === "password" ? (showPassword ? "text" : "password") : type;
-
-  return (
-    <div className="w-[80%] min-w-0">
-      <label htmlFor={name} className="block text-sm font-medium text-gray-600 dark:text-gray-400">
-    <div className="w-full min-w-0 box-border">
-      <label htmlFor={name} className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
-
-        {label}
-    <div className="w-full max-w-full flex flex-col box-border">
-      <label 
-        htmlFor={name} 
-        className="block text-xs font-semibold text-slate-600 dark:text-slate-400 uppercase tracking-wider mb-2 text-left"
-      >
-        {label} {required && <span className="text-rose-500">*</span>}
-      </label>
-      
-      <div className="relative w-full max-w-full flex items-center box-border">
-        {icon && (
-          <span className="absolute inset-y-0 left-0 pl-3 flex items-center text-gray-500">
-
             <i className={icon}></i>
           </span>
         )}
-
 
         <input
           type={inputType}
@@ -122,53 +97,6 @@ const SSInput = <T extends FieldValues>({
           className="text-xs font-semibold text-rose-400 mt-1.5 text-left w-full break-words"
           aria-live="polite"
         >
-
-       <input
-  type={inputType}
-  id={name}
-  className={`w-full min-w-0 max-w-full box-border pl-8 pr-10 py-1.5 text-base text-gray-900 dark:text-gray-100 placeholder:text-gray-500 dark:placeholder:text-gray-400 bg-white dark:bg-slate-800 border-0 sm:text-sm ${
-    error
-      ? "outline-red-500"
-      : "outline-gray-800 focus:outline-indigo-600"
-  }`}
-  placeholder={placeholder}
-  autoComplete={autoComplete}
-  {...register(name, validation)}
-/>
-
-        <input
-  type={inputType}
-  id={name}
-  className={`block w-full max-w-full box-border pl-8 ${
-    type === "password" ? "pr-0" : "pr-0"
-  } py-1.5 text-base text-gray-900 dark:text-gray-200 bg-white dark:bg-slate-800 border rounded-md sm:text-sm ${
-    error
-      ? "border-red-500"
-      : "border-gray-300 focus:outline-indigo-600"
-  }`}
-  placeholder={placeholder}
-  autoComplete={autoComplete}
-  {...register(name, validation)}
-/>
-        {type === "password" && (
-  <button
-    type="button"
-    onClick={() => setShowPassword(!showPassword)}
-
-    className="absolute inset-y-0 right-2 flex items-center text-gray-500"
-
-    
-    aria-label={showPassword ? "Hide password" : "Show password"}
-    title={showPassword ? "Hide password" : "Show password"}
-
-  >
-    <i className={showPassword ? "fi fi-rr-eye" : "fi fi-rr-eye-crossed"}></i>
-  </button>
-)}
-      </div>
-
-      {error && (
-        <p className="text-xs font-medium text-rose-500 mt-1.5 text-left w-full break-words overflow-hidden">
           {error.message}
         </p>
       )}


### PR DESCRIPTION
## What this PR does
The SSInput component (used across login, signup, and other forms) had multiple duplicate and conflicting code blocks left in from bad merges. This caused:
1. Password field text overlapping the show/hide eye icon (pr-0 instead of pr-11)
2. Duplicate <input> elements rendering for the same field
3. Conflicting className logic and broken variable references

Cleaned up the file to keep only the latest, correct version of the component which already has proper padding (pr-11 for password fields, pr-4 for others) and a single clean input element.

## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue
 Fixes #3543 

## More screenshots (optional)
before-:
<img width="1366" height="600" alt="image" src="https://github.com/user-attachments/assets/885b31b5-ac29-4aea-bff5-4bac8a25ad6d" />


## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [ ] I have tested my changes.
- [x] I have done a self-review of the code.
