### PR TITLE
fix: revoke object URL after download and sanitize filename for invalid characters

### DIFF
--- a/frontend/src/utils/downloadStories.ts
+++ b/frontend/src/utils/downloadStories.ts
@@ -1,4 +1,10 @@
-export const downloadTXT = (story: any) => {
+interface DownloadableStory {
+  title: string;
+  prompt: string;
+  content: string;
+}
+
+export const downloadTXT = (story: DownloadableStory) => {
   const content = `Title: ${story.title}\nPrompt: ${story.prompt}\nStory: ${story.content}\nGenerated: ${new Date().toLocaleString()}`;
   const blob = new Blob([content], { type: 'text/plain' });
   const url = URL.createObjectURL(blob);

--- a/frontend/src/utils/downloadStories.ts
+++ b/frontend/src/utils/downloadStories.ts
@@ -1,8 +1,10 @@
 export const downloadTXT = (story: any) => {
   const content = `Title: ${story.title}\nPrompt: ${story.prompt}\nStory: ${story.content}\nGenerated: ${new Date().toLocaleString()}`;
   const blob = new Blob([content], { type: 'text/plain' });
+  const url = URL.createObjectURL(blob);
   const link = document.createElement('a');
-  link.href = URL.createObjectURL(blob);
-  link.download = `${story.title.replace(/\s/g, '_')}.txt`;
+  link.href = url;
+  link.download = `${story.title.replace(/[\\/:*?"<>|\s]+/g, '_')}.txt`;
   link.click();
+  URL.revokeObjectURL(url);
 };


### PR DESCRIPTION
## Related Issue
Closes #3679

## Description of Changes
- Store the blob URL in a variable and call `URL.revokeObjectURL()` after the download is triggered, preventing the memory leak
- Extended the filename sanitization regex from `/\s/g` (whitespace only) to `/[\\/:*?"<>|\s]+/g`, covering all OS-reserved filename characters

## Type of Change
- [x] Bug fix

## Testing
- Downloaded a story with a plain title — works as before
- Downloaded a story titled `My Story: Part 1?` — filename now sanitizes correctly
- Confirmed `URL.revokeObjectURL()` is called immediately after `link.click()`