### PR TITLE
fix: sanitize TXT filenames and revoke object URLs

### DIFF
--- a/frontend/src/utils/downloadStories.ts
+++ b/frontend/src/utils/downloadStories.ts
@@ -1,8 +1,16 @@
 export const downloadTXT = (story: any) => {
   const content = `Title: ${story.title}\nPrompt: ${story.prompt}\nStory: ${story.content}\nGenerated: ${new Date().toLocaleString()}`;
-  const blob = new Blob([content], { type: 'text/plain' });
-  const link = document.createElement('a');
-  link.href = URL.createObjectURL(blob);
-  link.download = `${story.title.replace(/\s/g, '_')}.txt`;
+
+  const blob = new Blob([content], { type: "text/plain" });
+
+  const url = URL.createObjectURL(blob);
+
+  const link = document.createElement("a");
+  link.href = url;
+
+  link.download = `${story.title.replace(/[\\/:*?"<>|\s]+/g, "_")}.txt`;
+
   link.click();
+
+  URL.revokeObjectURL(url);
 };


### PR DESCRIPTION
Closes #3679

## Screenshot

N/A – utility function improvement.

## What this PR does

This PR fixes issues in `downloadTXT()`:

* Sanitizes filenames by replacing invalid characters (`\ / : * ? " < > |`) and whitespace with underscores.
* Prevents object URL memory leaks by revoking blob URLs after download.
* Improves cross-browser compatibility for downloaded TXT files.

## Type of change

* [x] Bug fix

## Related issue

Closes #3679

## More screenshots

N/A

## Checklist

* [x] I have added screenshots or noted N/A.
* [x] I have filled in the related issue number.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.
