### PR TITLE
feat: add comment moderation queue backend support

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -12,19 +12,14 @@ import cookieParser from "cookie-parser";
 import config from "./config";
 import { Routers } from "./router";
 import globalErrorHandler from "./app/middleware/global.error.handler";
-<<<<<<< feature/weekly-story-leaderboard
-import { User } from "./app/modules/user/user.model";
-import { NewsletterSubscriber } from "./app/modules/newsletter/newsletter.model";
-import storyRoutes from "./routes/story.routes";
 import leaderboardRoute from "./routes/leaderboard.route";
-=======
->>>>>>> main
+
 
 const app: Application = express();
 app.set("trust proxy", 1);
 app.use(helmet());
 
-const defaultCorsOrigins =
+const defaultCorsOrigins =  
   process.env.NODE_ENV === "development"
     ? ["http://localhost:4001", "http://localhost:4002"]
     : [

--- a/backend/src/app/modules/comment/comment.interface.ts
+++ b/backend/src/app/modules/comment/comment.interface.ts
@@ -6,8 +6,11 @@ export interface IComment {
   comment: string;
   parentCommentId?: Types.ObjectId;
   likes?: Types.ObjectId[];
+
   isDeleted?: boolean;
   deletedAt?: Date | null;
+
+  isHidden?: boolean;
 }
 
 export type CommentModel = Model<IComment, object>;

--- a/backend/src/app/modules/comment/comment.model.ts
+++ b/backend/src/app/modules/comment/comment.model.ts
@@ -28,6 +28,11 @@ deletedAt: {
   type: Date,
   default: null,
 },
+isHidden: {
+  type: Boolean,
+  default: false,
+},
+
   },
   { timestamps: true }
 );

--- a/backend/src/app/modules/comment/comment.service.ts
+++ b/backend/src/app/modules/comment/comment.service.ts
@@ -157,9 +157,43 @@ const deleteComment = async (commentId: string, token: ITokenPayload) => {
   return { message: "Comment deleted successfully!" };
 };
 
+const hideComment = async (commentId: string) => {
+  const comment = await Comment.findByIdAndUpdate(
+    commentId,
+    {
+      isHidden: true,
+    },
+    { new: true }
+  );
+
+  if (!comment) {
+    throw new ApiError(httpStatus.NOT_FOUND, "Comment not found!");
+  }
+
+  return comment;
+};
+
+const restoreComment = async (commentId: string) => {
+  const comment = await Comment.findByIdAndUpdate(
+    commentId,
+    {
+      isHidden: false,
+    },
+    { new: true }
+  );
+
+  if (!comment) {
+    throw new ApiError(httpStatus.NOT_FOUND, "Comment not found!");
+  }
+
+  return comment;
+};
+
 export const CommentService = {
   createComment,
   getCommentsByPostId,
   toggleCommentLike,
   deleteComment,
+  hideComment,
+  restoreComment,
 };

--- a/backend/src/app/modules/report/report.controller.ts
+++ b/backend/src/app/modules/report/report.controller.ts
@@ -18,6 +18,19 @@ const createReport = catchAsync(async (req: Request, res: Response) => {
   });
 });
 
+const getPendingCommentReports = catchAsync(
+  async (req: Request, res: Response) => {
+    const result = await ReportService.getPendingCommentReports();
+
+    sendResponse(res, {
+      statusCode: 200,
+      success: true,
+      message: "Pending comment reports fetched successfully",
+      data: result,
+    });
+  }
+);
+
 const getAllReports = catchAsync(async (req: Request, res: Response) => {
   const result = await ReportService.getAllReports();
   sendResponse(res, {
@@ -27,4 +40,8 @@ const getAllReports = catchAsync(async (req: Request, res: Response) => {
     data: result,
   });
 });
-export const ReportController = { createReport, getAllReports };
+export const ReportController = {
+  createReport,
+  getAllReports,
+  getPendingCommentReports,
+};

--- a/backend/src/app/modules/report/report.router.ts
+++ b/backend/src/app/modules/report/report.router.ts
@@ -24,4 +24,14 @@ router.get(
   auth(ENUM_USER_ROLE.ADMIN, ENUM_USER_ROLE.SUPER_ADMIN),
   ReportController.getAllReports
 );
+
+router.get(
+  "/pending-comments",
+  auth(
+    ENUM_USER_ROLE.ADMIN,
+    ENUM_USER_ROLE.SUPER_ADMIN
+  ),
+  ReportController.getPendingCommentReports
+);
+
 export const ReportRouter = router;

--- a/backend/src/app/modules/report/report.service.ts
+++ b/backend/src/app/modules/report/report.service.ts
@@ -1,6 +1,7 @@
 import { IReport } from "./report.interface";
 import { Report } from "./report.model";
 import ApiError from "../../../errors/api_error";
+import { ReportStatus, ReportTargetType } from "../../../enums/report.enum";
 import httpStatus from "http-status";
 
 const createReport = async (payload: IReport) => {
@@ -22,5 +23,51 @@ const getAllReports = async () => {
   const result = await Report.find().populate("reportedBy", "name email");
   return result;
 };
+const getPendingCommentReports = async () => {
+  return await Report.find({
+    targetType: ReportTargetType.COMMENT,
+    status: ReportStatus.PENDING,
+  }).populate("reportedBy", "name email");
+};
 
-export const ReportService = { createReport, getAllReports };
+const reviewReport = async (reportId: string) => {
+  const report = await Report.findByIdAndUpdate(
+    reportId,
+    {
+      status: ReportStatus.REVIEWED,
+    },
+    { new: true }
+  );
+
+  if (!report) {
+    throw new ApiError(httpStatus.NOT_FOUND, "Report not found");
+  }
+
+  return report;
+};
+
+const dismissReport = async (reportId: string) => {
+  const report = await Report.findByIdAndUpdate(
+    reportId,
+    {
+      status: ReportStatus.DISMISSED,
+    },
+    { new: true }
+  );
+
+  if (!report) {
+    throw new ApiError(httpStatus.NOT_FOUND, "Report not found");
+  }
+
+  return report;
+};
+
+
+
+export const ReportService = {
+  createReport,
+  getAllReports,
+  getPendingCommentReports,
+  reviewReport,
+  dismissReport,
+};


### PR DESCRIPTION
Closes #3547

### Screenshot (when helpful)

N/A – Backend-only changes, no UI updates.

---

## What this PR does

This PR introduces backend support for comment moderation.

### Changes made

* Added `isHidden` field to comments for soft hiding without permanent deletion.
* Added `hideComment()` and `restoreComment()` methods in `CommentService`.
* Added moderation-related methods in `ReportService`:

  * `getPendingCommentReports()`
  * `reviewReport()`
  * `dismissReport()`
* Added controller support for fetching pending comment reports.
* Added admin route:

`GET /pending-comments`

* Removed unresolved merge-conflict markers from `backend/src/app.ts`.

These changes provide the foundation for a moderation queue and future trust & safety improvements.

---

## Type of change

* [x] New feature

---

## More screenshots (optional)

N/A

---

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.
