### PR TITLE
fix: resolve sanitizeJsonText ReferenceError and fix storyboard .map() syntax

### DIFF
--- a/backend/src/app/modules/ai_model/ai_model.utils.ts
+++ b/backend/src/app/modules/ai_model/ai_model.utils.ts
@@ -26,6 +26,15 @@ import {
   StoryboardResponseSchema,
 } from "../ai";
 
+const sanitizeJsonText = (rawText: string): string => {
+  const trimmed = rawText.trim();
+  if (!trimmed.startsWith("```")) return trimmed;
+  return trimmed
+    .replace(/^```(?:json)?\s*/i, "")
+    .replace(/\s*```$/, "")
+    .trim();
+};
+
 const geminiApiKey = config.gemini_api_key?.trim() ?? "";
 const genAI = new GoogleGenerativeAI(geminiApiKey);
 const MISSING_GEMINI_API_KEY_MESSAGE =
@@ -751,7 +760,6 @@ Rules:
           "Invalid AI response: Storyboard scenes are malformed.",
         );
       }
-    );
 
       return {
         sceneNumber: index + 1,


### PR DESCRIPTION
## What this PR does

Fixes two bugs in `backend/src/app/modules/ai_model/ai_model.utils.ts`:

**Bug 1 — `sanitizeJsonText` undefined (Fixes #4078):**
`sanitizeJsonText()` was called in 6 places but was neither imported nor defined in the file. It existed only as a local `const` in `storyBranchingController.ts`. Added the helper directly to `ai_model.utils.ts` so all 6 Gemini endpoints work.

**Bug 2 — Broken `.map()` in `generateStoryboardWithGemini` (Fixes #4080):**
A misplaced `);` on the line after the `if` block closed the `.map()` callback prematurely. The `return` statement was orphaned outside the callback, causing a TypeScript syntax error. Removed the extra `);` and placed the `return` inside the callback.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #4078
Closes #4080

## Checklist

- [X] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason. N/A — code-only fixes.
- [X] I have filled in the related issue number when there is one.
- [X] I have tested my changes.
- [X] I have done a self-review of the code.