### PR TITLE
# Fix authentication form overflow caused by CSS parsing errors

### DIFF
--- a/auth.css
+++ b/auth.css
@@ -471,9 +471,12 @@ input[type="password"] {
     transition: background-color 9999s ease-in-out 0s;
 }
 
-.input-icon-wrapper {
+.input-icon-wrapper,
+.ds-input-group {
     position: relative;
     width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
 
     color:#a78bfa;
 
@@ -653,12 +656,6 @@ input[type="password"] {
 .ds-btn-submit:hover {
     box-shadow: 0 0 42px rgba(249, 115, 22, 0.35), 0 10px 26px rgba(0, 0, 0, 0.3);
     transform: translateY(-1px);
-
-        transform:
-            translateY(0)
-            scale(1);
-    }
- 
 }
 
 /* ──────────────────────────────────────────────
@@ -741,7 +738,7 @@ input[type="password"] {
     line-height: 1.45;
     color: #ffb4ab;
     display: none;
-
+}
 
 
 /* ── Centered Layout Panel Constraints ── */
@@ -862,7 +859,10 @@ input:focus{
  
 .ds-feedback.match::before {
     content: "✓";
-    font-weight: 700; ──────────────────────────────────────────────
+    font-weight: 700;
+}
+
+/* ──────────────────────────────────────────────
    TERMS BOX
 ────────────────────────────────────────────── */
 
@@ -995,7 +995,8 @@ input:focus{
     background: rgba(255, 255, 255, 0.05);
     color: #e1e2ea;
     padding: 0 16px;
- 
+}
+
 .ds-btn-submit:hover{
 
     transform:
@@ -1154,7 +1155,13 @@ input:focus{
 .ds-btn-google{
     width:100%;
     max-width:100%;
+    min-width:0;
     box-sizing:border-box;
+}
+
+.auth-fields,
+.auth-form > * {
+    min-width: 0;
 }
 
 @media(max-width:1100px){


### PR DESCRIPTION
## Related Issue

Closes #3555 

## Summary

This PR fixes the authentication form layout issue where input fields overflowed outside the rounded card container on both desktop and mobile screens.

## Root Cause

The issue was caused by multiple CSS syntax errors in `auth.css`:

* Three unclosed CSS blocks (`}`)
* One stray closing brace
* A malformed section comment

The most critical issue was an unclosed `.ds-error` rule, which caused the browser to stop parsing the remainder of the stylesheet.

As a result, multiple layout and responsive rules were silently ignored, including:

* Input width constraints
* Form container sizing
* Mobile alignment fixes
* All responsive breakpoints

### Layout fixes

* Added `.ds-input-group` to the positioning rule previously applied only to `.input-icon-wrapper`
* Added `min-width: 0` to flex/grid children to prevent overflow caused by implicit sizing
* Restored all responsive rules by fixing stylesheet parsing

## Impact

### Before

* Input fields overflowed outside the auth card
* Responsive breakpoints were ignored
* Several layout rules were silently dropped by the browser
* `.auth-header` styles were not applied correctly

### After

* Inputs remain inside the auth card at all screen sizes
* Responsive layouts work correctly across all breakpoints
* All CSS rules parse successfully
* Form elements resize correctly within flex and grid containers

## Files Changed

* `auth.css`

