### PR TITLE
fix : added 400 status for invalid ObjectId in handleCastError

### DIFF
--- a/backend/src/errors/handle_cast_error.ts
+++ b/backend/src/errors/handle_cast_error.ts
@@ -2,7 +2,7 @@ import mongoose from "mongoose";
 import { IGenericErrorMessage } from "../interfaces/error";
 
 const handleCastError = (err: mongoose.Error.CastError) => {
-  const statusCode = 500;
+  const statusCode = 400;
   const errors: IGenericErrorMessage[] = [
     {
       path: err.path,


### PR DESCRIPTION
Closes #3833.

Summary of What Has Been Done:
Changed the statusCode returned by handleCastError from 500 (Internal Server Error) to 400 (Bad Request). An invalid MongoDB ObjectId format is a client input validation error, not a server-side failure, so the correct HTTP status is 400.

Changes Made:
- backend/src/errors/handle_cast_error.ts: const statusCode = 400 (was 500)

Impact it Made:
- Correct HTTP semantics for API consumers
- Allows clients to distinguish malformed input (400) from internal errors (500)
- Local build verification passed with tsc

Note: Please assign this PR to the `tmdeveloper007` account.