### PR TITLE
fix: replace Promise.race with raceGenerationWithTimeout in generateCharacterProfile

### DIFF
--- a/backend/src/app/modules/ai_model/ai_model.service.ts
+++ b/backend/src/app/modules/ai_model/ai_model.service.ts
@@ -5,7 +5,6 @@ import {
   GenerationTimeoutError,
   raceGenerationWithTimeout,
 } from "../../../utils/generation_timeout";
-import { timeoutLimit } from "../../../utils/timeout_limit";
 import {
   IAIModel,
   IAlternateEndingPayload,
@@ -323,17 +322,15 @@ Story:
 ${story}
 `;
 
-    const result = await Promise.race([
-      timeoutLimit(30000),
-      generateWithGeminiStories(characterPrompt, 300, 1),
-    ]);
+    const result = await raceGenerationWithTimeout(
+      (signal) => generateWithGeminiStories(characterPrompt, 300, 1, "English", signal),
+      30000,
+    );
 
     return result;
   } catch (error) {
-    throw new ApiError(
-      httpStatus.GATEWAY_TIMEOUT,
-      "Failed to generate character profiles!"
-    );
+    if (error instanceof GenerationTimeoutError || error instanceof ApiError) throw error;
+    mapGenerationError(error, "Failed to generate character profiles!");
   }
 };
 


### PR DESCRIPTION
﻿The generateCharacterProfile function used Promise.race with a raw setTimeout promise (timeoutLimit). The loser promise was never cancelled, producing an unhandled promise rejection on every non-timeout invocation. Starting from Node 15, unhandled rejections terminate the process.

Replaced with raceGenerationWithTimeout which uses AbortController to properly cancel the loser. Also fixed the catch block to pass through non-timeout API errors instead of always throwing GATEWAY_TIMEOUT.

Fixes #3765
