### PR TITLE
fix: remove duplicate GoogleOAuthProvider wrapper

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -23,7 +23,6 @@ if (!container) {
 
 createRoot(container).render(
   <StrictMode>
-    <GoogleOAuthProvider clientId={GOOGLE_CLIENT_ID || ""}>
     <GoogleOAuthProvider clientId={GOOGLE_CLIENT_ID || "dummy-client-id"}>
       <Provider store={store}>
         <ThemeProvider>


### PR DESCRIPTION
## Related issue

Closes #3629 

## Screenshot (when helpful)

N/A

## What this PR does

Fixes a frontend compilation error in frontend/src/main.tsx caused by a duplicate GoogleOAuthProvider wrapper.

The duplicate opening tag resulted in mismatched JSX nesting, causing Vite to fail during startup with:

Unexpected closing "StrictMode" tag does not match opening "GoogleOAuthProvider" tag

This PR removes the extra GoogleOAuthProvider opening tag so the application can compile and start successfully.



## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [X] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update


## More screenshots (optional)
N/A

## Checklist

- [X] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [X] I have filled in the related issue number when there is one.
- [X] I have tested my changes.
- [X] I have done a self-review of the code.
