### PR TITLE
fix(collab): guard CollabEditor socket against unconfigured VITE_SOCK…

### DIFF
--- a/frontend/src/components/collab/CollabEditor.tsx
+++ b/frontend/src/components/collab/CollabEditor.tsx
@@ -95,46 +95,64 @@ export default function CollabEditor({ storyId, userId, username, userColor }: C
     };
     awareness.on('update', renderRemoteCursors);
 
-    // Connect to backend socket.io namespace for Yjs sync
+    // Connect to backend socket.io namespace for Yjs sync.
+    // If VITE_SOCKET_URL is unconfigured, resolveSocketUrl() returns "".
+    // Skip the socket entirely so we don't attempt a doomed connection to
+    // the app's own origin (which has no Socket.IO server) and retry forever.
+    // The editor still works locally via Yjs + IndexedDB persistence.
     const socketUrl = resolveSocketUrl();
-    const socket = io(`${socketUrl}/yjs`, {
-      transports: ['websocket', 'polling'],
-      query: { storyId },
-      withCredentials: true,
-    });
-    socketRef.current = socket;
+    let socket: Socket | null = null;
+    let sendUpdate: ((update: Uint8Array) => void) | null = null;
 
-    // Receive initial sync from server
-    socket.on('sync', (update: Uint8Array) => {
-      Y.applyUpdate(ydoc, update);
-    });
+    if (socketUrl) {
+      socket = io(`${socketUrl}/yjs`, {
+        transports: ['websocket', 'polling'],
+        query: { storyId },
+        withCredentials: true,
+      });
+      socketRef.current = socket;
 
-    // Receive remote updates
-    socket.on('update', (update: Uint8Array) => {
-      Y.applyUpdate(ydoc, update);
-    });
+      socket.on('connect_error', (err: Error) => {
+        console.warn('[Story Spark] Collab editor socket connection error:', err.message);
+      });
 
-    // Broadcast local updates
-    const sendUpdate = (update: Uint8Array) => {
-      socket.emit('update', update);
-    };
-    ydoc.on('update', sendUpdate);
+      // Receive initial sync from server
+      socket.on('sync', (update: Uint8Array) => {
+        Y.applyUpdate(ydoc, update);
+      });
 
-    // Awareness updates
-    const sendAwareness = (awarenessUpdate: Uint8Array) => {
-      socket.emit('awareness', awarenessUpdate);
-    };
-    awareness.on('update', ({ added, updated, removed }: any) => {
-      const awUpdate = awareness.encodeUpdate(added.concat(updated).concat(removed));
-      sendAwareness(awUpdate);
-    });
-    socket.on('awareness', (aw: Uint8Array) => {
-      awareness.applyUpdate(aw);
-    });
+      // Receive remote updates
+      socket.on('update', (update: Uint8Array) => {
+        Y.applyUpdate(ydoc, update);
+      });
+
+      // Broadcast local updates
+      sendUpdate = (update: Uint8Array) => {
+        socket!.emit('update', update);
+      };
+      ydoc.on('update', sendUpdate);
+
+      // Awareness updates
+      const sendAwareness = (awarenessUpdate: Uint8Array) => {
+        socket!.emit('awareness', awarenessUpdate);
+      };
+      awareness.on('update', ({ added, updated, removed }: any) => {
+        const awUpdate = awareness.encodeUpdate(added.concat(updated).concat(removed));
+        sendAwareness(awUpdate);
+      });
+      socket.on('awareness', (aw: Uint8Array) => {
+        awareness.applyUpdate(aw);
+      });
+    } else {
+      console.warn(
+        '[Story Spark] Real-time sync disabled: VITE_SOCKET_URL is not configured. ' +
+        'The collaborative editor will work locally only (no live sync between users).'
+      );
+    }
 
     return () => {
-      ydoc.off('update', sendUpdate);
-      socket.disconnect();
+      if (sendUpdate) ydoc.off('update', sendUpdate);
+      socket?.disconnect();
     };
   }, [storyId, userId, username, userColor]);
 


### PR DESCRIPTION
## Screenshot (when helpful)
N/A — this is a non-UI logic fix to socket connection handling. Verified via console behavior (see Checklist).

## What this PR does
Fixes the remaining gap in #1636. The CollabHome banner, the shared socket helper, and the CollabRoom / useCollaboration paths already guard the unconfigured case on `main`. `CollabEditor.tsx` was the one collab entry point that did not.

**Problem:** `resolveSocketUrl()` returns `""` when `VITE_SOCKET_URL` is unset. The editor called `io(\`${socketUrl}/yjs\`)` regardless, which becomes `io("/yjs")` — Socket.IO then tries to connect to the app's own origin (Vite dev server / Vercel static host), where no Socket.IO server exists, and retries indefinitely with no user-facing feedback. Because `CollabRoom` renders `<CollabEditor>` unconditionally once a room loads, this fired even though `CollabRoom` itself already guards.

**Fix:**
- Skip socket setup entirely when `resolveSocketUrl()` is empty.
- Editor still works locally via Yjs + IndexedDB persistence (no live sync, but no broken/hanging state).
- Added a `connect_error` handler and a clear console warning.
- Cleanup handles the now-nullable `socket` / `sendUpdate`.

This matches the defensive pattern already used in `CollabRoom.tsx` and `useCollaboration.ts`. Single file changed.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue
Fixes #1636

## More screenshots (optional)
N/A

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason. — N/A, non-UI logic fix.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes. — With `VITE_SOCKET_URL` unset: no connection attempts, warning logged, editor loads and works locally. With it set: real-time sync unchanged.
- [x] I have done a self-review of the code.