### PR TITLE
fix: make Latest Posts heading visible in light theme fixes #2110

### DIFF
--- a/frontend/src/components/home/latest_posts/latest_posts.component.tsx
+++ b/frontend/src/components/home/latest_posts/latest_posts.component.tsx
@@ -36,7 +36,7 @@ const LatestPostsComponent = () => {
   return (
 
     <section className="w-full min-w-0 max-w-full">
-      <h2 className="mb-6 text-2xl font-bold !text-slate-900 dark:!text-gray-200">Latest Posts</h2>
+      <h2 className="mb-6 text-2xl font-bold text-slate-900 dark:text-white">Latest Posts</h2>
 
       <div className="max-w-full space-y-3">
         {visiblePosts.length > 0 ? (


### PR DESCRIPTION
## Issue
Fixes #2110

## Summary
The "Latest Posts" heading was not visible in light theme due to incorrect text color classes.

## Changes Made
- Removed `!` (important) flags from text color classes
- Changed to `text-slate-900 dark:text-white` for proper light/dark theme support

## Testing
- Verified heading is visible in both light and dark themes
