### PR TITLE
fix: add onError to useEffect dependency array in useCollaboration (fixes #3814)

### DIFF
--- a/frontend/src/hooks/useCollaboration.ts
+++ b/frontend/src/hooks/useCollaboration.ts
@@ -1,4 +1,4 @@
-﻿import { useEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import { io, Socket } from "socket.io-client";
 import { getToken } from "../services/auth.service";
 import { resolveSocketUrl } from "../helpers/socket-url";
@@ -137,7 +137,7 @@ export function useCollaboration({
       socket.disconnect();
       socketRef.current = null;
     };
-  }, [roomId]);
+  }, [roomId, onError]);
 
   const addText = useCallback(
     (text: string) => {


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Fixes #3814
- **Description:** The `useCollaboration` hook was using `onError` inside a `useEffect` but missing it from the dependency array, causing React to flag a warning and resulting in a stale closure.
- **Screenshots:** N/A

> 🏷️ **GSSoC'26 Contribution** — Please add the `GSSoC` label to this PR.
> I am contributing to this issue under **GirlScript Summer of Code 2026**.

## Screenshot (when helpful)

N/A

## What this PR does

Adds `onError` to the dependency array of the `useEffect` hook inside `useCollaboration.ts` to prevent stale closure warnings.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change which updates existing code structure)
- [ ] Documentation update

## Related issue

Fixes #3814

## More screenshots (optional)

N/A
