### PR TITLE
fix: atomise consumeTokenQuota with Lua script to prevent quota overrun 

### DIFF
--- a/backend/src/__tests__/rateLimitStore.test.ts
+++ b/backend/src/__tests__/rateLimitStore.test.ts
@@ -41,3 +41,92 @@ describe("consumeRateLimit", () => {
     );
   });
 });
+
+// ─── consumeTokenQuota ────────────────────────────────────────────────────────
+
+const mockEval = jest.fn();
+
+jest.mock("ioredis", () => {
+  return jest.fn().mockImplementation(() => ({
+    eval: mockEval,
+  }));
+});
+
+import { consumeTokenQuota } from "../app/middleware/rate_limit.store";
+
+describe("consumeTokenQuota", () => {
+  const USER = "user_abc";
+  const TOKENS = 100;
+  const LIMIT = 1000;
+
+  beforeEach(() => {
+    mockEval.mockReset();
+  });
+
+  it("allows request when quota is not exceeded and returns correct remaining", async () => {
+    // Lua returns [allowed=1, usedAfter=100, ttlSec=<anything>]
+    mockEval.mockResolvedValueOnce([1, 100, 86400]);
+
+    const result = await consumeTokenQuota(USER, TOKENS, LIMIT);
+
+    expect(result.allowed).toBe(true);
+    expect(result.remainingTokens).toBe(900); // 1000 - 100
+    expect(result.retryAfterSec).toBe(0);
+  });
+
+  it("denies request when quota is exceeded and returns time-until-midnight", async () => {
+    // Lua returns [allowed=0, currentUsed=950, ttl=3600]
+    mockEval.mockResolvedValueOnce([0, 950, 3600]);
+
+    const result = await consumeTokenQuota(USER, TOKENS, LIMIT);
+
+    expect(result.allowed).toBe(false);
+    expect(result.remainingTokens).toBe(50); // 1000 - 950
+    expect(result.retryAfterSec).toBeGreaterThan(0);
+  });
+
+  it("passes a single atomic eval call (no separate GET + INCRBY)", async () => {
+    mockEval.mockResolvedValueOnce([1, 200, 86400]);
+
+    await consumeTokenQuota(USER, TOKENS, LIMIT);
+
+    // Must be exactly one call — the Lua script — not multiple round-trips
+    expect(mockEval).toHaveBeenCalledTimes(1);
+    const [, numKeys, key] = mockEval.mock.calls[0];
+    expect(numKeys).toBe(1);
+    expect(key).toMatch(/^token_quota:user_abc:\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("is concurrent-safe: 10 parallel bursts each get independent Lua calls", async () => {
+    // Simulate 10 concurrent requests each consuming 150 tokens against a 1000-token limit.
+    // With the atomic Lua fix, the backing store serialises them; only the first 6 pass.
+    // Here we just assert that 10 independent eval calls are made (not one GET + 10 INCRBY).
+    let counter = 0;
+    mockEval.mockImplementation(async () => {
+      counter += 150;
+      const allowed = counter <= LIMIT ? 1 : 0;
+      return [allowed, counter, 3600];
+    });
+
+    const results = await Promise.all(
+      Array.from({ length: 10 }, () => consumeTokenQuota(USER, 150, LIMIT))
+    );
+
+    expect(mockEval).toHaveBeenCalledTimes(10);
+    const allowed = results.filter((r) => r.allowed).length;
+    const denied = results.filter((r) => !r.allowed).length;
+    expect(allowed).toBe(6);  // floor(1000/150) = 6
+    expect(denied).toBe(4);
+  });
+
+  it("fails closed when Redis throws", async () => {
+    mockEval.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+    const result = await consumeTokenQuota(USER, TOKENS, LIMIT);
+
+    expect(result).toEqual({ allowed: false, remainingTokens: 0, retryAfterSec: 60 });
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      expect.stringContaining("Redis token quota error")
+    );
+  });
+});

--- a/backend/src/app/middleware/rate_limit.store.ts
+++ b/backend/src/app/middleware/rate_limit.store.ts
@@ -133,6 +133,25 @@ import Redis from "ioredis";
 // We use ioredis to securely track token quotas
 const redisClient = process.env.REDIS_URL ? new Redis(process.env.REDIS_URL) : new Redis();
 
+const QUOTA_LUA = `
+local key     = KEYS[1]
+local needed  = tonumber(ARGV[1])
+local limit   = tonumber(ARGV[2])
+local ttl_sec = tonumber(ARGV[3])
+
+local current = tonumber(redis.call('GET', key) or 0)
+if current + needed > limit then
+  return {0, current, redis.call('TTL', key)}
+end
+
+local after = redis.call('INCRBY', key, needed)
+if after == needed then
+  -- Key was just created (first request); set the expiry now.
+  redis.call('EXPIRE', key, ttl_sec)
+end
+return {1, after, ttl_sec}
+`;
+
 export const consumeTokenQuota = async (
   userIdOrIp: string,
   tokensRequired: number,
@@ -141,29 +160,44 @@ export const consumeTokenQuota = async (
   const dateStr = new Date().toISOString().split("T")[0]; // YYYY-MM-DD
   const key = `token_quota:${userIdOrIp}:${dateStr}`;
 
+  // TTL: seconds remaining until midnight UTC
+  const now = new Date();
+  const tomorrow = new Date(Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate() + 1
+  ));
+  const ttlSec = Math.ceil((tomorrow.getTime() - now.getTime()) / 1000);
+
   try {
-    const currentTokens = await redisClient.get(key);
-    const usedTokens = currentTokens ? parseInt(currentTokens, 10) : 0;
+    // eval(script, numkeys, ...keys, ...args) – ioredis signature
+    const result = await redisClient.eval(
+      QUOTA_LUA,
+      1,           // number of KEYS
+      key,         // KEYS[1]
+      String(tokensRequired),
+      String(dailyQuotaLimit),
+      String(ttlSec)
+    ) as [number, number, number];
 
-    if (usedTokens + tokensRequired > dailyQuotaLimit) {
-      // Calculate seconds until midnight UTC
-      const now = new Date();
-      const tomorrow = new Date(now);
-      tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
-      tomorrow.setUTCHours(0, 0, 0, 0);
-      const retryAfterSec = Math.ceil((tomorrow.getTime() - now.getTime()) / 1000);
+    const [allowed, usedOrAfter] = result;
 
-      return { allowed: false, remainingTokens: dailyQuotaLimit - usedTokens, retryAfterSec };
+    if (allowed === 0) {
+      return {
+        allowed: false,
+        remainingTokens: Math.max(0, dailyQuotaLimit - usedOrAfter),
+        retryAfterSec: ttlSec,
+      };
     }
 
-    // Atomically increment and set expiry to 48 hours (to be safe)
-    await redisClient.incrby(key, tokensRequired);
-    await redisClient.expire(key, 48 * 60 * 60);
-
-    return { allowed: true, remainingTokens: dailyQuotaLimit - (usedTokens + tokensRequired), retryAfterSec: 0 };
+    return {
+      allowed: true,
+      remainingTokens: Math.max(0, dailyQuotaLimit - usedOrAfter),
+      retryAfterSec: 0,
+    };
   } catch (error) {
     logger.error(`Redis token quota error: ${error}`);
-    // Fail open or closed? Typically fail closed for financial limits.
+    // Fail closed: deny when the quota store is unreachable.
     return { allowed: false, remainingTokens: 0, retryAfterSec: 60 };
   }
 };


### PR DESCRIPTION
## What type of PR is this?
Bug fix

## Description
`consumeTokenQuota` performed a **read → check → increment** across three separate Redis round-trips. Any two concurrent requests for the same `userIdOrIp` key could read the identical stale counter, both pass the quota check, and both write their token increment — allowing up to `N × tokensRequired` tokens to be consumed before the counter reflected any of them. This is a textbook TOCTOU (time-of-check / time-of-use) race condition.

## Fix
Replace the three round-trips with a single `redis.eval()` call that runs a **Lua script atomically on the Redis server**. Redis serialises all commands and guarantees no other client command executes while the Lua script is running, so the check-and-increment is race-free by design.

**Script contract** — returns `[allowed, usedTokens, ttlSec]`:
- If `current + needed > limit` → `[0, current, TTL]` (denied, no write)
- Otherwise → `[1, newTotal, TTL]` (allowed, INCRBY already applied)

Additional fixes bundled in the same change:
- `EXPIRE` is now only set when the key is **first created** (`after == needed`), not on every request — avoiding a subtle TTL-reset race under concurrency.
- TTL is now aligned to **midnight UTC** (seconds to next day boundary) instead of a rolling 48-hour window, matching the `YYYY-MM-DD` key naming convention already in use.
- Fail-closed error handling is preserved.

## Related issues
Closes #3872

## Changes
- `backend/src/app/middleware/rate_limit.store.ts` — replace non-atomic GET / INCRBY / EXPIRE with a single `eval(QUOTA_LUA, ...)` call
- `backend/src/__tests__/rateLimitStore.test.ts` — four new tests: allow path, deny path, single-eval assertion (proves atomicity at the call-site level), 10-concurrent-burst simulation, Redis error fail-closed

## Screenshots or screen recording
N/A — backend logic change with unit test coverage.

## Added to documentation?
No documentation change required.

## GSSoC '26