### PR TITLE
feat(backend): implement keyword extraction service for prompt optimization

### DIFF
--- a/backend/src/services/memoryExtractor.ts
+++ b/backend/src/services/memoryExtractor.ts
@@ -1,0 +1,32 @@
+export class MemoryExtractorService {
+  /**
+   * Scans a raw user prompt against an array of known entity names using
+   * case-insensitive word-boundary regular expressions to prevent false-positive matches.
+   *
+   * @param userPrompt The string input provided by the writer for the next chapter.
+   * @param knownEntities An array of registered string names representing lore, characters, or locations.
+   * @returns An array of entity names that were explicitly mentioned in the prompt.
+   */
+  public static extractRelevantEntities(userPrompt: string, knownEntities: string[]): string[] {
+    if (!userPrompt || !knownEntities || knownEntities.length === 0) {
+      return [];
+    }
+
+    const matchedEntities: string[] = [];
+
+    for (const entity of knownEntities) {
+      // Escape special regex characters in the entity name to avoid compilation syntax faults
+      const escapedEntity = entity.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+      
+      // Use \b (word boundary) flags to ensure accurate exact-word matching
+      // e.g., matching "Avalon" but ignoring "Avalonians"
+      const regex = new RegExp(`\\b${escapedEntity}\\b`, 'i');
+
+      if (regex.test(userPrompt)) {
+        matchedEntities.push(entity);
+      }
+    }
+
+    return matchedEntities;
+  }
+}

--- a/backend/src/types/universe.ts
+++ b/backend/src/types/universe.ts
@@ -1,0 +1,5 @@
+export interface IMentionedEntities {
+  storyId: string;
+  matchedKeywords: string[];
+  extractedAt: Date;
+}


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Closes #3992 
- **Description:** Implemented an isolated backend utility service to parse user input prompts and extract relevant universe entity keywords using case-insensitive word-boundary matching.
- **Screenshots:** Provided localized execution terminal logs as verifiable backend proof.

## Screenshot (when helpful)

```text
=== Extraction Diagnostics ===
Input Prompt: Tribhuvan journeys back to the Citadel to secure the perimeter.
Identified Matches (Should be Tribhuvan & The Citadel): [ 'Tribhuvan', 'The Citadel' ]
```


## What this PR does

This PR introduces the core foundation for a prompt optimization system via MemoryExtractorService.

When generating new chapters or long-form narrative iterations, passing a massive story bible to an LLM causes severe token bloat and dilutes the context window attention metrics. This service tackles that by taking a raw user text input and screening it against a collection of known world entity tags using exact word boundaries (\b).

It accurately flags specific keywords (such as characters or locations mentioned in that prompt sequence), allowing the backend pipeline to isolate and pull only the necessary database lore blocks into system prompts while safely pruning away the rest.




## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

closes #3992 



## More screenshots (optional)



## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
