### PR TITLE
test: add integration tests for addXp gamification data integrity

### DIFF
--- a/backend/src/__tests__/addXp.integration.test.ts
+++ b/backend/src/__tests__/addXp.integration.test.ts
@@ -1,4 +1,5 @@
 /// <reference types="jest" />
+
 import mongoose from "mongoose";
 import { MongoMemoryServer } from "mongodb-memory-server";
 import { User } from "../app/modules/user/user.model";
@@ -14,14 +15,18 @@ describe("addXp integration test (data loss verification)", () => {
     await mongoose.connect(mongoServer.getUri());
   });
 
+  afterEach(async () => {
+    await User.deleteMany({});
+  });
+
   afterAll(async () => {
     await mongoose.disconnect();
     await mongoServer.stop();
   });
 
   it("should verify if addXp causes data loss of adjacent gamification fields", async () => {
-    // 1. Create a user with complete gamification data
     const lastActiveDate = new Date("2026-06-09T00:00:00.000Z");
+
     const user = await User.create({
       email: "test1@example.com",
       role: ENUM_USER_ROLE.USER,
@@ -31,25 +36,27 @@ describe("addXp integration test (data loss verification)", () => {
         level: 2,
         streak: 5,
         badges: ["starter"],
-        lastActiveDate: lastActiveDate,
+        lastActiveDate,
       },
     });
 
-    // 2. Call the service to add XP
     await GamificationService.addXp(String(user._id), 50, "test");
 
-    // 3. Retrieve the updated user from DB
     const updatedUser = await User.findById(user._id);
 
-    console.log("TEST 1 - SIBLINGS INTACT:", JSON.stringify(updatedUser?.gamification, null, 2));
+    console.log(
+      "TEST 1 - SIBLINGS INTACT:",
+      JSON.stringify(updatedUser?.gamification, null, 2)
+    );
 
-    // 4. Run assertions
-    expect(updatedUser).toBeDefined();
+    expect(updatedUser).not.toBeNull();
     expect(updatedUser?.gamification?.xp).toBe(150);
     expect(updatedUser?.gamification?.level).toBe(2);
     expect(updatedUser?.gamification?.streak).toBe(5);
     expect(updatedUser?.gamification?.badges).toEqual(["starter"]);
-    expect(updatedUser?.gamification?.lastActiveDate?.toISOString()).toBe(lastActiveDate.toISOString());
+    expect(
+      updatedUser?.gamification?.lastActiveDate?.toISOString()
+    ).toBe(lastActiveDate.toISOString());
   });
 
   it("Test Case 1: should initialize gamification when it is missing", async () => {
@@ -57,16 +64,20 @@ describe("addXp integration test (data loss verification)", () => {
       email: "test2@example.com",
       role: ENUM_USER_ROLE.USER,
       status: USER_STATUS.ACTIVE,
-      // gamification object is completely missing (defaults should apply or be created)
     });
 
     await GamificationService.addXp(String(user._id), 50, "test");
 
     const updatedUser = await User.findById(user._id);
-    console.log("TEST 2 - MISSING GAMIFICATION INITIALIZED:", JSON.stringify(updatedUser?.gamification, null, 2));
 
+    console.log(
+      "TEST 2 - MISSING GAMIFICATION INITIALIZED:",
+      JSON.stringify(updatedUser?.gamification, null, 2)
+    );
+
+    expect(updatedUser).not.toBeNull();
     expect(updatedUser?.gamification?.xp).toBe(50);
-    expect(updatedUser?.gamification?.level).toBe(1); // floor(sqrt(50/100)) + 1 = 1
+    expect(updatedUser?.gamification?.level).toBe(1);
   });
 
   it("Test Case 2: should handle missing xp but existing siblings", async () => {
@@ -83,8 +94,13 @@ describe("addXp integration test (data loss verification)", () => {
     await GamificationService.addXp(String(user._id), 50, "test");
 
     const updatedUser = await User.findById(user._id);
-    console.log("TEST 3 - MISSING XP, SIBLINGS INTACT:", JSON.stringify(updatedUser?.gamification, null, 2));
 
+    console.log(
+      "TEST 3 - MISSING XP, SIBLINGS INTACT:",
+      JSON.stringify(updatedUser?.gamification, null, 2)
+    );
+
+    expect(updatedUser).not.toBeNull();
     expect(updatedUser?.gamification?.xp).toBe(50);
     expect(updatedUser?.gamification?.streak).toBe(5);
     expect(updatedUser?.gamification?.badges).toEqual(["starter"]);
@@ -104,9 +120,14 @@ describe("addXp integration test (data loss verification)", () => {
     await GamificationService.addXp(String(user._id), 20, "test");
 
     const updatedUser = await User.findById(user._id);
-    console.log("TEST 4 - LEVEL UP SCENARIO:", JSON.stringify(updatedUser?.gamification, null, 2));
 
+    console.log(
+      "TEST 4 - LEVEL UP SCENARIO:",
+      JSON.stringify(updatedUser?.gamification, null, 2)
+    );
+
+    expect(updatedUser).not.toBeNull();
     expect(updatedUser?.gamification?.xp).toBe(410);
-    expect(updatedUser?.gamification?.level).toBe(3); // floor(sqrt(410/100)) + 1 = floor(2.02) + 1 = 3
+    expect(updatedUser?.gamification?.level).toBe(3);
   });
 });


### PR DESCRIPTION
## Screenshot (when helpful)

N/A – This PR adds backend integration tests and does not introduce UI changes.

---

## What this PR does

* Adds integration tests for `GamificationService.addXp()`.
* Verifies that XP updates do not unintentionally overwrite adjacent fields within the `gamification` object.
* Covers scenarios where:

  * Existing gamification fields should remain intact after XP updates.
  * The gamification object is missing and must be initialized.
  * The XP field is missing while sibling fields already exist.
  * XP increases trigger level-up calculations correctly.
* Improves test isolation by clearing test data between test runs.

---

## Type of change

* [x] Bug fix

---

## Related issue

Closes #3728 

---

## More screenshots (optional)

N/A

---

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.
