### PR TITLE
fix(backend): Allow users to update writing goals by fixing strict Zod validation schema

### DIFF
--- a/backend/src/app/modules/user/user.interface.ts
+++ b/backend/src/app/modules/user/user.interface.ts
@@ -22,9 +22,7 @@ export interface IUser {
       twitter: string;
       linkedin: string;
       instagram: string;
-    github: string;
-    discord: string;
-      github: string;  
+      github: string;
       discord: string;
     };
   };

--- a/backend/src/app/modules/user/user.validation.ts
+++ b/backend/src/app/modules/user/user.validation.ts
@@ -65,6 +65,14 @@ const updateUser = z.object({
         .partial()
         .strict()
         .optional(),
+      writingGoals: z
+        .object({
+          dailyWordCount: z.number().min(0).optional(),
+          weeklyWordCount: z.number().min(0).optional(),
+        })
+        .partial()
+        .strict()
+        .optional(),
     })
     .partial()
     .strict(),


### PR DESCRIPTION
**Description:**
Closes #3672 
**What this PR does:**
This PR under gssoc'26 fixes a critical validation bug that prevented users from saving or updating their writing goals (daily and weekly word counts) via the `/api/v1/users/update` endpoint. It also resolves a TypeScript compilation error caused by duplicate keys in the `user.interface.ts`.

**Why it's needed:**
Although the user service (`updateUser`) had the necessary logic to process and persist `writingGoals.dailyWordCount` and `writingGoals.weeklyWordCount`, the corresponding Zod validation schema in `user.validation.ts` was missing the `writingGoals` field entirely. Because the schema enforces `.strict()` validation, any request containing `writingGoals` was completely rejected by the `validateRequest` middleware, returning a `400 Bad Request` error before the service layer could process it. This effectively broke the writing goals feature.

**Changes made:**
- Added the `writingGoals` object (with optional `dailyWordCount` and `weeklyWordCount` numbers) to the `updateUser` Zod schema to allow these fields to pass validation.
- Cleaned up duplicate `github` and `discord` properties in `IUser` within `user.interface.ts` to fix upstream TypeScript build errors.
- Verified the build locally with the TypeScript compiler.

**Checklist:**
- [x] I have read the contribution guidelines.
- [x] I have tested the changes locally.
- [x] My code follows the project's style guidelines.

@ronisarkarexe please check this