### PR TITLE
fix: add rate limiter to /send-otp endpoint

### DIFF
--- a/backend/src/app/modules/auth/auth.router.ts
+++ b/backend/src/app/modules/auth/auth.router.ts
@@ -24,7 +24,7 @@ router.post(
 
 // Google Login API route
 router.post("/google-login", loginRateLimiter, AuthController.googleLogin);
-router.post("/send-otp", validateRequest(UserValidator.sendOtp), AuthController.sendOtp);// Register API route
+router.post("/send-otp", forgotPasswordRateLimiter, validateRequest(UserValidator.sendOtp), AuthController.sendOtp);// Register API route
 router.post(
   "/register",
   validateRequest(UserValidator.register),


### PR DESCRIPTION
## Summary
Added `forgotPasswordRateLimiter` to the `/send-otp` route which had no rate limiting, allowing unlimited OTP emails to be triggered by any unauthenticated user.

`otpRateLimiter` was already applied to `/verify-otp` and `forgotPasswordRateLimiter` was already imported in `auth.router.ts` — this fix applies it consistently to `/send-otp` as well.

## Test plan
- [ ] Verified `/send-otp` now returns 429 after exceeding rate limit threshold
- [ ] Verified normal OTP send flow still works within limit

Fixes #4064