### PR TITLE
fix: improve story prompt character counter accessibility

### DIFF
--- a/frontend/src/components/stories/stories.component.tsx
+++ b/frontend/src/components/stories/stories.component.tsx
@@ -28,7 +28,6 @@ type Inputs = {
 };
 
 const MAX_PROMPT_LENGTH = 2000;
-const WARN_THRESHOLD = 0.85;
 const lengths = ["short", "medium", "long"] as const;
 const WARN_THRESHOLD = 0.8;
 const DANGER_THRESHOLD = 0.95;
@@ -1846,12 +1845,18 @@ onKeyDown={(e) => {
                         ) : null}
                       </div>
 
-                      <span className={`text-[11px] font-bold tabular-nums shrink-0 ml-auto ${
-                        isOverLimit || isDangerLimit ? "text-red-500 dark:text-red-400" : isNearLimit ? "text-amber-500" : "text-slate-400"
-                      }`}>
-                        {textareaValue.length} / {MAX_PROMPT_LENGTH}
-
-                      </span>
+                      <span
+  aria-live="polite"
+  className={`text-[11px] font-bold tabular-nums shrink-0 ml-auto ${
+    isOverLimit || isDangerLimit
+      ? "text-red-500 dark:text-red-400"
+      : isNearLimit
+      ? "text-amber-500"
+      : "text-slate-400"
+  }`}
+>
+  {textareaValue.length} / {MAX_PROMPT_LENGTH}
+</span>
                     </div>
                   </div>
 


### PR DESCRIPTION
Closes #3482

## Screenshot

N/A – small UI accessibility improvement.

## What this PR does

This PR improves the story prompt character counter by:

* Removing a duplicate `WARN_THRESHOLD` declaration.
* Ensuring the warning threshold remains at 80%.
* Adding `aria-live="polite"` to the character counter so updates are announced by screen readers.
* Improving accessibility without changing existing functionality.

## Type of change

* [x] Bug fix

## Related issue

Closes #3482

## More screenshots

N/A

## Checklist

* [x] I have added screenshots or noted N/A.
* [x] I have filled in the related issue number.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.
