### PR TITLE
Optimize createPost by using JWT _id lookup

### DIFF
--- a/backend/src/app/modules/post/post.service.ts
+++ b/backend/src/app/modules/post/post.service.ts
@@ -93,11 +93,9 @@ const getCursorCondition = (
 };
 
 const createPost = async (payload: IPostPayload, token: ITokenPayload) => {
-  const { email, role } = token;
-  const user = await User.findOne({
-    email: email,
-    role: role,
-  });
+  const { _id } = token;
+
+  const user = await User.findById(_id).select("_id role postsCount");
   if (!user) {
     throw new ApiError(httpStatus.BAD_REQUEST, "User not found!");
   }


### PR DESCRIPTION
## Before you open this PR
- Issue: Fixes  #4026

## Screenshot (when helpful)
 N/A (Backend change)


## What this PR does
- This PR optimizes the createPost flow by replacing the email-based user lookup with a primary key lookup using the authenticated user's JWT _id.

### Changes made

- Replaced User.findOne({ email, role }) with User.findById(token._id).
- Used JWT _id as the primary identifier for user lookup.
- Selected only the required fields using .select("_id role postsCount").
- Improved the performance of the createPost flow by reducing unnecessary database lookup overhead.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue
Fixes #4026

## More screenshots (optional)
N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
