### PR TITLE
fix: remove deleted user from followers/following arrays

### DIFF
--- a/backend/src/app/modules/user/user.service.ts
+++ b/backend/src/app/modules/user/user.service.ts
@@ -109,6 +109,10 @@ const deleteUser = async (id: string): Promise<void> => {
   await Notification.deleteMany({ userId: id });
   await Post.deleteMany({ author: id });
 
+  // ─── FIX: REMOVE DANGLING REFERENCES ───
+  await User.updateMany({ followers: id }, { $pull: { followers: id } });
+  await User.updateMany({ following: id }, { $pull: { following: id } });
+
   const result = await User.deleteOne({ _id: id });
 
   if (result.deletedCount === 0) {


### PR DESCRIPTION
What this PR does
Fixes a bug where deleting a user left behind dangling ObjectId references in other users' followers and following arrays. Added updateMany operations with $pull to clean up these references across the database during user deletion.

Type of change
[x] Bug fix

Related issue
Closes #1026

Screenshot (when helpful)
N/A (Backend logic fix).

Checklist
[x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.

[x] I have filled in the related issue number when there is one.

[x] I have tested my changes.

[x] I have done a self-review of the code.