### PR TITLE
fix: replace fa-regular clock icon with fa-solid to fix broken icon rendering

### DIFF
--- a/frontend/src/components/home/feature/feature.component.tsx
+++ b/frontend/src/components/home/feature/feature.component.tsx
@@ -102,7 +102,7 @@ const FeatureComponent = () => {
                             </span>
 
                             <p className="text-xs text-purple-400 font-medium flex items-center gap-1">
-                              <i className="fa-regular fa-clock"></i> {calculateReadingTime(post.content)} min read
+                              <i className="fa-solid fa-clock"></i> {calculateReadingTime(post.content)} min read
                             </p>
                           </div>
                         </div>


### PR DESCRIPTION
This PR fixes the broken clock icon displayed before the reading time in the Featured Posts section.

The project was using fa-regular fa-clock, which is not available in the free Font Awesome bundle being used. As a result, the icon was rendered incorrectly.

This change replaces:

fa-regular fa-clock

with:

fa-solid fa-clock

This is a one-line fix and does not affect any other functionality.

## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [* ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Checklist

- [*] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [*] I have filled in the related issue number when there is one.
- [*] I have tested my changes.
- [*] I have done a self-review of the code.

Screenshot

N/A – Simple one-line icon class replacement. No functional UI changes beyond fixing the broken icon rendering.