### PR TITLE
fix : added 50000-char max bound to plot hole detection content field

### DIFF
--- a/backend/src/app/modules/plot_hole_detector/plot_hole.validation.ts
+++ b/backend/src/app/modules/plot_hole_detector/plot_hole.validation.ts
@@ -6,7 +6,8 @@ const detectSchema = z.object({
     content: z
       .string({ required_error: "Story content is required." })
       .trim()
-      .min(1, "Story content cannot be empty."),
+      .min(1, "Story content cannot be empty.")
+      .max(50000, "Content cannot exceed 50000 characters"),
   }),
 });
 

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,12 +1,11 @@
 import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
   test: {
     globals: true,
     environment: 'jsdom',
-    globals: true,
     setupFiles: [],
   },
 });
-


### PR DESCRIPTION
Closes #4192.

Summary of What Has Been Done:
Added .max(50000) constraint to the content field in detectSchema, preventing unbounded content payloads from reaching the AI generation pipeline.

Changes Made:
- backend/src/app/modules/plot_hole_detector/plot_hole.validation.ts: added .max(50000, "Content cannot exceed 50000 characters") to the content field

Impact it Made:
- Protects the AI pipeline from multi-MB payloads; aligns with the max content length used in post validation.

Note: Please assign this PR to the `tmdeveloper007` account.