### PR TITLE
fix: match env var names in apiKeyRotationService fallbacks

### DIFF
--- a/backend/src/services/apiKeyRotationService.ts
+++ b/backend/src/services/apiKeyRotationService.ts
@@ -30,7 +30,9 @@ function loadKeys(): string[] {
 
   // Backward-compat fallbacks (single-key setups)
   const fallback =
+    process.env.OPEN_AI_KEY ??
     process.env.OPENAI_API_KEY ??
+    process.env.GEMINI_API_KEY ??
     process.env.GOOGLE_GEMINI_API_KEY ??
     "";
 
@@ -48,7 +50,7 @@ export function getNextApiKey(): string {
     throw new Error(
       "[apiKeyRotationService] No AI API keys found.\n" +
       "Set AI_API_KEYS=key1,key2,key3 in your .env file.\n" +
-      "Or set OPENAI_API_KEY / GOOGLE_GEMINI_API_KEY for single-key mode."
+      "Or set OPEN_AI_KEY / GEMINI_API_KEY for single-key mode."
     );
   }
 


### PR DESCRIPTION
Fixes #3568

## Problem
apiKeyRotationService.ts checked OPENAI_API_KEY and GOOGLE_GEMINI_API_KEY 
as fallbacks, but the codebase documents OPEN_AI_KEY and GEMINI_API_KEY 
in .env.example and config/index.ts.

This caused "No AI API keys found" error even when valid keys were set.

## Fix
Updated fallback chain to check both variants:
- OPEN_AI_KEY || OPENAI_API_KEY
- GEMINI_API_KEY || GOOGLE_GEMINI_API_KEY

This matches the pattern already used in ai.service.ts line 30.

## Testing
Set OPEN_AI_KEY in .env as documented → no error on story generation.