### PR TITLE
fix: migrate backend vercel.json from legacy builds/routes to modern functions/rewrites

### DIFF
--- a/backend/vercel.json
+++ b/backend/vercel.json
@@ -2,16 +2,15 @@
   "version": 2,
   "installCommand": "cd .. && npm install",
   "buildCommand": "npm run build",
-  "builds": [
-    {
-      "src": "src/server.ts",
-      "use": "@vercel/node"
+  "functions": {
+    "src/server.ts": {
+      "runtime": "@vercel/node@3.0.7"
     }
-  ],
-  "routes": [
+  },
+  "rewrites": [
     {
-      "src": "/(.*)",
-      "dest": "src/server.ts"
+      "source": "/(.*)",
+      "destination": "/src/server.ts"
     }
   ]
 }


### PR DESCRIPTION
## Screenshot (when helpful)

N/A

## What this PR does

backend/vercel.json was using Vercel's deprecated legacy 
builds and routes configuration. Vercel recommends 
migrating to the modern functions + rewrites format, 
which:-
1.  Supports modern Vercel features (Edge Functions, 
2.  better caching control)
3. Is the officially recommended configuration going forward
4.  Avoids unpredictable deployment behavior tied to 
5.  legacy config

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

#3658 

## More screenshots (optional)

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
