### PR TITLE
Refactor career article component structure

### DIFF
--- a/frontend/src/components/footer/career.tsx
+++ b/frontend/src/components/footer/career.tsx
@@ -239,9 +239,9 @@ const Career = () => {
             {opportunities.map(
               ({ title, icon: Icon, type, focus, description, skills }) => (
                 <article
-                  key={title}
-                  className="group rounded-[2rem] border border-slate-200 dark:border-white/10 bg-white dark:bg-slate-900/60 p-7 shadow-lg hover:-translate-y-2 hover:shadow-blue-500/10 transition-all duration-300"
-                >
+  key={title}
+  className="group flex h-full flex-col rounded-[2rem] border border-slate-200 dark:border-white/10 bg-white dark:bg-slate-900/60 p-7 shadow-lg hover:-translate-y-2 hover:shadow-blue-500/10 transition-all duration-300"
+>
                   <div className="flex items-start justify-between mb-7">
                     <div className="rounded-2xl bg-blue-500/10 p-4 text-blue-600 dark:text-blue-300 group-hover:bg-blue-600 group-hover:text-white transition-all duration-300">
                       <Icon size={30} />
@@ -274,12 +274,12 @@ const Career = () => {
                     ))}
                   </div>
 
-                  <a
-                    href={`mailto:ronichandrasarkar@gmail.com?subject=Application%3A%20${encodeURIComponent(
-                      title
-                    )}`}
-                    className="mt-8 inline-flex w-full items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-blue-600 to-indigo-600 px-5 py-3.5 text-white font-semibold shadow-lg hover:scale-[1.02] hover:shadow-blue-500/25 transition-all duration-300"
-                  >
+                <a
+  href={`mailto:ronichandrasarkar@gmail.com?subject=Application%3A%20${encodeURIComponent(
+    title
+  )}`}
+  className="mt-auto inline-flex w-full items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-blue-600 to-indigo-600 px-5 py-3.5 text-white font-semibold shadow-lg hover:scale-[1.02] hover:shadow-blue-500/25 transition-all duration-300"
+>
                     Apply Now
                     <ArrowRight size={17} />
                   </a>


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Open or link a related issue when there is one (`Closes #123`, `Fixes #45`, or write **None** under Related issue below).
- **Description:** Fill in **What this PR does** so a reviewer can understand the change without your local context.
- **Screenshots:** Add screenshots or a short recording when they help (UI changes, confusing flows, or non-code proof). If not needed, say so in the checklist.

## Screenshot (when helpful)

<!-- Drag & drop or paste. For non-UI work, you can use tests output, logs, or API responses. Write “N/A” in the checklist if you skip this section. -->

<img width="1513" height="1039" alt="ChatGPT Image Jun 22, 2026, 10_25_12 PM" src="https://github.com/user-attachments/assets/7677f5c7-cbbf-4b0f-8208-0f150e166233" />


## What this PR does

<!-- Short summary: what problem does this solve, and how? -->

This PR fixes the alignment inconsistency of the "Apply Now" buttons in the Career page opportunity cards.

Changes made:
Converted opportunity cards to use a flex column layout.
Added full-height card behavior to ensure consistent card sizing.
Positioned the "Apply Now" button at the bottom of each card using mt-auto.
Improved visual consistency across cards regardless of varying content lengths.

As a result, all opportunity cards now maintain a uniform layout and the call-to-action buttons are perfectly aligned.


## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [.] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

<!-- Example: Closes #123 or Fixes #45. Use “None” if there is no issue. -->

Closes #4009 


## More screenshots (optional)

<!-- Extra before/after images, flows, or recordings for reviewers. -->



## Checklist

- [.] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [.] I have filled in the related issue number when there is one.
- [.] I have tested my changes.
- [.] I have done a self-review of the code.
