### PR TITLE
Replace require() with import in CollabEditor.tsx for ESM compatibility

### DIFF
--- a/frontend/src/components/collab/CollabEditor.tsx
+++ b/frontend/src/components/collab/CollabEditor.tsx
@@ -5,6 +5,7 @@ import * as Y from 'yjs';
 import { QuillBinding } from 'y-quill';
 import { IndexeddbPersistence } from 'y-indexeddb';
 import { io, Socket } from 'socket.io-client';
+import { Awareness } from 'y-protocols/awareness';
 import { resolveSocketUrl } from '../../helpers/socket-url';
 
 interface CollabEditorProps {
@@ -54,7 +55,6 @@ export default function CollabEditor({ storyId, userId, username, userColor }: C
     const binding = new QuillBinding(ytext, quill);
 
     // Setup awareness for presence
-    const Awareness = require('y-protocols/awareness').Awareness;
     const awareness = new Awareness(ydoc);
     awarenessRef.current = awareness;
     awareness.setLocalStateField('user', {


### PR DESCRIPTION
Replaces the require() call with a proper top-level ES module import for y-protocols/awareness. Fixes runtime error since frontend uses ES modules.

Closes #3879