### PR TITLE
fix: validate page, limit, dateFrom, and dateTo query params in search endpoint

### DIFF
--- a/backend/src/app/modules/search/search.controller.ts
+++ b/backend/src/app/modules/search/search.controller.ts
@@ -25,13 +25,52 @@ const search = catchAsync(async (req: Request, res: Response) => {
     });
   }
 
+  const parsedPage = page ? Number(page) : 1;
+  const parsedLimit = limit ? Number(limit) : 10;
+
+  if (!Number.isInteger(parsedPage) || parsedPage < 1) {
+    return sendResponse(res, {
+      statusCode: httpStatus.BAD_REQUEST,
+      success: false,
+      message: "page must be a positive integer",
+      data: null,
+    });
+  }
+
+  if (!Number.isInteger(parsedLimit) || parsedLimit < 1) {
+    return sendResponse(res, {
+      statusCode: httpStatus.BAD_REQUEST,
+      success: false,
+      message: "limit must be a positive integer",
+      data: null,
+    });
+  }
+
+  if (dateFrom && isNaN(new Date(dateFrom).getTime())) {
+    return sendResponse(res, {
+      statusCode: httpStatus.BAD_REQUEST,
+      success: false,
+      message: "dateFrom is not a valid date",
+      data: null,
+    });
+  }
+
+  if (dateTo && isNaN(new Date(dateTo).getTime())) {
+    return sendResponse(res, {
+      statusCode: httpStatus.BAD_REQUEST,
+      success: false,
+      message: "dateTo is not a valid date",
+      data: null,
+    });
+  }
+
   const result = await SearchService.search({
     q,
     type: type as "story" | "user" | "tag" | "all",
     genre,
     sortBy: sortBy as "relevance" | "date" | "popularity",
-    page: page ? parseInt(page, 10) : 1,
-    limit: limit ? Math.min(parseInt(limit, 10), 50) : 10,
+    page: parsedPage,
+    limit: Math.min(parsedLimit, 50),
     dateFrom,
     dateTo,
   });


### PR DESCRIPTION
## Related Issue
Closes #3748

## Description of Changes
Added validation for query parameters in `SearchController.search`:
- `page` and `limit` are now checked with `Number.isInteger()` and must be positive — invalid values (e.g. `page=abc`) now return a clean 400 instead of letting `NaN` flow into `.skip()`/`.limit()`
- `dateFrom` and `dateTo` are validated with `isNaN(new Date(...).getTime())` — invalid date strings now return a 400 instead of silently producing wrong/empty search results

## Root Cause
None of these query params were validated before being parsed/used. Non-numeric `page`/`limit` produced `NaN` flowing into MongoDB pagination, and invalid date strings created `Invalid Date` objects that MongoDB silently filtered on without error.

## Type of Change
- [x] Bug fix

## Testing
- `q` validation still works as before (existing tests pass)
- `page=abc` / `limit=abc` now returns 400 with clear message
- `dateFrom=notadate` now returns 400 with clear message
- Valid requests behave exactly as before