### PR TITLE
fix(accessibility): add aria-pressed to CharacterPlanner arc step but…

### DIFF
--- a/frontend/src/components/character-planner/CharacterPlanner.jsx
+++ b/frontend/src/components/character-planner/CharacterPlanner.jsx
@@ -72,6 +72,7 @@ export default function CharacterPlanner({ onContextUpdate }) {
               key={step}
               type="button"
               className={`cp-arc-node ${arcStep === step ? 'active' : ''}`}
+              aria-pressed={arcStep === step}
               onClick={() => handleArcChange(step)}
             >
               {step}


### PR DESCRIPTION
## Screenshot (when helpful)

N/A — this is a non-visual accessibility fix (HTML attribute change, no UI appearance change).



## What this PR does

The arc step buttons (Introduction, Climax, Resolution) in CharacterPlanner.jsx were missing the aria-pressed attribute. The selected state was only communicated via a CSS class (active), which screen readers cannot detect. This means users relying on assistive technology had no way to know which arc step was currently selected.

Fix: added aria-pressed={arcStep === step} to each button in the arc timeline. Screen readers will now announce the selected button as "pressed" and others as "not pressed".



## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #4186 

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
