### PR TITLE
fix: use jwt subject for notification lookups

### DIFF
--- a/backend/src/app/modules/auth/auth.service.ts
+++ b/backend/src/app/modules/auth/auth.service.ts
@@ -54,6 +54,7 @@ const normalizeString = (value: unknown, fieldName: string) => {
 // Token claims; tokenVersion enables global session revocation.
 const buildClaims = (user: any) => ({
   _id: user._id,
+  userId: user._id,
   email: user.email,
   role: user.role,
   subscriptionType: user.subscriptionType,

--- a/backend/src/app/modules/notification/__tests__/notification.service.test.ts
+++ b/backend/src/app/modules/notification/__tests__/notification.service.test.ts
@@ -1,0 +1,78 @@
+const mockFindOne = jest.fn();
+const mockFind = jest.fn();
+const mockCountDocuments = jest.fn();
+const mockFindOneAndUpdate = jest.fn();
+const mockUpdateMany = jest.fn();
+const mockDeleteMany = jest.fn();
+const mockEmitNotificationToUser = jest.fn();
+const mockEmitNotificationStateToUser = jest.fn();
+
+jest.mock("../notification.model", () => ({
+  Notification: {
+    create: jest.fn(),
+    find: mockFind,
+    countDocuments: mockCountDocuments,
+    findOneAndUpdate: mockFindOneAndUpdate,
+    updateMany: mockUpdateMany,
+    deleteMany: mockDeleteMany,
+  },
+}), { virtual: true });
+
+jest.mock("../../user/user.model", () => ({
+  User: {
+    findOne: mockFindOne,
+  },
+}), { virtual: true });
+
+jest.mock("../../../../socket/notification.socket", () => ({
+  emitNotificationToUser: mockEmitNotificationToUser,
+  emitNotificationStateToUser: mockEmitNotificationStateToUser,
+}), { virtual: true });
+
+import { NotificationService } from "../notification.service";
+
+describe("NotificationService.resolveUserId", () => {
+  beforeEach(() => {
+    mockFindOne.mockReset();
+    mockFind.mockReset();
+    mockCountDocuments.mockReset();
+    mockFindOneAndUpdate.mockReset();
+    mockUpdateMany.mockReset();
+    mockDeleteMany.mockReset();
+    mockEmitNotificationToUser.mockReset();
+    mockEmitNotificationStateToUser.mockReset();
+  });
+
+  it("uses _id from the token without hitting the database", async () => {
+    const token = {
+      _id: "user-123",
+      email: "ada@example.com",
+      role: "user",
+      name: "Ada",
+      subscriptionType: "FREE",
+      postsCount: 0,
+    } as any;
+
+    await expect(NotificationService.resolveUserId(token)).resolves.toBe("user-123");
+    expect(mockFindOne).not.toHaveBeenCalled();
+  });
+
+  it("falls back to email lookup when _id is missing", async () => {
+    mockFindOne.mockReturnValueOnce({
+      select: jest.fn().mockResolvedValueOnce({
+        _id: { toString: () => "user-456" },
+      }),
+    });
+
+    const token = {
+      email: "ada@example.com",
+      role: "user",
+      name: "Ada",
+      subscriptionType: "FREE",
+      postsCount: 0,
+    } as any;
+
+    await expect(NotificationService.resolveUserId(token)).resolves.toBe("user-456");
+    expect(mockFindOne).toHaveBeenCalledWith({ email: "ada@example.com" });
+  });
+});

--- a/backend/src/app/modules/notification/notification.service.ts
+++ b/backend/src/app/modules/notification/notification.service.ts
@@ -16,6 +16,10 @@ const createNotification = async (payload: INotification) => {
 };
 
 const resolveUserId = async (token: ITokenPayload) => {
+  if (token._id) {
+    return token._id;
+  }
+
   if (token.userId) {
     return token.userId;
   }


### PR DESCRIPTION
Summary:\n- Use the JWT _id claim as the primary user identifier for notifications\n- Keep email lookup as a fallback for older or incomplete tokens\n- Add a regression test that covers both the fast path and fallback path\n\nTesting:\n- npm test -- --runInBand src/app/modules/notification/__tests__/notification.service.test.ts\n- git diff --check\n\nCloses #3987