### PR TITLE
fix: remove malformed and duplicated twitter:image meta tag in index.html

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -31,8 +31,7 @@
     <meta name="twitter:description" content="Ignite your imagination with powerful AI-driven storytelling tools." />
     <meta name="twitter:image" content="https://storysparkai.vercel.app/og-image.jpg">
 >
-    <meta name="twitter:image" content="https://storysparkai.vercel.app/og-image.jpg" />
-    <link rel="icon" href="/favicon.ico" sizes="any" />
+    <link rel="icon" hr`ef="/favicon.ico" sizes="any" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />


### PR DESCRIPTION
## Screenshot (when helpful)

N/A


## What this PR does

`index.html` had a `twitter:image` meta tag missing its closing `/>`,
followed by a stray `>` on its own line, then the same tag duplicated
correctly right after it.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Fixes #3687 

## More screenshots (optional)

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.