### PR TITLE
fix: catch duplicate-key error on bookmark create to handle race condition gracefully

### DIFF
--- a/backend/src/app/modules/bookmark/bookmark.service.ts
+++ b/backend/src/app/modules/bookmark/bookmark.service.ts
@@ -30,9 +30,16 @@ const toggleBookmark = async (storyId: string, token: ITokenPayload) => {
     await Post.findByIdAndUpdate(post._id, { $inc: { bookmarksCount: -1 } });
     return { message: "Bookmark removed", isBookmarked: false };
   } else {
-    await Bookmark.create({ userId: user._id, storyId: post._id });
-    await Post.findByIdAndUpdate(post._id, { $inc: { bookmarksCount: 1 } });
-    return { message: "Story bookmarked!", isBookmarked: true };
+    try {
+      await Bookmark.create({ userId: user._id, storyId: post._id });
+      await Post.findByIdAndUpdate(post._id, { $inc: { bookmarksCount: 1 } });
+      return { message: "Story bookmarked!", isBookmarked: true };
+    } catch (err: any) {
+      if (err?.code === 11000) {
+        return { message: "Story already bookmarked!", isBookmarked: true };
+      }
+      throw err;
+    }
   }
 };
 
@@ -163,3 +170,5 @@ export const BookmarkService = {
   checkBookmarkStatus,
   deleteBookmark,
 };
+
+


### PR DESCRIPTION
## Related Issue
Closes #3682

## Description of Changes
Wrapped the `Bookmark.create()` call in `toggleBookmark` with a try/catch block. If a concurrent request already created the bookmark (triggering the unique compound index on `{ userId, storyId }`, error code `11000`), the function now returns a graceful "already bookmarked" response instead of letting the error propagate as an unhandled 500.

## Root Cause
The check-then-act pattern (`findOne` then `create`) is not atomic. Two near-simultaneous requests (double-click, retry) could both pass the `findOne` check before either `create` call resolves, causing the second `create` to fail on the unique index without being caught.

## Type of Change
- [x] Bug fix

## Testing
- Single bookmark toggle — works as before (bookmark/unbookmark)
- Simulated duplicate-key error path — returns graceful response instead of 500