### PR TITLE
fix: resolve layout jump shifts on genre filter toggle

### DIFF
--- a/frontend/src/components/story-inspiration/story_inspiration.component.tsx
+++ b/frontend/src/components/story-inspiration/story_inspiration.component.tsx
@@ -197,7 +197,7 @@ const StoryInspirationComponent: React.FC = () => {
 
         {/* Stories Grid */}
         {filteredStories.length > 0 ? (
-          <motion.div layout className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+          <motion.div layout className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 min-h-[75vh]">
             {filteredStories.map((story) => (
               <StoryInspirationCard key={story.id} story={story} />
             ))}


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Open or link a related issue when there is one (`Closes #123`, `Fixes #45`, or write **None** under Related issue below).
- **Description:** Fill in **What this PR does** so a reviewer can understand the change without your local context.
- **Screenshots:** Add screenshots or a short recording when they help (UI changes, confusing flows, or non-code proof). If not needed, say so in the checklist.

## Screenshot (when helpful)

N/A - Minor CSS container height adjustment (`min-h-[75vh]`) to stabilize dynamic content height shifts during list filtering.



## What this PR does
Fixes the sudden vertical layout shifts/viewport jumps when selecting different genre filter tags on the `/story-inspiration` page.

By adding a `min-h-[75vh]` layout boundary class to the dynamic `<motion.div>` grid wrapper in `story_inspiration.component.tsx`, the structural height remains stable while Framer Motion filters the card lists. This prevents the page layout from collapsing and keeps the user's vertical scroll position perfectly still.




## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [x ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #3799



## More screenshots (optional)

<!-- Extra before/after images, flows, or recordings for reviewers. -->



## Checklist

- [ ] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [ x] I have filled in the related issue number when there is one.
- [x ] I have tested my changes.
- [ x] I have done a self-review of the code.
