### PR TITLE
fix: replace global memory rate limiter with distributed store

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -5,7 +5,6 @@ import express, {
   Response,
 } from "express";
 import helmet from "helmet";
-import rateLimit from "express-rate-limit";
 import cors from "cors";
 import httpStatus from "http-status";
 import cookieParser from "cookie-parser";
@@ -13,6 +12,7 @@ import config from "./config";
 import { Routers } from "./router";
 import globalErrorHandler from "./app/middleware/global.error.handler";
 import leaderboardRoute from "./routes/leaderboard.route";
+import globalRateLimiter from "./app/middleware/global.rate-limiter";
 
 
 const app: Application = express();
@@ -56,12 +56,7 @@ app.use(
 
 // Rate limiter — placed after CORS so OPTIONS preflight requests are
 // never counted against the limit before CORS has a chance to respond.
-const limiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  max: 100,
-  message: "Too many requests, please try again later.",
-});
-app.use(limiter);
+app.use(globalRateLimiter);
 
 // ─── 1. FIXED: ENFORCED HARDENED PAYLOAD LIMITS TO PREVENT DoS ───
 app.use(express.json({ limit: "2mb" }));

--- a/backend/src/app/middleware/global.rate-limiter.ts
+++ b/backend/src/app/middleware/global.rate-limiter.ts
@@ -1,0 +1,11 @@
+import { createRateLimiter } from "./ip.rate-limiter";
+
+export const globalRateLimiter = createRateLimiter({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  maxRequests: 100,
+  blockTimeMs: 15 * 60 * 1000,
+  keyPrefix: "global",
+  actionLabel: "request",
+});
+
+export default globalRateLimiter;


### PR DESCRIPTION
## Screenshot (when helpful)

N/A – Backend-only change. No UI modifications were made.

## What this PR does

This PR replaces the remaining global in-memory rate limiter with the project's existing distributed rate limiting infrastructure.

### Changes Made

* Added a new `global.rate-limiter.ts` middleware using the existing `createRateLimiter()` factory.
* Replaced the global `express-rate-limit` middleware in `app.ts`.
* Removed the unused `express-rate-limit` import.
* Preserved the original rate limiting configuration (100 requests per 15 minutes).

### Why this change?

The previous implementation relied on Express Rate Limit's default in-memory store, which does not enforce limits consistently across multiple application instances, containers, or serverless workers.

This update reuses the existing shared rate-limiting infrastructure already used throughout the project, ensuring consistent rate-limit enforcement across deployments.

## Type of change

* [x] Bug fix
* [ ] New feature
* [x] Code refactor
* [ ] Documentation update

## Related issue

Fixes #<#3654>

## More screenshots (optional)

N/A

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.
