### PR TITLE
fix: validate invalid pagination cursors

### DIFF
--- a/backend/src/app/modules/post/post.service.ts
+++ b/backend/src/app/modules/post/post.service.ts
@@ -40,13 +40,19 @@ const decodeCursor = (cursor?: string): ICursorPayload | null => {
   try {
     const decoded = Buffer.from(cursor, "base64").toString("utf-8");
     const parsed = JSON.parse(decoded);
-    if (!parsed?.id || parsed.value === undefined) {
-      return null;
-    }
+   if (!parsed?.id || parsed.value === undefined) {
+  throw new ApiError(
+    httpStatus.BAD_REQUEST,
+    "Invalid pagination cursor"
+  );
+}
     return parsed as ICursorPayload;
   } catch {
-    return null;
-  }
+  throw new ApiError(
+    httpStatus.BAD_REQUEST,
+    "Invalid pagination cursor"
+  );
+}
 };
 
 const getCursorCondition = (


### PR DESCRIPTION
## What this PR does

This PR fixes the pagination cursor validation logic in `backend/src/app/modules/post/post.service.ts`.

Previously, malformed or invalid pagination cursors were silently treated as if no cursor had been provided. As a result, the API returned the first page of results instead of notifying the client about the invalid input.

### Changes made
- Added validation for malformed pagination cursors.
- Return a `400 Bad Request` error when an invalid cursor is supplied.
- Preserve existing behavior for requests where no cursor is provided.
- Prevent silent pagination resets caused by corrupted or tampered cursor values.

## Type of change

- [x] Bug fix

## Related issue

Closes #3980

## Screenshot

N/A – Backend validation change, no UI updates.

## Testing

- Verified that requests without a cursor continue to return the first page.
- Verified that invalid or malformed cursors now return a validation error instead of silently resetting pagination.

## Checklist

- [x] I have added screenshots or noted N/A.
- [x] I have filled in the related issue number.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.