### PR TITLE
fix : added Bearer prefix to Authorization header after token refresh

### DIFF
--- a/frontend/src/helpers/axios/axiosInstance.ts
+++ b/frontend/src/helpers/axios/axiosInstance.ts
@@ -28,7 +28,7 @@ instance.interceptors.response.use(
           })
         );
 
-        originalRequest.headers.Authorization = newToken;
+        originalRequest.headers.Authorization = `Bearer ${newToken}`;
         return instance(originalRequest);
       } catch {
         localStorage.removeItem('accessToken');


### PR DESCRIPTION
Closes #3940.

Summary of What Has Been Done:
Fixed the token refresh interceptor in axiosInstance.ts. After a successful token refresh, the Authorization header was set to the raw token value instead of `Bearer <token>`, causing the replayed request to be rejected by the backend with 401. Added the correct Bearer prefix.

Changes Made:
- frontend/src/helpers/axios/axiosInstance.ts: changed `Authorization = newToken` to `Authorization = `Bearer ${newToken}``

Impact it Made:
- Fixes an auth regression where the first API call after token expiry would fail with 401
- One-line change with no side effects; token refresh flow now works end-to-end

Note: Please assign this PR to the `tmdeveloper007` account.