### PR TITLE
fix: resolve duplicate React app rendering and eager imports

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,51 +1,21 @@
 import React, { lazy, Suspense } from "react";
 import { createBrowserRouter, Outlet, RouterProvider, Navigate } from "react-router-dom";
-
 import { USER_ROLE } from "./constants/role";
 
-import React from "react";
-import { createBrowserRouter, Navigate, Outlet, RouterProvider } from "react-router-dom";
-import ScrollToTop from "./components/ScrollToTop";
-import StoryInspirationWrapper from "./components/StoryInspirationWrapper";
-import WritingAssistantComponent from "./components/writing-assistant/writing_assistant.component";
-import CollabHome from "./components/collab/CollabHome";
-import CollabRoom from "./components/collab/CollabRoom";
-import HeroSectionComponent from "./components/hero/hero_section.component";
-import HomeComponent from "./components/home/home.component";
-import LoginComponent from "./components/login/login.component";
-import SignUpComponent from "./components/signup/signup.component";
-import DashboardComponent from "./components/dashboard/dashboard.component";
-import RootLayout from "./components/layout/root_layout.component";
-import DashboardLayout from "./components/dashboard/dashboard_layout.component";
+// Eagerly loaded layouts, utilities, and components
 import LoadingAnimation from "./components/loading/loading.component";
 import ProtectedRoute from "./components/ProtectedRoute";
-import ScrollToTopButton from "./components/ScrollToTopButton";
+import NotFoundComponent from "./components/not-found.component";
+import Leaderboard from "./pages/Leaderboard";
+import HeroSectionComponent from "./components/hero/hero_section.component";
+import HomeComponent from "./components/home/home.component";
 import ScrollToTop from "./components/ScrollToTop";
+import ScrollToTopButton from "./components/ScrollToTopButton";
 import PageTitleUpdater from "./components/PageTitleUpdater";
 import MagicCursorComponent from "./components/magic-cursor/magic_cursor.component";
 import ThemeSwitcher from "./components/theme-switcher/ThemeSwitcher";
