### PR TITLE
fix: remove dead socket reconnect listener — Socket.IO v3 fires reconnect on Manager not socket

### DIFF
--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -107,14 +107,12 @@ export const useNotifications = () => {
       };
 
       socket.on("connect", handleSocketConnected);
-      socket.on("reconnect", handleSocketConnected);
       socket.on("notification:new", handleNewNotification);
       socket.on("notification:updated", handleNotificationUpdated);
       socket.on("notification:all-read", handleAllRead);
 
       return () => {
         socket.off("connect", handleSocketConnected);
-        socket.off("reconnect", handleSocketConnected);
         socket.off("notification:new", handleNewNotification);
         socket.off("notification:updated", handleNotificationUpdated);
         socket.off("notification:all-read", handleAllRead);


### PR DESCRIPTION
### Related Issue
Closes #3627 

### Description of Changes
- Removed `socket.on("reconnect", handleSocketConnected)` and its corresponding `socket.off` cleanup from `useNotifications.ts`.
- In Socket.IO v3+, the `reconnect` event fires on `socket.io` (the Manager), not on the socket instance, so this listener silently never fired.
- The `connect` event already handles all reconnection scenarios correctly and remains in place.