### PR TITLE
style(frontend): resolve page scrollbars, pricing/error theme contrast, and component alignments

### DIFF
--- a/frontend/src/components/community/community.component.tsx
+++ b/frontend/src/components/community/community.component.tsx
@@ -50,8 +50,7 @@ const CommunityComponent: React.FC = () => {
     <div className="min-h-screen bg-white text-slate-900 transition-colors duration-300 dark:bg-[#0b1329] dark:text-white">
       {/* Hero Section */}
       <section
-        className="relative pb-20 overflow-hidden"
-        style={{ paddingTop: 'calc(var(--header-height, 0px) + 8rem)' }}
+        className="relative pt-16 pb-20 overflow-hidden"
       >
         <div className="absolute top-0 left-1/2 -translate-x-1/2 w-[1000px] h-[600px] bg-blue-600/10 rounded-full blur-[120px] -z-10"></div>
 

--- a/frontend/src/components/login/login.component.tsx
+++ b/frontend/src/components/login/login.component.tsx
@@ -103,29 +103,56 @@ const LoginComponent = () => {
           transition={{ duration: 0.6, ease: "easeOut" }}
           className="hidden lg:flex flex-col justify-center gap-6 w-full max-w-md mx-auto box-border"
         >
-          <div className="flex justify-center items-center gap-6 border border-gray-300 dark:border-slate-700 rounded-2xl p-4 bg-slate-50 dark:bg-slate-800 dark:text-gray-400">
-            <WandSparkles className="text-violet-600 shrink-0" />
-            <div>
-              <h2 className="font-bold">Smart writing</h2>
-              <p className="text-sm">AI that understands your ideas</p>
-            </div>
+          {/* Brand headline */}
+          <div className="mb-1">
+            <h2 className="text-3xl font-extrabold text-slate-900 dark:text-white tracking-tight leading-tight">
+              Your stories,{" "}
+              <span className="bg-gradient-to-r from-indigo-600 to-violet-500 bg-clip-text text-transparent">
+                reimagined with AI.
+              </span>
+            </h2>
+            <p className="mt-3 text-sm text-slate-500 dark:text-slate-400 leading-relaxed">
+              Join thousands of writers creating amazing content with our AI-powered storytelling platform.
+            </p>
           </div>
 
-          <motion.div
-            initial={{ opacity: 0, scale: 0.95 }}
-            animate={{ opacity: 1, scale: 1 }}
-            transition={{ duration: 0.5, delay: 0.1 }}
-            className="bg-slate-50 dark:bg-slate-800/60 backdrop-blur-xl border border-slate-200 dark:border-slate-700/50 rounded-2xl p-6 sm:p-8 shadow-2xl w-full min-w-0 box-border"
-          >
-            <div className="border border-gray-300 dark:border-slate-700 p-4 rounded-2xl bg-slate-50 dark:bg-slate-800 dark:text-gray-400 text-sm">
-              Create, edit, and generate engaging multiple story variations from a
-              single prompt. Perfect for writers, creators, and enthusiasts
-              exploring the future of fiction.
+          {/* Feature cards */}
+          <div className="space-y-3">
+            <div className="flex items-start gap-4 rounded-2xl border border-violet-200/60 dark:border-violet-800/40 bg-violet-50 dark:bg-violet-950/40 p-4">
+              <div className="mt-0.5 shrink-0 rounded-xl border border-white/80 bg-white dark:bg-slate-800/80 p-2 shadow-sm">
+                <WandSparkles className="w-5 h-5 text-violet-500" />
+              </div>
+              <div>
+                <p className="text-sm font-bold text-slate-800 dark:text-slate-100">Smart AI Writing</p>
+                <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5 leading-relaxed">AI that understands your creative style and helps you break through blocks.</p>
+              </div>
             </div>
-          </motion.div>
+            <div className="flex items-start gap-4 rounded-2xl border border-blue-200/60 dark:border-blue-800/40 bg-blue-50 dark:bg-blue-950/40 p-4">
+              <div className="mt-0.5 shrink-0 rounded-xl border border-white/80 bg-white dark:bg-slate-800/80 p-2 shadow-sm">
+                <svg className="w-5 h-5 text-blue-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+                </svg>
+              </div>
+              <div>
+                <p className="text-sm font-bold text-slate-800 dark:text-slate-100">Infinite Variations</p>
+                <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5 leading-relaxed">Generate multiple unique story branches from a single prompt.</p>
+              </div>
+            </div>
+            <div className="flex items-start gap-4 rounded-2xl border border-pink-200/60 dark:border-pink-800/40 bg-pink-50 dark:bg-pink-950/40 p-4">
+              <div className="mt-0.5 shrink-0 rounded-xl border border-white/80 bg-white dark:bg-slate-800/80 p-2 shadow-sm">
+                <svg className="w-5 h-5 text-pink-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
+                </svg>
+              </div>
+              <div>
+                <p className="text-sm font-bold text-slate-800 dark:text-slate-100">Community Driven</p>
+                <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5 leading-relaxed">Publish, get feedback, and collaborate with a thriving creative ecosystem.</p>
+              </div>
+            </div>
+          </div>
         </motion.div>
 
-        <div className="flex justify-center w-full box-border">
+                <div className="flex justify-center w-full box-border">
           <div className="w-full max-w-md bg-slate-50 dark:bg-slate-800/60 backdrop-blur-xl border border-slate-200 dark:border-slate-700/50 rounded-2xl p-6 sm:p-8 lg:p-10 shadow-2xl box-border overflow-hidden relative mx-auto">
             <button
               onClick={() => (window.location.href = "/")}

--- a/frontend/src/components/story-inspiration/story_inspiration.component.tsx
+++ b/frontend/src/components/story-inspiration/story_inspiration.component.tsx
@@ -54,14 +54,9 @@ const StoryInspirationComponent: React.FC = () => {
 
         {/* Top Navigation */}
         <motion.div initial={{ opacity: 0, y: -15 }} animate={{ opacity: 1, y: 0 }} className="pt-10 flex items-center justify-between">
-          <button onClick={() => navigate("/")} className="group inline-flex items-center gap-3 px-5 py-3 rounded-2xl bg-white/70 dark:bg-white/[0.05] border border-white/60 dark:border-white/10 backdrop-blur-xl shadow-lg shadow-black/[0.03] hover:shadow-indigo-500/15 hover:border-indigo-400/40 transition-all duration-300">
-            <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-indigo-500 to-blue-500 flex items-center justify-center text-white shadow-lg">
-              <i className="fas fa-arrow-left text-sm group-hover:-translate-x-0.5 transition-transform" />
-            </div>
-            <div className="text-left">
-              <p className="text-sm font-semibold text-slate-800 dark:text-white">Back to Home</p>
-              <p className="text-xs text-slate-500 dark:text-slate-400">Return to homepage</p>
-            </div>
+          <button onClick={() => navigate("/")} className="group inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-white/70 dark:bg-white/[0.05] border border-white/60 dark:border-white/10 backdrop-blur-xl shadow-sm hover:border-indigo-400/40 transition-all duration-300 text-slate-700 dark:text-slate-300 text-sm font-semibold">
+            <i className="fas fa-arrow-left text-xs group-hover:-translate-x-0.5 transition-transform" />
+            Back to Home
           </button>
           <div className="hidden md:flex items-center gap-3 px-4 py-2 rounded-full bg-white/70 dark:bg-white/[0.04] border border-white/60 dark:border-white/10 backdrop-blur-xl">
             <div className="w-2 h-2 rounded-full bg-emerald-500 animate-pulse" />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -788,7 +788,7 @@ body {
 *,
 *::before,
 *::after {
-  box-sizing: inherit;
+  box-sizing: border-box;
 }
 
 button,


### PR DESCRIPTION
## Screenshot (when helpful)

### Pricing Cards Contrast (Before vs After)
<img width="1920" height="970" alt="pricing_page_1781905550755" src="https://github.com/user-attachments/assets/a75496f7-f53c-4f79-8bb4-6a0dcd6f0454" />
*Above: Original pricing cards with hardcoded dark text blending into dark overlay.*

<img width="1888" height="912" alt="image" src="https://github.com/user-attachments/assets/a54f14e7-5e0b-414e-9217-71ebbd538fd4" />
*Above: Corrected adaptive styling for light and dark theme modes.*

---

### Login Page Left Showcase (Before vs After)
<img width="1920" height="970" alt="login_page_1781905502750" src="https://github.com/user-attachments/assets/93fc9bf7-0c55-42c0-9c15-d62ee58903d5" />
*Above: Duplicate text blocks on left panel.*

<img width="1901" height="912" alt="image" src="https://github.com/user-attachments/assets/4e581f20-5824-43f5-969c-f48c7b1fccee" />
*Above: Optimized clean features list.*

## What this PR does

This PR resolves layout inconsistencies and alignment bugs:
1. **Global Scrollbar Bug (`index.css`)**: Changes box-sizing rule from browser default inheritance `content-box` to `border-box` reset globally. This resolves the wide overflow scrollbars on login/signup pages.
2. **Pricing Page (`pricing.component.tsx`)**: Upgrades pricing blocks with adaptive background classes (`bg-white dark:bg-slate-800`), custom feature checklist icons, and premium highlighted Pro tier styling.
3. **Login Panel (`login.component.tsx`)**: Replaces the redundant duplicate card copy in the left panel with a modern icon-driven feature list.
4. **Button & Padding Sizing (`story_inspiration.component.tsx` & `community.component.tsx`)**: Simplifies the oversized Back-to-Home button and corrects the community section top padding gap.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #3638 

## More screenshots (optional)

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
