### PR TITLE
fix: avoid Redis startup crash without REDIS_URL

### DIFF
--- a/backend/src/__tests__/rateLimitStore.test.ts
+++ b/backend/src/__tests__/rateLimitStore.test.ts
@@ -1,5 +1,14 @@
 const mockFindOneAndUpdate = jest.fn();
 const mockLoggerError = jest.fn();
+const mockRedisClient = {
+  status: "end",
+  get: jest.fn(),
+  set: jest.fn(),
+  del: jest.fn(),
+  incrby: jest.fn(),
+  expire: jest.fn(),
+  on: jest.fn(),
+};
 
 jest.mock("mongoose", () => ({
   Schema: jest.fn().mockImplementation(() => ({
@@ -8,7 +17,7 @@ jest.mock("mongoose", () => ({
   model: jest.fn(() => ({
     findOneAndUpdate: mockFindOneAndUpdate,
   })),
-}));
+}), { virtual: true });
 
 jest.mock("../utils/logger.util", () => ({
   __esModule: true,
@@ -17,12 +26,24 @@ jest.mock("../utils/logger.util", () => ({
   },
 }));
 
-import { consumeRateLimit } from "../app/middleware/rate_limit.store";
+jest.mock("../app/utils/redis.client", () => ({
+  __esModule: true,
+  default: mockRedisClient,
+}), { virtual: true });
+
+import { consumeRateLimit, consumeTokenQuota } from "../app/middleware/rate_limit.store";
 
 describe("consumeRateLimit", () => {
   beforeEach(() => {
     mockFindOneAndUpdate.mockReset();
     mockLoggerError.mockReset();
+    mockRedisClient.status = "end";
+    mockRedisClient.get.mockReset();
+    mockRedisClient.set.mockReset();
+    mockRedisClient.del.mockReset();
+    mockRedisClient.incrby.mockReset();
+    mockRedisClient.expire.mockReset();
+    mockRedisClient.on.mockReset();
   });
 
   it("fails closed when the backing store throws", async () => {
@@ -39,5 +60,18 @@ describe("consumeRateLimit", () => {
     expect(mockLoggerError).toHaveBeenCalledWith(
       "Rate limit store error for login_127.0.0.1: database unavailable"
     );
+  });
+
+  it("falls back to allowing token quota checks when Redis is not ready", async () => {
+    const result = await consumeTokenQuota("user-123", 2, 10);
+
+    expect(result).toEqual({
+      allowed: true,
+      remainingTokens: 10,
+      retryAfterSec: 0,
+    });
+    expect(mockRedisClient.get).not.toHaveBeenCalled();
+    expect(mockRedisClient.incrby).not.toHaveBeenCalled();
+    expect(mockRedisClient.expire).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/app/middleware/rate_limit.store.ts
+++ b/backend/src/app/middleware/rate_limit.store.ts
@@ -1,5 +1,6 @@
 import { Schema, model } from "mongoose";
 import logger from "../../utils/logger.util";
+import redis from "../utils/redis.client";
 
 // Shared, serverless safe rate limit store backed by MongoDB. The previous
 // in-memory Map could not work across Vercel function instances or cold starts,
@@ -128,11 +129,6 @@ export const consumeRateLimit = async (
   }
 };
 
-import Redis from "ioredis";
-
-// We use ioredis to securely track token quotas
-const redisClient = process.env.REDIS_URL ? new Redis(process.env.REDIS_URL) : new Redis();
-
 export const consumeTokenQuota = async (
   userIdOrIp: string,
   tokensRequired: number,
@@ -141,8 +137,16 @@ export const consumeTokenQuota = async (
   const dateStr = new Date().toISOString().split("T")[0]; // YYYY-MM-DD
   const key = `token_quota:${userIdOrIp}:${dateStr}`;
 
+  if (redis.status !== "ready") {
+    return {
+      allowed: true,
+      remainingTokens: dailyQuotaLimit,
+      retryAfterSec: 0,
+    };
+  }
+
   try {
-    const currentTokens = await redisClient.get(key);
+    const currentTokens = await redis.get(key);
     const usedTokens = currentTokens ? parseInt(currentTokens, 10) : 0;
 
     if (usedTokens + tokensRequired > dailyQuotaLimit) {
@@ -157,8 +161,8 @@ export const consumeTokenQuota = async (
     }
 
     // Atomically increment and set expiry to 48 hours (to be safe)
-    await redisClient.incrby(key, tokensRequired);
-    await redisClient.expire(key, 48 * 60 * 60);
+    await redis.incrby(key, tokensRequired);
+    await redis.expire(key, 48 * 60 * 60);
 
     return { allowed: true, remainingTokens: dailyQuotaLimit - (usedTokens + tokensRequired), retryAfterSec: 0 };
   } catch (error) {

--- a/backend/src/app/utils/redis.client.ts
+++ b/backend/src/app/utils/redis.client.ts
@@ -1,27 +1,70 @@
 import Redis from "ioredis";
 
-const redis = new Redis(process.env.REDIS_URL || "redis://127.0.0.1:6379", {
-  retryStrategy(times: number) {
-    const delay = Math.min(times * 100, 2000);
-    return delay;
-  },
-  maxRetriesPerRequest: 3,
-  enableReadyCheck: true,
-  reconnectOnError(err: Error) {
-    return err?.message?.includes("ECONNREFUSED") ?? false;
-  },
-});
+type RedisLike = {
+  status: string;
+  on: (event: string, listener: (...args: unknown[]) => void) => RedisLike;
+  get: (key: string) => Promise<string | null>;
+  set: (...args: unknown[]) => Promise<unknown>;
+  del: (...args: unknown[]) => Promise<unknown>;
+  incrby: (...args: unknown[]) => Promise<unknown>;
+  expire: (...args: unknown[]) => Promise<unknown>;
+};
 
-redis.on("ready", () => {
-  // Redis is available and ready to serve commands.
-});
+class DisabledRedisClient implements RedisLike {
+  status = "end";
 
-redis.on("error", (err: Error) => {
-  if (err && (err as any).code === "ECONNREFUSED") {
-    // Redis is not running. Caching will be skipped until the connection recovers.
-    return;
+  on() {
+    return this;
   }
-  console.error("Redis Error:", err);
-});
+
+  async get() {
+    return null;
+  }
+
+  async set() {
+    return "OK";
+  }
+
+  async del() {
+    return 0;
+  }
+
+  async incrby() {
+    return 0;
+  }
+
+  async expire() {
+    return 0;
+  }
+}
+
+const redisUrl = process.env.REDIS_URL?.trim();
+const redis: RedisLike = redisUrl
+  ? (new Redis(redisUrl, {
+      retryStrategy(times: number) {
+        const delay = Math.min(times * 100, 2000);
+        return delay;
+      },
+      maxRetriesPerRequest: 3,
+      enableReadyCheck: true,
+      reconnectOnError(err: Error) {
+        return err?.message?.includes("ECONNREFUSED") ?? false;
+      },
+    }) as unknown as RedisLike)
+  : new DisabledRedisClient();
+
+if (redisUrl) {
+  redis.on("ready", () => {
+    // Redis is available and ready to serve commands.
+  });
+
+  redis.on("error", (err: Error) => {
+    if (err && (err as any).code === "ECONNREFUSED") {
+      // Redis is not running. Caching will be skipped until the connection recovers.
+      return;
+    }
+    console.error("Redis Error:", err);
+  });
+}
 
 export default redis;


### PR DESCRIPTION
Summary:\n- Make the shared Redis client optional when REDIS_URL is missing\n- Reuse the safe client in token quota checks so the backend can boot without Redis\n- Add a regression test for the no-Redis path\n\nTesting:\n- npm test -- --runInBand src/__tests__/rateLimitStore.test.ts\n- git diff --check\n\nCloses #3997