### PR TITLE
fix: persist theme preference across page refreshes (#3483)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <script>
+      (function() {
+        var theme = localStorage.getItem("theme");
+        if (theme === "dark" || (!theme && window.matchMedia("(prefers-color-scheme: dark)").matches)) {
+          document.documentElement.classList.add("dark");
+        }
+      })();
+    </script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" type="image/svg+xml" href="/favicon.svg?v=2" />

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -23,15 +23,6 @@ if (!container) {
 
 createRoot(container).render(
   <StrictMode>
-    {/* <HelmetProvider> */}
-      <GoogleOAuthProvider clientId={GOOGLE_CLIENT_ID || "dummy-client-id"}>
-        <Provider store={store}>
-          <ThemeProvider>
-            <App />
-          </ThemeProvider>
-        </Provider>
-      </GoogleOAuthProvider>
-    {/* </HelmetProvider> */}
     <GoogleOAuthProvider clientId={GOOGLE_CLIENT_ID || "dummy-client-id"}>
       <Provider store={store}>
         <ThemeProvider>


### PR DESCRIPTION
Closes #3483

## Summary

Theme preference (dark/light mode) was not persisting across page refreshes on secondary pages. Two issues:

1. No inline script in `index.html` to apply the stored theme before React hydrates — the page would render with default styling until React reads localStorage
2. `main.tsx` had a duplicate `GoogleOAuthProvider > Provider > ThemeProvider > App` block causing double render

## Type of Change

- [x] Bug fix