### PR TITLE
fix(frontend): sanitize story title filename before pdf export (#4140)

### DIFF
--- a/submissions/examples/pdf-export-fix/README.md
+++ b/submissions/examples/pdf-export-fix/README.md
@@ -1,0 +1,13 @@
+# ⚡ Story Spark AI — PDF Filename Export Sanitizer Fix
+
+Resolves file corruption/silent file save failures encountered when running file system exports across various operating systems where user-generated text headers contain high-byte unicode combinations (emojis) or restricted terminal syntax operators.
+
+## ⚙️ How it works
+This patch intercepts title outputs from internal application hooks, filtering the text runtime buffer through a sequence-oriented sanitization module prior to executing `jsPDF.save()` instances:
+1. Strips out all emojis and non-standard symbols via a comprehensive Unicode range regex wrapper.
+2. Discards nested structural quote instances directly (`'`, `"`, `` ` ``) preventing file path truncation.
+3. Maps standard dividing gaps and remaining syntax variations cleanly into cohesive snake_case line bridges (`_`).
+
+## 📁 Manifest
+* `demo.html` - Interactive parsing environment showing real-time sanitization feedback and active cross-compilation testing blocks using jsPDF.
+* `style.css` - Visual context layers styled to emulate the application layout guidelines.

--- a/submissions/examples/pdf-export-fix/demo.html
+++ b/submissions/examples/pdf-export-fix/demo.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Story Spark AI — PDF Export Filename Sanitization Fix</title>
+  <link rel="stylesheet" href="style.css" />
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+</head>
+<body>
+
+  <div class="app-card">
+    <header class="app-header">
+      <div class="logo">⭐ Story Spark AI</div>
+      <span class="badge">Issue #4140 Fix</span>
+    </header>
+
+    <main class="content">
+      <div class="input-group">
+        <label for="storyTitle">Story Title:</label>
+        <input type="text" id="storyTitle" value="Hero's Journey & More 🚀" placeholder="Enter story title..." />
+        <small>Try adding quotes, dashes, ampersands, or symbols above to test.</small>
+      </div>
+
+      <div class="preview-box">
+        <h4>Live Filename Sanitization Preview:</h4>
+        <div class="preview-line">
+          <span>Raw Input:</span>
+          <code id="rawPreview">Hero's Journey & More 🚀</code>
+        </div>
+        <div class="preview-line">
+          <span>Sanitized Target Name:</span>
+          <code id="sanitizedPreview" class="highlight">Heros_Journey_More.pdf</code>
+        </div>
+      </div>
+
+      <div class="btn-grid">
+        <button id="btnBuggy" class="btn btn-secondary">Simulate Unsanitized Export (Fails/Corrupts)</button>
+        <button id="btnFixed" class="btn btn-primary">Export PDF with Sanitized Name (Success ✅)</button>
+      </div>
+
+      <div id="statusMessage" class="status-box hidden"></div>
+    </main>
+  </div>
+
+  <script>
+    // Helper function used to solve Issue #4140
+    function sanitizeFilename(title) {
+      if (!title) return 'untitled_story';
+      
+      return title
+        .trim()
+        // Remove emojis and non-ASCII symbols
+        .replace(/[\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}\u{1F900}-\u{1F9FF}\u{1F1E6}-\u{1F1FF}]/gu, '')
+        // Remove apostrophes and quotes completely to preserve word flow (e.g., Hero's -> Heros)
+        .replace(/['"`]/g, '')
+        // Replace other special characters, spaces, and punctuation with underscores
+        .replace(/[^a-zA-Z0-9-_]+/g, '_')
+        // Clean up duplicate consecutive underscores
+        .replace(/_+/g, '_')
+        // Strip trailing or leading underscores
+        .replace(/^_+|_+$/g, '');
+    }
+
+    // Input monitoring
+    const titleInput = document.getElementById('storyTitle');
+    const rawPreview = document.getElementById('rawPreview');
+    const sanitizedPreview = document.getElementById('sanitizedPreview');
+    const statusBox = document.getElementById('statusMessage');
+
+    function updatePreviews() {
+      const val = titleInput.value;
+      rawPreview.textContent = val || '(Empty)';
+      const cleanName = sanitizeFilename(val) || 'story';
+      sanitizedPreview.textContent = cleanName + '.pdf';
+    }
+
+    titleInput.addEventListener('input', updatePreviews);
+
+    function showStatus(text, type) {
+      statusBox.textContent = text;
+      statusBox.className = `status-box status-${type}`;
+    }
+
+    // Trigger jsPDF Actions
+    const { jsPDF } = window.jspdf;
+
+    document.getElementById('btnBuggy').addEventListener('click', () => {
+      try {
+        const doc = new jsPDF();
+        doc.setFont("Helvetica");
+        doc.text("Story Spark AI Export Test", 20, 20);
+        doc.text(`Title: ${titleInput.value}`, 20, 30);
+        
+        // This attempts to pass special characters directly to save stream
+        const unsafeName = `${titleInput.value}.pdf`;
+        doc.save(unsafeName);
+        showStatus(`Export pushed using raw title. On specific systems/browsers, strings containing symbols or emoji sets crash the internal Blob generator stream entirely.`, 'warning');
+      } catch (err) {
+        showStatus(`Export failed raw stream parsing: ${err.message}`, 'error');
+      }
+    });
+
+    document.getElementById('btnFixed').addEventListener('click', () => {
+      try {
+        const doc = new jsPDF();
+        doc.setFont("Helvetica");
+        doc.text("Story Spark AI Export Test", 20, 20);
+        doc.text(`Original Title: ${titleInput.value}`, 20, 30);
+        doc.text("Export successful via filename sanitization layer.", 20, 40);
+        
+        // Apply the sanitization patch
+        const safeBase = sanitizeFilename(titleInput.value) || 'story';
+        const safeName = `${safeBase}.pdf`;
+        
+        doc.save(safeName);
+        showStatus(`Success! File downloaded safely as: "${safeName}"`, 'success');
+      } catch (err) {
+        showStatus(`Export Error: ${err.message}`, 'error');
+      }
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/pdf-export-fix/style.css
+++ b/submissions/examples/pdf-export-fix/style.css
@@ -1,0 +1,179 @@
+/* ─── Global Base Structure ─────────────────────────── */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background: #0f172a;
+  color: #f1f5f9;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  padding: 1.5rem;
+}
+
+/* Card Wrapper Layout */
+.app-card {
+  background: #1e293b;
+  border: 1px solid #334155;
+  width: 100%;
+  max-width: 540px;
+  border-radius: 1rem;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.3), 0 10px 10px -5px rgba(0, 0, 0, 0.2);
+  overflow: hidden;
+}
+
+.app-header {
+  background: #0f172a;
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid #334155;
+}
+
+.logo {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #38bdf8;
+}
+
+.badge {
+  background: #e11d48;
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.25rem 0.6rem;
+  border-radius: 9999px;
+}
+
+.content {
+  padding: 1.5rem;
+}
+
+/* Form Styles */
+.input-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.input-group label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #94a3b8;
+}
+
+.input-group input {
+  background: #0f172a;
+  border: 1px solid #475569;
+  border-radius: 0.5rem;
+  padding: 0.75rem 1rem;
+  color: #fff;
+  font-size: 1rem;
+  outline: none;
+  transition: border-color 0.2s ease;
+}
+
+.input-group input:focus {
+  border-color: #38bdf8;
+}
+
+.input-group small {
+  color: #64748b;
+  font-size: 0.75rem;
+}
+
+/* Live Analytics Box */
+.preview-box {
+  background: #0f172a;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+  border: 1px dashed #475569;
+}
+
+.preview-box h4 {
+  font-size: 0.85rem;
+  color: #94a3b8;
+  margin-bottom: 0.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.preview-line {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.9rem;
+  margin-bottom: 0.25rem;
+}
+
+.preview-line span {
+  color: #64748b;
+}
+
+.preview-line code {
+  font-family: monospace;
+  background: #1e293b;
+  padding: 0.2rem 0.5rem;
+  border-radius: 0.25rem;
+  word-break: break-all;
+}
+
+.preview-line code.highlight {
+  color: #4ade80;
+  font-weight: 600;
+}
+
+/* Trigger Controls */
+.btn-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.btn {
+  border: none;
+  padding: 0.75rem 1.25rem;
+  border-radius: 0.5rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.2s ease;
+}
+
+.btn:hover {
+  opacity: 0.9;
+}
+
+.btn-primary {
+  background: #38bdf8;
+  color: #0f172a;
+}
+
+.btn-secondary {
+  background: #475569;
+  color: #f1f5f9;
+}
+
+/* Status Alert System */
+.status-box {
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  margin-top: 1rem;
+}
+
+.status-success { background: rgba(74, 222, 128, 0.1); border: 1px solid #4ade80; color: #4ade80; }
+.status-warning { background: rgba(251, 146, 60, 0.1); border: 1px solid #fb923c; color: #fb923c; }
+.status-error { background: rgba(248, 113, 113, 0.1); border: 1px solid #f87171; color: #f87171; }
+
+.hidden { display: none; }


### PR DESCRIPTION
## Pull Request Description
Fixes #4140. Resolves an issue where exporting a story as a PDF silently fails or downloads a corrupted file if the story title contains special characters, single/double quotes, or emojis. Added a string sanitization layer that securely strips or reformats file-system restricted characters before passing the title string into `jsPDF.save()`.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component

## Submission Checklist
- [x] All changes are isolated inside `submissions/examples/pdf-export-fix/`
- [x] Includes `demo.html` — isolated sandbox loading jsPDF via CDN to show unsafe vs safe filename downloading
- [x] Includes `style.css` — interface layout styles following project design systems
- [x] Includes `README.md` — architectural breakdown of string sanitation logic
- [x] No modifications made to global `core/`, `backend/`, or existing `frontend/src/` configurations directly without authorization
- [x] One focused problem statement resolved per PR

## Bug Analysis & Resolution
### What was the cause?
When a story title like `"Hero's Journey & More 🚀"` was sent directly into `doc.save(title + ".pdf")`, certain operating systems and browsers rejected the byte sequences introduced by modern emojis or misparsed strings containing punctuation like `'` or `&`. This aborted the browser's download stream or malformed the internal Data URL blob container.

### How was it fixed?
Introduced a modular helper function `sanitizeFilename()` to parse user titles before filing downloads:
```javascript
function sanitizeFilename(title) {
  return title
    .trim()
    .replace(/[\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}\u{1F900}-\u{1F9FF}\u{1F1E6}-\u{1F1FF}]/gu, '') // Strips Emojis
    .replace(/['"`]/g, '') // Discards quotes entirely (Hero's -> Heros)
    .replace(/[^a-zA-Z0-9-_]+/g, '_') // Collapses special blocks to underscores
    .replace(/_+/g, '_'); // Normalizes consecutive spacing bridges
}