### PR TITLE
fix(auth): prevent login and signup input overflow

### DIFF
--- a/frontend/src/components/login/login.component.tsx
+++ b/frontend/src/components/login/login.component.tsx
@@ -150,7 +150,7 @@ const LoginComponent = () => {
           </div>
         </motion.div>
 
-                <div className="flex justify-center w-full box-border">
+                <div className="flex justify-center w-full min-w-0 box-border overflow-hidden">
           <div className="w-full max-w-md bg-slate-50 dark:bg-slate-800/60 backdrop-blur-xl border border-slate-200 dark:border-slate-700/50 rounded-2xl p-6 sm:p-8 lg:p-10 shadow-2xl box-border overflow-hidden relative mx-auto">
             <button
               onClick={() => (window.location.href = "/")}

--- a/frontend/src/components/signup/signup.component.tsx
+++ b/frontend/src/components/signup/signup.component.tsx
@@ -481,7 +481,7 @@ const otpPayload = {
                 </div>
               </div>
 
-              <div className="flex justify-center w-full box-border overflow-hidden">
+              <div className="flex justify-center w-full min-w-0 box-border overflow-hidden">
                 <GoogleLogin
                   onSuccess={handleGoogleLoginSuccess}
                   onError={handleGoogleLoginError}

--- a/frontend/src/components/ui-component/ss-input/ss-input.tsx
+++ b/frontend/src/components/ui-component/ss-input/ss-input.tsx
@@ -51,7 +51,7 @@ const SSInput = <T extends FieldValues>({
       >
         {label} {required && <span className="text-rose-500">*</span>}
       </label>
-      <div className="relative mt-2 flex items-center">
+      <div className="relative mt-2 flex items-center w-full min-w-0 overflow-hidden">
         {icon && (
           //<span className="absolute inset-y-0 left-0 pl-2 flex items-center text-gray-500">
             <span className="absolute left-3 text-gray-500 flex items-center pointer-events-none">


### PR DESCRIPTION
## Before you open this PR

## Screenshot (when helpful)

N/A — small UI layout fix, no additional screenshots required.

---

## What this PR does

Fixes the authentication form layout where input fields could overflow beyond the login and signup card boundaries.

### Changes made
- Added proper `min-w-0` constraints to prevent flex items from overflowing.
- Added `overflow-hidden` to relevant wrappers.
- Updated the reusable `SSInput` component to ensure inputs remain contained within their parent cards.
- Applied the fix to both Login and Signup pages.

---

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

---

## Related issue

Fixes #3615

May also resolve #3396, as both issues appear to describe the same authentication form overflow/layout problem shown in the screenshots.

---

## More screenshots (optional)

N/A

---

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.