### PR TITLE
feat : added zod validation schema for engagement analyze endpoint

### DIFF
--- a/backend/src/app/modules/engagement/engagement.controller.ts
+++ b/backend/src/app/modules/engagement/engagement.controller.ts
@@ -5,12 +5,6 @@ export const EngagementController = {
   analyzeChapter: async (req: Request, res: Response) => {
     try {
       const { chapterText, title } = req.body;
-      if (!chapterText || chapterText.trim().length < 100) {
-        return res.status(400).json({
-          success: false,
-          message: "Chapter text must be at least 100 characters.",
-        });
-      }
       const data = await analyzeEngagement(chapterText, title);
       return res.status(200).json({ success: true, data });
     } catch {

--- a/backend/src/app/modules/engagement/engagement.router.ts
+++ b/backend/src/app/modules/engagement/engagement.router.ts
@@ -1,9 +1,16 @@
 import express from "express";
 import { EngagementController } from "./engagement.controller";
+import { EngagementValidation } from "./engagement.validation";
 import freeAiRateLimiter from "../../middleware/free-ai.rate-limiter";
+import validateRequest from "../../middleware/validate.request";
 
 const router = express.Router();
 
-router.post("/analyze", freeAiRateLimiter, EngagementController.analyzeChapter);
+router.post(
+  "/analyze",
+  freeAiRateLimiter,
+  validateRequest(EngagementValidation.analyzeChapter),
+  EngagementController.analyzeChapter
+);
 
 export const EngagementRouter = router;

--- a/backend/src/app/modules/engagement/engagement.validation.ts
+++ b/backend/src/app/modules/engagement/engagement.validation.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+const analyzeChapter = z.object({
+  body: z.object({
+    chapterText: z.string({
+      required_error: "chapterText is required",
+    }).min(100, "Chapter text must be at least 100 characters"),
+    title: z.string().optional(),
+  }),
+});
+
+export const EngagementValidation = {
+  analyzeChapter,
+};


### PR DESCRIPTION
Closes #3897.

Summary of What Has Been Done:
Added a Zod validation schema for the engagement analyze endpoint following the same pattern as other modules (bug_report, story_rating). The controller no longer needs inline validation logic - it is handled by the validateRequest middleware.

Changes Made:
- backend/src/app/modules/engagement/engagement.validation.ts (new file)
- backend/src/app/modules/engagement/engagement.controller.ts: removed inline chapterText validation
- backend/src/app/modules/engagement/engagement.router.ts: added validateRequest middleware

Impact it Made:
- Consistent validation pattern across all backend modules
- Cleaner controller code without inline validation logic
- Better error messages via Zod validation errors

Note: Please assign this PR to the `tmdeveloper007` account.