### PR TITLE
feat: add new story genres

### DIFF
--- a/backend/src/utils/promptBuilder.ts
+++ b/backend/src/utils/promptBuilder.ts
@@ -16,6 +16,73 @@ export interface StructuredPrompt {
   userPrompt: string;
 }
 
+const DEFAULT_GENRE = "general fiction";
+
+const GENRE_PROMPT_INSTRUCTIONS: Record<string, string> = {
+  drama:
+    "Write a character-driven drama with emotional conflict, realistic stakes, and meaningful character development.",
+
+  comedy:
+    "Write a light, humorous story with funny situations, witty dialogue, and an entertaining resolution.",
+
+  horror:
+    "Write a suspenseful horror story with tension, fear, atmosphere, and a chilling but age-appropriate narrative.",
+
+  romance:
+    "Write an emotional romance story focused on relationships, feelings, trust, conflict, and heartfelt resolution.",
+
+  "sci-fi":
+    "Write a science-fiction story involving futuristic ideas, advanced technology, discovery, and imaginative world-building.",
+
+  fantasy:
+    "Write a fantasy story with magical elements, imaginative worlds, quests, wonder, and memorable characters.",
+
+  mystery:
+    "Write a mystery story with clues, suspense, investigation, secrets, and a satisfying reveal.",
+
+  adventure:
+    "Write an adventure story with exploration, risk, discovery, challenges, and a heroic journey.",
+
+  adventurous:
+    "Write an action-packed adventurous story with quests, danger, exploration, challenges, and a satisfying heroic journey.",
+
+  "tech / sci-fi":
+    "Write a technology-driven sci-fi story involving AI, hacking, futuristic systems, robotics, cyber worlds, space, or advanced inventions.",
+
+  "romance / love":
+    "Write an emotional romance/love story focused on relationships, feelings, trust, conflict, character growth, and a heartfelt resolution.",
+};
+
+const normalizeGenre = (genre?: string): string => {
+  if (!genre || typeof genre !== "string") {
+    return DEFAULT_GENRE;
+  }
+
+  return genre
+    .replace(/^[^A-Za-z0-9]+/, "")
+    .trim()
+    .toLowerCase();
+};
+
+const getGenreInstruction = (
+  genre?: string
+): { genre: string; instruction: string } => {
+  const normalizedGenre = normalizeGenre(genre);
+
+  if (GENRE_PROMPT_INSTRUCTIONS[normalizedGenre]) {
+    return {
+      genre: normalizedGenre,
+      instruction: GENRE_PROMPT_INSTRUCTIONS[normalizedGenre],
+    };
+  }
+
+  return {
+    genre: DEFAULT_GENRE,
+    instruction:
+      "Write a balanced general fiction story with a clear plot, engaging characters, and a satisfying ending.",
+  };
+};
+
 export const buildStoryPrompt = (
   userInput: string,
   options: PromptOptions = {}
@@ -27,12 +94,14 @@ export const buildStoryPrompt = (
     length = 'medium'
   } = options;
 
+  const resolvedGenre = getGenreInstruction(genre);
+
   const systemPrompt = `You are an expert creative storyteller and narrative designer.
 Your task is to generate a high-quality, engaging story based on the user's prompt.
 
 RULES AND CONSTRAINTS:
 1. Tone: the story must maintain a ${tone} tone.
-2. Genre: the narrative should fit within the ${genre} genre.
+2. Genre: ${resolvedGenre.instruction}
 3. Audience: write for a ${targetAudience}.
 4. Length: the story should be approximately ${length} in length.
 5. Output Format: you MUST return the output strictly as a valid JSON object. Do not include markdown formatting blocks (e.g., \`\`\`json). Just return the raw JSON.
@@ -40,7 +109,7 @@ RULES AND CONSTRAINTS:
 EXPECTED JSON SCHEMA:
 {
   "title": "A captivating title for the story",
-  "genre": "${genre}",
+  "genre": "${resolvedGenre.genre}",
   "tone": "${tone}",
   "summary": "A brief 2-3 sentence summary of the story.",
   "content": "The full story text formatted with appropriate paragraph breaks (\\n\\n).",

--- a/frontend/src/components/stories/stories.component.tsx
+++ b/frontend/src/components/stories/stories.component.tsx
@@ -30,7 +30,10 @@ const soundtrackMap: Record<string, string> = {
   "😂 Comedy": "/audio/comedy.mp3",
   "🚀 Sci-Fi": "/audio/sci-fi.mp3",
   "🔍 Mystery": "/audio/mystery.mp3",
-  "🌟 Adventure": "/audio/adventure.mp3"
+  "🌟 Adventure": "/audio/adventure.mp3",
+  "🗺️ Adventurous": "/audio/adventure.mp3",
+  "🤖 Tech / Sci-Fi": "/audio/sci-fi.mp3",
+  "💖 Romance / Love": "/audio/romance.mp3",
 };
 
 type Inputs = {
@@ -69,6 +72,11 @@ const GENRES = [
   { value: "🧙 Fantasy", icon: "🧙", name: "Fantasy" },
   { value: "🔍 Mystery", icon: "🔍", name: "Mystery" },
   { value: "🌟 Adventure", icon: "🌟", name: "Adventure" },
+
+  // New premium genres
+  { value: "🗺️ Adventurous", icon: "🗺️", name: "Adventurous" },
+  { value: "🤖 Tech / Sci-Fi", icon: "🤖", name: "Tech / Sci-Fi" },
+  { value: "💖 Romance / Love", icon: "💖", name: "Romance / Love" },
 ] as const;
 
 
@@ -78,53 +86,88 @@ const GENRE_LABELS: Record<string, Record<GenreName, string>> = {
   English: {
     Drama: "Drama", Comedy: "Comedy", Horror: "Horror", Romance: "Romance",
     "Sci-Fi": "Sci-Fi", Fantasy: "Fantasy", Mystery: "Mystery", Adventure: "Adventure",
+    Adventurous: "Adventurous",
+    "Tech / Sci-Fi": "Tech / Sci-Fi",
+    "Romance / Love": "Romance / Love",
   },
   Spanish: {
     Drama: "Drama", Comedy: "Comedia", Horror: "Terror", Romance: "Romance",
     "Sci-Fi": "Ciencia ficcion", Fantasy: "Fantasia", Mystery: "Misterio", Adventure: "Aventura",
+    Adventurous: "Adventurous",
+    "Tech / Sci-Fi": "Tech / Sci-Fi",
+    "Romance / Love": "Romance / Love",
   },
   French: {
     Drama: "Drame", Comedy: "Comedie", Horror: "Horreur", Romance: "Romance",
     "Sci-Fi": "Science-fiction", Fantasy: "Fantastique", Mystery: "Mystere", Adventure: "Aventure",
+    Adventurous: "Adventurous",
+    "Tech / Sci-Fi": "Tech / Sci-Fi",
+    "Romance / Love": "Romance / Love",
   },
   Portuguese: {
     Drama: "Drama", Comedy: "Comedia", Horror: "Terror", Romance: "Romance",
     "Sci-Fi": "Ficcao cientifica", Fantasy: "Fantasia", Mystery: "Misterio", Adventure: "Aventura",
+    Adventurous: "Adventurous",
+    "Tech / Sci-Fi": "Tech / Sci-Fi",
+    "Romance / Love": "Romance / Love",
   },
   Hindi: {
     Drama: "नाटक", Comedy: "à¤¹à¤¾à¤¸à¥à¤¯", Horror: "डरावनी", Romance: "à¤ªà¥à¤°à¥‡à¤®",
     "Sci-Fi": "à¤µà¤¿à¤œà¥à¤žà¤¾à¤¨ à¤•à¤¥à¤¾", Fantasy: "à¤•à¤²à¥à¤ªà¤¨à¤¾", Mystery: "à¤°à¤¹à¤¸à¥à¤¯", Adventure: "रोमांच",
+    Adventurous: "Adventurous",
+    "Tech / Sci-Fi": "Tech / Sci-Fi",
+    "Romance / Love": "Romance / Love",
   },
   German: {
     Drama: "Drama", Comedy: "Komodie", Horror: "Horror", Romance: "Romanze",
     "Sci-Fi": "Science-Fiction", Fantasy: "Fantasy", Mystery: "Mysterie", Adventure: "Abenteuer",
+    Adventurous: "Adventurous",
+    "Tech / Sci-Fi": "Tech / Sci-Fi",
+    "Romance / Love": "Romance / Love",
   },
   Japanese: {
     Drama: "ãƒ‰ãƒ©ãƒž", Comedy: "ã‚³ãƒ¡ãƒ‡ã‚£", Horror: "ãƒ›ãƒ©ãƒ¼", Romance: "ãƒ­ãƒžãƒ³ã‚¹",
     "Sci-Fi": "SF", Fantasy: "ãƒ•ã‚¡ãƒ³ã‚¿ã‚¸ãƒ¼", Mystery: "ãƒŸã‚¹ãƒ†ãƒªãƒ¼", Adventure: "å†’é™º",
+    Adventurous: "Adventurous",
+    "Tech / Sci-Fi": "Tech / Sci-Fi",
+    "Romance / Love": "Romance / Love",
   },
   Korean: {
     Drama: "ë“œë¼ë§ˆ", Comedy: "ì½”ë¯¸ë””", Horror: "ê³µí¬", Romance: "ë¡œë§¨ìŠ¤",
     "Sci-Fi": "SF", Fantasy: "íŒíƒ€ì§€", Mystery: "ë¯¸ìŠ¤í„°ë¦¬", Adventure: "ëª¨í—˜",
+    Adventurous: "Adventurous",
+    "Tech / Sci-Fi": "Tech / Sci-Fi",
+    "Romance / Love": "Romance / Love",
   },
   Bengali: {
 
     Drama: "à¦¨à¦¾à¦Ÿà¦•", Comedy: "à¦•à§Œà¦¤à§à¦•", Horror: "à¦­à§Œà¦¤à¦¿à¦•", Romance: "à¦ªà§à¦°à§‡à¦®",
     "Sci-Fi": "à¦¬à¦¿à¦œà§à¦žà¦¾à¦¨ à¦•à¦²à§à¦ªà¦•à¦¾à¦¹à¦¿à¦¨à¦¿", Fantasy: "à¦•à¦²à§à¦ªà¦¨à¦¾", Mystery: "à¦°à¦¹à¦¸à§à¦¯", Adventure: "à¦…à¦­à¦¿à¦¯à¦¾à¦¨",
-
+    Adventurous: "Adventurous",
+    "Tech / Sci-Fi": "Tech / Sci-Fi",
+    "Romance / Love": "Romance / Love",
   },
   Tamil: {
     Drama: "à®¨à®¾à®Ÿà®•à®®à¯", Comedy: "à®¨à®•à¯ˆà®šà¯à®šà¯à®µà¯ˆ", Horror: "à®¤à®¿à®•à®¿à®²à¯", Romance: "à®•à®¾à®¤à®²à¯",
     "Sci-Fi": "à®…à®±à®¿à®µà®¿à®¯à®²à¯ à®ªà¯à®©à¯ˆà®µà¯", Fantasy: "à®•à®±à¯à®ªà®©à¯ˆ", Mystery: "à®®à®°à¯à®®à®®à¯", Adventure: "à®šà®¾à®•à®šà®®à¯",
+    Adventurous: "Adventurous",
+    "Tech / Sci-Fi": "Tech / Sci-Fi",
+    "Romance / Love": "Romance / Love",
   },
   Telugu: {
     Drama: "à°¨à°¾à°Ÿà°•à°‚", Comedy: "à°¹à°¾à°¸à±à°¯à°‚", Horror: "à°­à°¯à°¾à°¨à°•à°‚", Romance: "à°ªà±à°°à±‡à°®",
     "Sci-Fi": "à°µà°¿à°œà±à°žà°¾à°¨ à°•à°¥", Fantasy: "à°•à°¾à°²à±à°ªà°¨à°¿à°•à°‚", Mystery: "à°°à°¹à°¸à±à°¯à°‚", Adventure: "à°¸à°¾à°¹à°¸à°‚",
+    Adventurous: "Adventurous",
+    "Tech / Sci-Fi": "Tech / Sci-Fi",
+    "Romance / Love": "Romance / Love",
   },
   Marathi: {
 
     Drama: "नाटक", Comedy: "विनोद", Horror: "भयकथा", Romance: "à¤ªà¥à¤°à¥‡à¤®à¤•à¤¥à¤¾",
     "Sci-Fi": "à¤µà¤¿à¤œà¥à¤žà¤¾à¤¨à¤•à¤¥à¤¾", Fantasy: "à¤•à¤²à¥à¤ªà¤¨à¤¾à¤°à¤®à¥à¤¯", Mystery: "à¤°à¤¹à¤¸à¥à¤¯", Adventure: "साहस",
+    Adventurous: "Adventurous",
+    "Tech / Sci-Fi": "Tech / Sci-Fi",
+    "Romance / Love": "Romance / Love",
 
   },
 };


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Open or link a related issue when there is one (`Closes #123`, `Fixes #45`, or write **None** under Related issue below).
- **Description:** Fill in **What this PR does** so a reviewer can understand the change without your local context.
- **Screenshots:** Add screenshots or a short recording when they help (UI changes, confusing flows, or non-code proof). If not needed, say so in the checklist.

## Screenshot (when helpful)

N/A — I was unable to capture the updated UI locally because the dev server is currently blocked by pre-existing unrelated compile errors in frontend/src/App.tsx duplicate imports and other unrelated files. I confirmed these errors are unrelated by stashing this PR’s changes and rerunning typecheck; the same errors still occurred.


## What this PR does

This PR adds support for three new story genres in the story generation flow:

- Adventurous
- Tech / Sci-Fi
- Romance / Love
Changes made:

- Added the new genre options to the frontend story genre selector.
- Added matching genre labels and soundtrack mappings using the existing emoji-based genre pattern already used in the project.
- Updated the backend prompt builder to provide genre-specific AI instructions for the new genres.
- Added fallback handling so unsupported or invalid genres safely resolve to general fiction instead of breaking prompt generation.

## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #1861 

## More screenshots (optional)

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
**Testing**

- Updated the frontend genre list with Adventurous, Tech / Sci-Fi, and Romance / Love.
- Updated backend prompt generation with specific prompt instructions for the new genres.
- Verified fallback logic for unsupported genres in the prompt builder.
- Ran npm run typecheck -w story-spark-ai-frontend.
- Ran npm run typecheck -w story-spark-ai-backend.

Note: Typecheck currently fails due to pre-existing unrelated syntax/import errors. I confirmed this by stashing this PR’s changes and rerunning typecheck; the same errors still occurred. Existing unrelated failures include:

- 
- frontend/src/App.tsx
- frontend/src/components/help_center/help_center.utils.ts
- frontend/src/components/hero/nav_list.component.tsx
- frontend/src/components/home/writer_feedback/ReviewForm.tsx
- frontend/src/hooks/useSpeechSynthesis.ts
- backend/src/app/modules/ai_model/ai_model.utils.ts
- backend/src/utils/promptSecurity.ts
- 