### PR TITLE
Fix story section heading colors

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -235,12 +235,7 @@ html, body {
   padding-block: clamp(3rem, 7vw, 5.5rem);
 }
 
-.story-section-heading {
-  color: #f8fafc;
-  font-size: clamp(1.875rem, 4vw, 2.75rem);
-  font-weight: 800;
-  line-height: 1.08;
-}
+
 
 .story-section-copy {
   color: #94a3b8;


### PR DESCRIPTION
Fixes #2119 

## Summary
Removed a duplicate 'story-section-heading' CSS rule from `frontend/src/index.css`.

## Changes
- Removed duplicate heading style definition
- Preserved existing dark-mode override
- No functional changes