### PR TITLE
fix: implement server-side MongoDB caching for AI stories (#3759)

### DIFF
--- a/backend/src/models/storyCache.model.ts
+++ b/backend/src/models/storyCache.model.ts
@@ -1,0 +1,33 @@
+// backend/src/models/storyCache.model.ts
+import mongoose, { Schema, Document } from "mongoose";
+
+export interface IStoryCache extends Document {
+  promptKey: string;
+  provider: string;
+  storyData: string;
+  createdAt: Date;
+}
+
+const StoryCacheSchema: Schema = new Schema(
+  {
+    promptKey: { 
+      type: String, 
+      required: true, 
+      unique: true, // Prevents duplicate cache insertions
+      index: true   // Speeds up lookups on repeated views
+    },
+    provider: { 
+      type: String, 
+      required: true 
+    },
+    storyData: { 
+      type: String, 
+      required: true 
+    }
+  },
+  { 
+    timestamps: { createdAt: true, updatedAt: false } 
+  }
+);
+
+export default mongoose.model<IStoryCache>("StoryCache", StoryCacheSchema);

--- a/backend/src/models/storyCache.model.ts
+++ b/backend/src/models/storyCache.model.ts
@@ -30,4 +30,4 @@ const StoryCacheSchema: Schema = new Schema(
   }
 );
 
-export default mongoose.model<IStoryCache>("StoryCache", StoryCacheSchema);
+export const StoryCache = mongoose.model<IStoryCache>("StoryCache", StoryCacheSchema);

--- a/backend/src/services/ai.service.ts
+++ b/backend/src/services/ai.service.ts
@@ -5,6 +5,7 @@ import { buildStoryPrompt, PromptOptions } from "../utils/promptBuilder";
 import OpenAI from "openai";
 import { GoogleGenerativeAI } from "@google/generative-ai";
 import Anthropic from "@anthropic-ai/sdk";
+import StoryCache from "../models/storyCache.model"; // Added Cache Model Import
 
 let openai: OpenAI | null = null;
 let genAI: GoogleGenerativeAI | null = null;