-import HeroSectionComponent from "./components/hero/hero_section.component";
-import HomeComponent from "./components/home/home.component";
-
-import NotFoundComponent from "./components/not-found.component";
-import Leaderboard from "./pages/Leaderboard";
-import PaymentComponent from "./components/home/pricing/payment.component";
-import PostDetailsComponent from "./components/post/post.details.component";
-import PostListsComponent from "./components/dashboard/posts/post_lists.component";
-import PricingComponent from "./components/pricing/pricing.component";
-import PrivacyPolicy from "./components/footer/Privacy.tsx";
-import ProfileComponent from "./components/dashboard/profile/profile.component";
-import PublishedStoriesComponent from "./components/dashboard/posts/published_stories.component";
-import ReportBug from "./components/report-bug/ReportBug";
-import ResourceDetailComponent from "./components/community/resource_detail.component";
-import ResourcesListComponent from "./components/community/resources_list.component";
-import ScrollToTop from "./components/ScrollToTop";
-import ScrollToTopButton from "./components/ScrollToTopButton";
-import SettingComponent from "./components/dashboard/settings/settings.component";
-import SignUpComponent from "./components/signup/signup.component";
-import SimpleProtectedRoute from "./components/ProtectedRoute";
-import StoriesComponent from "./components/stories/stories.component";
-import ChatPage from "./components/chat/ChatPage";
+import RootLayout from "./components/layout/root_layout.component";
+import DashboardLayout from "./components/dashboard/dashboard_layout.component";
 
 type ProtectedRouteProps = {
   allowedRoles: string[];
@@ -93,7 +63,6 @@ const AnalyticsPage = lazy(() => import("./components/dashboard/analytics/analyt
 const PostListsComponent = lazy(() => import("./components/dashboard/posts/post_lists.component"));
 const EmailValidationComponent = lazy(() => import("./components/email_validation/email.validation.component"));
 const PaymentComponent = lazy(() => import("./components/home/pricing/payment.component"));
-const SearchPageComponent = lazy(() => import("./pages/analytics/SearchPage"));
 const ChatPage = lazy(() => import("./components/chat/ChatPage"));
 
 const ALL_ROLES = [USER_ROLE.ADMIN, USER_ROLE.SUPER_ADMIN, USER_ROLE.WRITER, USER_ROLE.USER];
@@ -115,41 +84,40 @@ const router = createBrowserRouter([
     ),
     children: [
       { index: true, element: <><HeroSectionComponent /><HomeComponent /></> },
-      { path: "templates", element: <TemplatesComponent /> },
+      { path: "templates", element: lazyPage(<TemplatesComponent />) },
       { path: "create", element: <Navigate to="/stories" replace /> },
-      { path: "writing-assistant", element: <ProtectedRoute allowedRoles={ALL_ROLES}><WritingAssistantComponent /></ProtectedRoute>, },
-      { path: "story-inspiration", element: <StoryInspirationWrapper /> },
-      { path: "login", element: <LoginComponent /> },
-      { path: "signup", element: <SignUpComponent /> },
-      { path: "forgot-password", element: <ForgotPasswordComponent /> },
-      { path: "pricing", element: <PricingComponent /> },
-      { path: "post/:id", element: <PostDetailsComponent /> },
-      { path: "profile/:id", element: <PublicProfileComponent /> },
-      { path: "contact-us", element: <Contact /> },
-      { path: "about-us", element: <AboutUsComponent /> },
-      { path: "career", element: <CareerComponent /> },
-      { path: "blog", element: <BlogComponent /> },
-      { path: "privacy-policy", element: <PrivacyPolicy /> },
-      { path: "cookie-policy", element: <CookiePolicy /> },
-      { path: "terms", element: <Terms /> },
-      { path: "help-center", element: <HelpCenterComponent /> },
-      { path: "guidelines", element: <GuidelinesComponent /> },
-      
-      { path: "contributors", element: <ContributorsComponent /> },
+      { path: "writing-assistant", element: <ProtectedRoute allowedRoles={ALL_ROLES}>{lazyPage(<WritingAssistantComponent />)}</ProtectedRoute> },
+      { path: "story-inspiration", element: lazyPage(<StoryInspirationWrapper />) },
+      { path: "login", element: lazyPage(<LoginComponent />) },
+      { path: "signup", element: lazyPage(<SignUpComponent />) },
+      { path: "forgot-password", element: lazyPage(<ForgotPasswordComponent />) },
+      { path: "pricing", element: lazyPage(<PricingComponent />) },
+      { path: "post/:id", element: lazyPage(<PostDetailsComponent />) },
+      { path: "profile/:id", element: lazyPage(<PublicProfileComponent />) },
+      { path: "contact-us", element: lazyPage(<Contact />) },
+      { path: "about-us", element: lazyPage(<AboutUsComponent />) },
+      { path: "career", element: lazyPage(<CareerComponent />) },
+      { path: "blog", element: lazyPage(<BlogComponent />) },
+      { path: "privacy-policy", element: lazyPage(<PrivacyPolicy />) },
+      { path: "cookie-policy", element: lazyPage(<CookiePolicy />) },
+      { path: "terms", element: lazyPage(<Terms />) },
+      { path: "help-center", element: lazyPage(<HelpCenterComponent />) },
+      { path: "guidelines", element: lazyPage(<GuidelinesComponent />) },
+      { path: "contributors", element: lazyPage(<ContributorsComponent />) },
       { path: "leaderboard", element: <Leaderboard /> },
-      { path: "community", element: <CommunityComponent /> },
-      { path: "report-bug", element: <ReportBug /> },
-      { path: "chat", element: <ChatPage /> },
+      { path: "community", element: lazyPage(<CommunityComponent />) },
+      { path: "report-bug", element: lazyPage(<ReportBug />) },
+      { path: "chat", element: lazyPage(<ChatPage />) },
       {
         element: <ProtectedRoute allowedRoles={ALL_ROLES} />,
         children: [
-          { path: "explore", element: <ExploreComponent /> },
-          { path: "bookmarks", element: <BookmarksComponent /> },
-          { path: "resources", element: <ResourcesListComponent /> },
-          { path: "resources/:resourceName", element: <ResourceDetailComponent /> },
-          { path: "stories", element: <StoriesComponent /> },
-          { path: "branching-story", element: <BranchingStory /> },
-          { path: "story-workspace", element: <StoryWorkspace /> },
+          { path: "explore", element: lazyPage(<ExploreComponent />) },
+          { path: "bookmarks", element: lazyPage(<BookmarksComponent />) },
+          { path: "resources", element: lazyPage(<ResourcesListComponent />) },
+          { path: "resources/:resourceName", element: lazyPage(<ResourceDetailComponent />) },
+          { path: "stories", element: lazyPage(<StoriesComponent />) },
+          { path: "branching-story", element: lazyPage(<BranchingStory />) },
+          { path: "story-workspace", element: lazyPage(<StoryWorkspace />) },
         ],
       },
       { path: "*", element: <NotFoundComponent /> },
@@ -187,41 +155,40 @@ const router = createBrowserRouter([
         ),
         children: [
           { index: true, element: <><HeroSectionComponent /><HomeComponent /></> },
-          { path: "templates", element: <TemplatesComponent /> },
-          { path: "writing-assistant", element: <WritingAssistantComponent /> },
-          { path: "story-inspiration", element: <StoryInspirationWrapper /> },
-          { path: "login", element: <LoginComponent /> },
-          { path: "signup", element: <SignUpComponent /> },
-          { path: "forgot-password", element: <ForgotPasswordComponent /> },
-          { path: "pricing", element: <PricingComponent /> },
-          { path: "post/:id", element: <PostDetailsComponent /> },
-          { path: "contact-us", element: <Contact /> },
-          { path: "about-us", element: <AboutUsComponent /> },
-          { path: "career", element: <CareerComponent /> },
-          { path: "blog", element: <BlogComponent /> },
-          { path: "privacy-policy", element: <PrivacyPolicy /> },
-          { path: "cookie-policy", element: <CookiePolicy /> },
-          { path: "terms", element: <Terms /> },
-          { path: "help-center", element: <HelpCenterComponent /> },
-          { path: "guidelines", element: <GuidelinesComponent /> },
-          
-          { path: "contributors", element: <ContributorsComponent /> },
-          { path: "community", element: <CommunityComponent /> },
-          { path: "report-bug", element: <ReportBug /> },
+          { path: "templates", element: lazyPage(<TemplatesComponent />) },
+          { path: "writing-assistant", element: lazyPage(<WritingAssistantComponent />) },
+          { path: "story-inspiration", element: lazyPage(<StoryInspirationWrapper />) },
+          { path: "login", element: lazyPage(<LoginComponent />) },
+          { path: "signup", element: lazyPage(<SignUpComponent />) },
+          { path: "forgot-password", element: lazyPage(<ForgotPasswordComponent />) },
+          { path: "pricing", element: lazyPage(<PricingComponent />) },
+          { path: "post/:id", element: lazyPage(<PostDetailsComponent />) },
+          { path: "contact-us", element: lazyPage(<Contact />) },
+          { path: "about-us", element: lazyPage(<AboutUsComponent />) },
+          { path: "career", element: lazyPage(<CareerComponent />) },
+          { path: "blog", element: lazyPage(<BlogComponent />) },
+          { path: "privacy-policy", element: lazyPage(<PrivacyPolicy />) },
+          { path: "cookie-policy", element: lazyPage(<CookiePolicy />) },
+          { path: "terms", element: lazyPage(<Terms />) },
+          { path: "help-center", element: lazyPage(<HelpCenterComponent />) },
+          { path: "guidelines", element: lazyPage(<GuidelinesComponent />) },
+          { path: "contributors", element: lazyPage(<ContributorsComponent />) },
+          { path: "community", element: lazyPage(<CommunityComponent />) },
+          { path: "report-bug", element: lazyPage(<ReportBug />) },
           // Public routes
           { path: "explore", element: lazyPage(<ExploreComponent />) },
-          { path: "resources", element: <ResourcesListComponent /> },
-          { path: "resources/:resourceName", element: <ResourceDetailComponent /> },
+          { path: "resources", element: lazyPage(<ResourcesListComponent />) },
+          { path: "resources/:resourceName", element: lazyPage(<ResourceDetailComponent />) },
           { path: "chat", element: lazyPage(<ChatPage />) },
 
           // Protected routes
           {
             element: <ProtectedRoute allowedRoles={ALL_ROLES} />,
             children: [
-              { path: "bookmarks", element: <BookmarksComponent /> },
-              { path: "stories", element: <StoriesComponent /> },
-              { path: "branching-story", element: <BranchingStory /> },
-              { path: "story-workspace", element: <StoryWorkspace /> },
+              { path: "bookmarks", element: lazyPage(<BookmarksComponent />) },
+              { path: "stories", element: lazyPage(<StoriesComponent />) },
+              { path: "branching-story", element: lazyPage(<BranchingStory />) },
+              { path: "story-workspace", element: lazyPage(<StoryWorkspace />) },
             ],
           },
           { path: "*", element: <NotFoundComponent /> },
@@ -250,24 +217,24 @@ const router = createBrowserRouter([
               </Suspense>
             ),
             children: [
-              { index: true, element: <DashboardComponent /> },
-              { path: "profile", element: <ProfileComponent /> },
-              { path: "settings", element: <SettingComponent /> },
-              { path: "published-stories", element: <PublishedStoriesComponent /> },
+              { index: true, element: lazyPage(<DashboardComponent />) },
+              { path: "profile", element: lazyPage(<ProfileComponent />) },
+              { path: "settings", element: lazyPage(<SettingComponent />) },
+              { path: "published-stories", element: lazyPage(<PublishedStoriesComponent />) },
               {
                 element: <ProtectedRoute allowedRoles={ELEVATED_ADMIN_ROLES} />,
                 children: [
-                  { path: "writers", element: <WriterApplicationComponent /> },
-                  { path: "users", element: <UserComponent /> },
+                  { path: "writers", element: lazyPage(<WriterApplicationComponent />) },
+                  { path: "users", element: lazyPage(<UserComponent />) },
                 ],
               },
               {
                 element: <ProtectedRoute allowedRoles={[USER_ROLE.WRITER]} />,
-                children: [{ path: "analytics", element: <AnalyticsPage /> }],
+                children: [{ path: "analytics", element: lazyPage(<AnalyticsPage />) }],
               },
               {
                 element: <ProtectedRoute allowedRoles={WRITER_PLUS_ADMIN_ROLES} />,
-                children: [{ path: "post-lists", element: <PostListsComponent /> }],
+                children: [{ path: "post-lists", element: lazyPage(<PostListsComponent />) }],
               },
             ],
           },

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,7 +2,6 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { Provider } from "react-redux";
 import { GoogleOAuthProvider } from "@react-oauth/google";
-// import { HelmetProvider } from "react-helmet-async";
 import App from "./App.tsx";
 import { store } from "./redux/store.ts";
 import { ThemeProvider } from "./components/theme/theme.context";
@@ -18,20 +17,13 @@ if (!GOOGLE_CLIENT_ID) {
 const container = document.getElementById("root");
 
 if (!container) {
-  throw new Error("Failed to find the root element. Ensure index.html has <div id='root'></div>");
+  throw new Error(
+    "Failed to find the root element. Ensure index.html has <div id='root'></div>"
+  );
 }
 
 createRoot(container).render(
   <StrictMode>
-    {/* <HelmetProvider> */}
-      <GoogleOAuthProvider clientId={GOOGLE_CLIENT_ID || "dummy-client-id"}>
-        <Provider store={store}>
-          <ThemeProvider>
-            <App />
-          </ThemeProvider>
-        </Provider>
-      </GoogleOAuthProvider>
-    {/* </HelmetProvider> */}
     <GoogleOAuthProvider clientId={GOOGLE_CLIENT_ID || "dummy-client-id"}>
       <Provider store={store}>
         <ThemeProvider>


### PR DESCRIPTION
## Screenshot (when helpful)

N/A (Bootstrap and routing optimization fix. Confirmed that the application still renders identically, but console logs, context instances, and component trees are no longer doubled.)

## What this PR does

This PR resolves two critical optimization bugs in the application entry points:

1. **Duplicate Application Tree in `main.tsx`**:
   The entire Provider and App component tree (`<GoogleOAuthProvider><Provider><ThemeProvider><App /></ThemeProvider></Provider></GoogleOAuthProvider>`) was rendered twice inside `<StrictMode>`. This created two concurrent React trees, double-mounted all contexts, and doubled Redux store setups. Removed the duplicate tree so the application boots up exactly once.

2. **Duplicate/Shadowed Imports in `App.tsx`**:
   Over 20 pages were imported eagerly at the top of the file AND lazily below. This shadowed the eager imports, breaking code-splitting (Vite pulled all pages into the main chunk) and causing TypeScript duplicate identifier errors. Cleaned up the eager imports block, keeping only the layout, loader, and core landing components eager, and wrapped the remaining lazy components in `lazyPage` Suspense fallbacks to prevent routing crashes.

## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [x] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Documentation update

## Related issue

Closes #3807 

## More screenshots (optional)

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
