### PR TITLE
fix: return 400 for invalid MongoDB ObjectId (#3833)

### DIFF
--- a/backend/src/errors/handle_cast_error.ts
+++ b/backend/src/errors/handle_cast_error.ts
@@ -2,7 +2,7 @@ import mongoose from "mongoose";
 import { IGenericErrorMessage } from "../interfaces/error";
 
 const handleCastError = (err: mongoose.Error.CastError) => {
-  const statusCode = 500;
+  const statusCode = 400;
   const errors: IGenericErrorMessage[] = [
     {
       path: err.path,


### PR DESCRIPTION
## Fixes #3833

Changed `statusCode` from 500 to 400 in `handleCastError` since an invalid ObjectId format is a client-side mistake (malformed input), not a server-side failure.

- backend/src/errors/handle_cast_error.ts: statusCode 500 → 400