### PR TITLE
fix(frontend): prevent input fields from overflowing login card

### DIFF
--- a/frontend/src/components/ui-component/ss-input/ss-input.tsx
+++ b/frontend/src/components/ui-component/ss-input/ss-input.tsx
@@ -51,7 +51,7 @@ const SSInput = <T extends FieldValues>({
       >
         {label} {required && <span className="text-rose-500">*</span>}
       </label>
-      <div className="relative mt-2 flex items-center">
+      <div className="relative mt-2 flex items-center w-full">
         {icon && (
           //<span className="absolute inset-y-0 left-0 pl-2 flex items-center text-gray-500">
             <span className="absolute left-3 text-gray-500 flex items-center pointer-events-none">


### PR DESCRIPTION

## What this PR does

This PR fixes a UI responsiveness issue on the Login Page where the username and password input fields overflowed outside the login container.

### Changes made:

* Fixed input field sizing and container alignment.
* Ensured form elements remain within the login card boundaries.
* Improved responsiveness across different screen sizes.
* Maintained consistent spacing and layout for better user experience.

---

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

---

## Related issue

Closes #4123

---

## More screenshots (optional)

### Desktop View

Attach screenshot after fix.

### Responsive/Mobile View

Attach screenshot after fix.

---

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.
