### PR TITLE
fix: ErrorBoundary getDerivedStateFromError resets retryCount to 0 #3572

### DIFF
--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -21,11 +21,10 @@ class ErrorBoundary extends Component<Props, State> {
     };
   }
 
-  static getDerivedStateFromError(error: Error): State {
+  static getDerivedStateFromError(error: Error): Partial<State> {
     return { 
       hasError: true,
-      error,
-      retryCount: 0
+      error
     };
   }
 


### PR DESCRIPTION
### Description

Modified the static getDerivedStateFromError method inside ErrorBoundary.tsx to return a Partial<State> instead of a full State object. This removes the accidental retryCount: 0 overwrite that occurred every time a component threw an error. 

By preserving the existing state's counter during the error lifecycle, the maximum retry cap logic defined inside the handleRetry method can now execute and track sequential failures properly rather than resetting indefinitely.

### Related Issues

Closes #3572