@@ -155,8 +156,28 @@ export async function generateStory(
   // ── Prompt builder: morph into structured AI instructions ───────
   const { systemPrompt, userPrompt } = buildStoryPrompt(securePrompt, options);
 
+  // ── Cache Lookup Step ───────────────────────────────────────────────
+  // Combine prompt and key options to build a unique cache signature
+  const cacheKey = `${securePrompt.trim()}_${options?.genre || "default"}_${options?.length || "medium"}`;
+  
+  try {
+    const existingCache = await StoryCache.findOne({ promptKey: cacheKey });
+    if (existingCache) {
+      console.log("[CACHE HIT] Serving story instantly from MongoDB cache");
+      return {
+        story: existingCache.storyData,
+        provider: existingCache.provider as "openai" | "gemini" | "anthropic",
+        fallbackUsed: false
+      };
+    }
+  } catch (cacheError) {
+    // If the database cache check fails for any strange reason, log it but don't crash the generation flow
+    console.warn("[CACHE ERROR] Failed to query cache:", cacheError);
+  }
+
   const chosenProvider = provider?.toLowerCase();
   let didFallbackToGemini = false;
+  let finalResult: AIResponse | null = null;
 
   if (chosenProvider === "anthropic" || chosenProvider === "claude") {
     // ── Try Anthropic first ──────────────────────────────────────────────────
@@ -164,7 +185,7 @@ export async function generateStory(
       let story = await generateWithAnthropic(systemPrompt, userPrompt);
       story = validateOutput(story); // Security layer: validate output
       console.log("[AI] Story generated successfully via Anthropic");
-      return { story, provider: "anthropic", fallbackUsed: false };
+      finalResult = { story, provider: "anthropic", fallbackUsed: false };
     } catch (anthropicError) {
       console.warn(
         "[AI] Anthropic failed:",
@@ -185,8 +206,7 @@ export async function generateStory(
       let story = await generateWithOpenAI(systemPrompt, userPrompt);
       story = validateOutput(story); // Security layer: validate output
       console.log("[AI] Story generated successfully via OpenAI");
-
-      return { story, provider: "openai", fallbackUsed: false };
+      finalResult = { story, provider: "openai", fallbackUsed: false };
 
     } catch (openAIError) {
       console.warn(
@@ -212,22 +232,37 @@ export async function generateStory(
   }
 
   // ── Try Gemini as fallback / direct ───────────────────────────────────────
-  try {
-    let story = await generateWithGemini(systemPrompt, userPrompt);
-    story = validateOutput(story); // Security layer: validate output
-    console.log(`[AI] Story generated successfully via Gemini (${didFallbackToGemini ? "fallback" : "direct"})`);
+  if (!finalResult) {
+    try {
+      let story = await generateWithGemini(systemPrompt, userPrompt);
+      story = validateOutput(story); // Security layer: validate output
+      console.log(`[AI] Story generated successfully via Gemini (${didFallbackToGemini ? "fallback" : "direct"})`);
+      finalResult = { story, provider: "gemini", fallbackUsed: didFallbackToGemini };
 
-    return { story, provider: "gemini", fallbackUsed: didFallbackToGemini };
+    } catch (geminiError) {
+      console.error(
+        "[AI] Gemini also failed.",
+        geminiError instanceof Error ? geminiError.message : geminiError
+      );
 
-  } catch (geminiError) {
-    console.error(
-      "[AI] Gemini also failed.",
-      geminiError instanceof Error ? geminiError.message : geminiError
-    );
-
-    // All failed — throw a clean user-facing error
-    throw new Error(
-      "Story generation failed. All AI providers are currently unavailable. Please try again later."
-    );
+      // All failed — throw a clean user-facing error
+      throw new Error(
+        "Story generation failed. All AI providers are currently unavailable. Please try again later."
+      );
+    }
   }
+
+  // ── Populate Cache Before Returning ────────────────────────────────
+  try {
+    await StoryCache.create({
+      promptKey: cacheKey,
+      provider: finalResult.provider,
+      storyData: finalResult.story
+    });
+    console.log("[CACHE STORED] New AI story cached to MongoDB successfully");
+  } catch (saveCacheError) {
+    console.warn("[CACHE ERROR] Failed to save story generation to cache:", saveCacheError);
+  }
+
+  return finalResult;
 }

--- a/backend/src/services/ai.service.ts
+++ b/backend/src/services/ai.service.ts
@@ -5,7 +5,7 @@ import { buildStoryPrompt, PromptOptions } from "../utils/promptBuilder";
 import OpenAI from "openai";
 import { GoogleGenerativeAI } from "@google/generative-ai";
 import Anthropic from "@anthropic-ai/sdk";
-import StoryCache from "../models/storyCache.model"; // Added Cache Model Import
+import { StoryCache } from "../models/storyCache.model"; // Added Cache Model Import
 
 let openai: OpenAI | null = null;
 let genAI: GoogleGenerativeAI | null = null;


### PR DESCRIPTION
### Description
Closes #3759

This PR resolves the issue where AI-generated stories are recreated on every single page load, incurring high API costs and causing unnecessary 3-10 second loading latencies for identical content. 

### Changes Made
- Created a dedicated `StoryCache` Mongoose schema under `backend/src/models/storyCache.model.ts` to map and store structured story payloads with indexed prompt tokens.
- Updated the main core orchestration logic inside `generateStory` (`backend/src/services/ai.service.ts`) to leverage a clean Cache-Aside pattern.
- The service layer now validates and screens incoming cache keys against the database prior to evaluating downstream API calls (OpenAI/Anthropic/Gemini) and logs cache outcomes.

### Impact
- Eliminates repeated expensive API processing overhead for identical prompts.
- Delivers instantaneous rendering speed on repeated views.

Contributing under GSSoC'26! 🚀