### PR TITLE
fix: check buffer length before timingSafeEqual to prevent RangeError on malformed payment signature

### DIFF
--- a/backend/src/controllers/payment.controller.ts
+++ b/backend/src/controllers/payment.controller.ts
@@ -113,10 +113,12 @@ export const verifyPayment = async (
       .update(`${razorpay_order_id}|${razorpay_payment_id}`)
       .digest("hex");
 
-    const isSignatureValid = crypto.timingSafeEqual(
-      Buffer.from(expectedSignature, "hex"),
-      Buffer.from(razorpay_signature, "hex")
-    );
+    const expectedBuffer = Buffer.from(expectedSignature, "hex");
+    const providedBuffer = Buffer.from(razorpay_signature, "hex");
+
+    const isSignatureValid =
+      expectedBuffer.length === providedBuffer.length &&
+      crypto.timingSafeEqual(expectedBuffer, providedBuffer);
 
     if (!isSignatureValid) {
       res.status(400).json({


### PR DESCRIPTION
## Related Issue
Closes #3750

## Description of Changes
Added a length comparison before calling `crypto.timingSafeEqual()` in `verifyPayment`. The two buffers are now confirmed to be the same length before the constant-time comparison runs.

## Root Cause
`crypto.timingSafeEqual()` throws a `RangeError` when the two buffers it compares are not the same length. Since `razorpay_signature` is taken directly from `req.body` with no prior length validation, an attacker could send a malformed/short signature and trigger an uncaught exception in a payment-critical code path instead of a clean 400 response.

## Type of Change
- [x] Bug fix (security)

## Testing
- Valid signature of correct length — verifies as before
- Malformed/short signature — now returns 400 cleanly instead of throwing
- Tampered signature of correct length — still correctly rejected