### PR TITLE
test : added unit tests for regex.util escapeRegex function

### DIFF
--- a/backend/src/__tests__/regex.util.test.ts
+++ b/backend/src/__tests__/regex.util.test.ts
@@ -1,0 +1,89 @@
+import { escapeRegex } from "../utils/regex.util";
+
+describe("escapeRegex", () => {
+  it("returns empty string for empty input", () => {
+    expect(escapeRegex("")).toBe("");
+  });
+
+  it("passes plain strings through unchanged", () => {
+    expect(escapeRegex("hello world")).toBe("hello world");
+    expect(escapeRegex("story spark")).toBe("story spark");
+  });
+
+  it("escapes opening square bracket", () => {
+    expect(escapeRegex("text[more")).toBe("text\\[more");
+  });
+
+  it("escapes closing square bracket", () => {
+    expect(escapeRegex("text]more")).toBe("text\\]more");
+  });
+
+  it("escapes curly braces", () => {
+    expect(escapeRegex("{start}")).toBe("\\{start\\}");
+  });
+
+  it("escapes parentheses", () => {
+    expect(escapeRegex("(group)")).toBe("\\(group\\)");
+  });
+
+  it("escapes dot", () => {
+    expect(escapeRegex("file.txt")).toBe("file\\.txt");
+  });
+
+  it("escapes asterisk", () => {
+    expect(escapeRegex("a*b")).toBe("a\\*b");
+  });
+
+  it("escapes plus sign", () => {
+    expect(escapeRegex("a+b")).toBe("a\\+b");
+  });
+
+  it("escapes question mark", () => {
+    expect(escapeRegex("colou?r")).toBe("colou\\?r");
+  });
+
+  it("escapes caret", () => {
+    expect(escapeRegex("^start")).toBe("\\^start");
+  });
+
+  it("escapes dollar sign", () => {
+    expect(escapeRegex("end$")).toBe("end\\$");
+  });
+
+  it("escapes backslash", () => {
+    expect(escapeRegex("path\\to")).toBe("path\\\\to");
+  });
+
+  it("escapes pipe", () => {
+    expect(escapeRegex("a|b")).toBe("a\\|b");
+  });
+
+  it("escapes hash", () => {
+    expect(escapeRegex("tag#1")).toBe("tag\\#1");
+  });
+
+  it("escapes hyphen (when not in character class range)", () => {
+    expect(escapeRegex("a-b")).toBe("a\\-b");
+  });
+
+  it("escapes all metacharacters in a combined string", () => {
+    const result = escapeRegex("[a-z]{1,3}(foo|bar)+?bar$");
+    expect(result).toBe(
+      "\\[a\\-z\\]\\{1\\,3\\}\\(foo\\|bar\\)\\+?bar\\$"
+    );
+  });
+
+  it("output can be safely used as pattern in RegExp constructor", () => {
+    const userInput = "users[id]: (test|example)*";
+    const escaped = escapeRegex(userInput);
+    expect(() => new RegExp(escaped)).not.toThrow();
+  });
+
+  it("escaped pattern matches the original literal string when wrapped", () => {
+    const literal = "hello.world";
+    const escaped = escapeRegex(literal);
+    const regex = new RegExp(escaped);
+    expect("hello.world").toMatch(regex);
+    expect("helloXworld").not.toMatch(regex);
+  });
+});


### PR DESCRIPTION
Closes #3789.

Summary of What Has Been Done:
Added unit tests for the escapeRegex function in backend/src/utils/regex.util.ts. Tests cover plain strings, all 12 regex metacharacters individually, combined metacharacter strings, empty input, RegExp constructor safety, and that escaped patterns match literal strings correctly.

Changes Made:
- backend/src/__tests__/regex.util.test.ts: new test file (89 lines)
- Tests all 12 metacharacters: [ ] { } ( ) . * + ? ^ $ \ | # -
- Verifies escaped output can be safely used in new RegExp() without throwing

Impact it Made:
- Test coverage for a security-adjacent utility used in MongoDB  queries
- Regression safety for the metacharacter escaping logic

Note: Please assign this PR to the `tmdeveloper007` account.