### PR TITLE
fix: allow short OAuth display names

### DIFF
--- a/backend/src/app/modules/user/__tests__/user.model.test.ts
+++ b/backend/src/app/modules/user/__tests__/user.model.test.ts
@@ -1,0 +1,29 @@
+jest.mock(
+  "bcryptjs",
+  () => ({
+    hash: jest.fn(),
+  }),
+  { virtual: true }
+);
+
+jest.mock("../../../../config", () => ({
+  __esModule: true,
+  default: {
+    bcrypt_salt_rounds: 10,
+  },
+}));
+
+import { User } from "../user.model";
+
+describe("User model name validation", () => {
+  it("allows short OAuth display names", () => {
+    const user = new User({
+      email: "ada@example.com",
+      name: "Ada",
+    });
+
+    const validationError = user.validateSync();
+
+    expect(validationError).toBeUndefined();
+  });
+});

--- a/backend/src/app/modules/user/user.model.ts
+++ b/backend/src/app/modules/user/user.model.ts
@@ -10,7 +10,7 @@ import { USER_STATUS } from "../../../enums/user_status";
 export const UserSchema: Schema<IUser> = new Schema<IUser, UserModel>(
   {
     email: { type: String, required: true, unique: true, lowercase: true },
-    name: { type: String, maxlength: 100, minlength: 5 },
+    name: { type: String, maxlength: 100, minlength: 1 },
     password: { type: String, required: false, default: "" },
     role: {
       type: String,


### PR DESCRIPTION
Summary:\n- Lower the user name minimum length so Google OAuth identities with short display names can register\n- Add a regression test that validates short names at the model layer\n\nTesting:\n- npm test -- --runInBand src/__tests__/rateLimitStore.test.ts src/app/modules/user/__tests__/user.model.test.ts\n- git diff --check\n\nCloses #3988