### PR TITLE
fix: await doc hydration before emitting sync to prevent YJS desync

### DIFF
--- a/backend/src/__tests__/yjsGateway.test.ts
+++ b/backend/src/__tests__/yjsGateway.test.ts
@@ -1,0 +1,186 @@
+// We mock socket.io, yjs, and CollabService so the suite has no I/O deps.
+
+import * as Y from 'yjs';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockGetCollabState = jest.fn<Promise<string | undefined>, [string]>();
+const mockUpdateCollabState = jest.fn<Promise<void>, [string, string]>();
+
+jest.mock('../app/modules/collab/collab.service', () => ({
+  CollabService: {
+    getCollabState: (...args: [string]) => mockGetCollabState(...args),
+    updateCollabState: (...args: [string, string]) => mockUpdateCollabState(...args),
+  },
+}));
+
+jest.mock('y-protocols/awareness', () => ({
+  Awareness: jest.fn().mockImplementation(() => ({
+    setLocalStateField: jest.fn(),
+    applyUpdate: jest.fn(),
+  })),
+}));
+
+// Minimal Socket.io Server / Socket stubs
+type Handler = (...args: unknown[]) => void;
+
+function makeSocket(storyId: string | undefined): {
+  handshake: { query: Record<string, string | undefined> };
+  emit: jest.Mock;
+  on: jest.Mock;
+  broadcast: { emit: jest.Mock };
+  disconnect: jest.Mock;
+  handlers: Record<string, Handler>;
+} {
+  const handlers: Record<string, Handler> = {};
+  const socket = {
+    handshake: { query: { storyId } as Record<string, string | undefined> },
+    emit: jest.fn(),
+    on: jest.fn((event: string, fn: Handler) => { handlers[event] = fn; }),
+    broadcast: { emit: jest.fn() },
+    disconnect: jest.fn(),
+    handlers,
+  };
+  return socket;
+}
+
+type ConnectionHandler = (socket: ReturnType<typeof makeSocket>) => void;
+let capturedConnectionHandler: ConnectionHandler;
+
+jest.mock('socket.io', () => ({
+  Server: jest.fn().mockImplementation(() => ({
+    of: jest.fn().mockReturnValue({
+      on: jest.fn((event: string, fn: ConnectionHandler) => {
+        if (event === 'connection') capturedConnectionHandler = fn;
+      }),
+    }),
+  })),
+}));
+
+// ── Import under test (after mocks are in place) ─────────────────────────────
+import { YjsGateway } from '../app/modules/collab/yjs.gateway';
+import { Server } from 'socket.io';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function buildGateway() {
+  const io = new Server();
+  new YjsGateway(io);
+  return io;
+}
+
+/** Encode a real Y.Doc with a single text entry so we can recognise it. */
+function encodeDocWithText(text: string): string {
+  const doc = new Y.Doc();
+  doc.getText('content').insert(0, text);
+  return Buffer.from(Y.encodeStateAsUpdate(doc)).toString('base64');
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('YjsGateway — initialisation race fix (#3873)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    buildGateway();
+  });
+
+  it('disconnects sockets that provide no storyId', () => {
+    const socket = makeSocket(undefined);
+    capturedConnectionHandler(socket as never);
+    expect(socket.disconnect).toHaveBeenCalledWith(true);
+    expect(socket.emit).not.toHaveBeenCalled();
+  });
+
+  it('emits sync with persisted state to the first connecting socket', async () => {
+    const base64 = encodeDocWithText('persisted content');
+    mockGetCollabState.mockResolvedValueOnce(base64);
+
+    const socket = makeSocket('story-1');
+    capturedConnectionHandler(socket as never);
+
+    // Flush the loader promise
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(socket.emit).toHaveBeenCalledWith('sync', expect.any(Uint8Array));
+    // The emitted update should decode to a doc containing 'persisted content'
+    const [, update] = socket.emit.mock.calls[0] as [string, Uint8Array];
+    const doc = new Y.Doc();
+    Y.applyUpdate(doc, update);
+    expect(doc.getText('content').toString()).toBe('persisted content');
+  });
+
+  it('emits sync to second socket using the same in-flight loader (no duplicate DB call)', async () => {
+    let resolveLoader!: (v: string) => void;
+    const loaderPromise = new Promise<string>(res => { resolveLoader = res; });
+    mockGetCollabState.mockReturnValueOnce(loaderPromise as Promise<string | undefined>);
+
+    const socketA = makeSocket('story-2');
+    const socketB = makeSocket('story-2');
+
+    // Both connect while the loader is still pending
+    capturedConnectionHandler(socketA as never);
+    capturedConnectionHandler(socketB as never);
+
+    // Resolve the single DB call
+    resolveLoader(encodeDocWithText('shared state'));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Only one DB fetch, not two
+    expect(mockGetCollabState).toHaveBeenCalledTimes(1);
+
+    // Both sockets receive sync
+    expect(socketA.emit).toHaveBeenCalledWith('sync', expect.any(Uint8Array));
+    expect(socketB.emit).toHaveBeenCalledWith('sync', expect.any(Uint8Array));
+  });
+
+  it('does not register update handler until after persisted state is applied', async () => {
+    // Loader resolves after a tick
+    let resolveLoader!: (v: string | undefined) => void;
+    mockGetCollabState.mockReturnValueOnce(
+      new Promise<string | undefined>(res => { resolveLoader = res; })
+    );
+
+    const socket = makeSocket('story-3');
+    capturedConnectionHandler(socket as never);
+
+    // Before loader resolves: no 'update' handler yet
+    expect(socket.handlers['update']).toBeUndefined();
+
+    resolveLoader(undefined);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // After loader resolves: 'update' handler is registered
+    expect(socket.handlers['update']).toBeDefined();
+  });
+
+  it('disconnects socket and clears the loader when DB load fails', async () => {
+    mockGetCollabState.mockRejectedValueOnce(new Error('DB connection lost'));
+
+    const socket = makeSocket('story-4');
+    capturedConnectionHandler(socket as never);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(socket.emit).toHaveBeenCalledWith('error', expect.objectContaining({
+      message: expect.stringContaining('Failed to load document state'),
+    }));
+    expect(socket.disconnect).toHaveBeenCalledWith(true);
+  });
+
+  it('emits sync with empty state when no persisted state exists', async () => {
+    mockGetCollabState.mockResolvedValueOnce(undefined);
+
+    const socket = makeSocket('story-5');
+    capturedConnectionHandler(socket as never);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(socket.emit).toHaveBeenCalledWith('sync', expect.any(Uint8Array));
+  });
+});

--- a/backend/src/app/modules/collab/yjs.gateway.ts
+++ b/backend/src/app/modules/collab/yjs.gateway.ts
@@ -2,20 +2,80 @@ import { Server, Socket } from 'socket.io';
 import * as Y from 'yjs';
 import { debounce } from 'lodash';
 import { CollabService } from './collab.service';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { Awareness } = require('y-protocols/awareness');
 
 /**
- * Yjs gateway that syncs a Yjs document over a Socket.io namespace
+* Yjs gateway that syncs a Yjs document over a Socket.io namespace
  * and persists the document state to MongoDB.
+ *
+ * ## Initialisation protocol
+ *
+ * The previous implementation placed an empty Y.Doc into `this.docs`
+ * immediately and fired the MongoDB load in an unawaited `.then()`.
+ * This created two race conditions:
+ *
+ *  1. A second socket connecting while the load was in-flight found
+ *     the doc in the Map (non-null), skipped the load branch entirely,
+ *     and therefore never received a `sync` event.
+ *
+ *  2. Any `update` events that arrived before `.then()` resolved were
+ *     applied to the empty doc and then silently overwritten when the
+ *     persisted state was applied on top.
+ *
+ * Fix: replace the raw Doc with a Promise<Y.Doc> during the load phase.
+ * `this.docLoaders` stores that promise for every storyId whose doc is
+ * still being initialised.  Every socket — first or subsequent — awaits
+ * the same promise before registering event handlers, so:
+ *
+ *  - All sockets receive `sync` with the fully-hydrated document state.
+ *  - No `update` handler is registered until after `Y.applyUpdate` has
+ *    been called, so in-flight edits cannot race with the initial load.
  */
 export class YjsGateway {
   private readonly io: Server;
   private readonly docs: Map<string, Y.Doc> = new Map();
+  // Holds the in-flight load promise so concurrent connections share it
+  // instead of each triggering an independent DB fetch.
+  private readonly docLoaders: Map<string, Promise<Y.Doc>> = new Map();
   private readonly debouncedSaves: Map<string, () => void> = new Map();
   private readonly saveDelay = 2000; // ms
 
   constructor(io: Server) {
     this.io = io.of('/yjs');
     this.setup();
+  }
+
+  /**
+   * Returns a Promise that resolves to the fully-hydrated Y.Doc for the
+   * given storyId.  If the doc is already loaded it resolves immediately.
+   * If a load is in progress every caller awaits the same Promise (no
+   * duplicate DB reads).  Otherwise a new load is started.
+   */
+  private getOrLoadDoc(storyId: string): Promise<Y.Doc> {
+    // Already fully loaded — wrap in a resolved promise.
+    const existing = this.docs.get(storyId);
+    if (existing) return Promise.resolve(existing);
+
+    // Load already in flight — share it.
+    const inFlight = this.docLoaders.get(storyId);
+    if (inFlight) return inFlight;
+
+    // First connection for this storyId — start the load.
+    const loader = CollabService.getCollabState(storyId).then(state => {
+      const doc = new Y.Doc();
+      if (state) {
+        const update = Uint8Array.from(Buffer.from(state, 'base64'));
+        Y.applyUpdate(doc, update);
+      }
+      // Promote to the stable docs map and retire the loader.
+      this.docs.set(storyId, doc);
+      this.docLoaders.delete(storyId);
+      return doc;
+    });
+
+    this.docLoaders.set(storyId, loader);
+    return loader;
   }
 
   private setup() {
@@ -25,34 +85,38 @@ export class YjsGateway {
         socket.disconnect(true);
         return;
       }
-      let doc = this.docs.get(storyId);
-      if (!doc) {
-        doc = new Y.Doc();
-        this.docs.set(storyId, doc);
-        // Load persisted state if any
-        CollabService.getCollabState(storyId).then(state => {
-          if (state) {
-            const update = Uint8Array.from(Buffer.from(state, 'base64'));
-            Y.applyUpdate(doc!, update);
-          }
-          socket.emit('sync', Y.encodeStateAsUpdate(doc!));
+
+      // All sockets — first or concurrent — await the same loader promise.
+      // No event handlers are registered until the doc is fully hydrated.
+      this.getOrLoadDoc(storyId).then(doc => {
+        // Send the full current state to the newly connected client.
+        socket.emit('sync', Y.encodeStateAsUpdate(doc));
+
+        // Broadcast updates from this socket to others in the room.
+        socket.on('update', (update: Uint8Array) => {
+          Y.applyUpdate(doc, update);
+          socket.broadcast.emit('update', update);
+          this.scheduleSave(storyId, doc);
         });
-      }
-      // Broadcast updates from this socket to others
-      socket.on('update', (update: Uint8Array) => {
-        Y.applyUpdate(doc!, update);
-        socket.broadcast.emit('update', update);
-        this.scheduleSave(storyId, doc!);
-      });
-      // Awareness (cursors/selection)
-      const awareness = new (require('y-protocols/awareness')).Awareness(doc);
-      awareness.setLocalStateField('user', {
-        name: socket.id,
-        color: this.randomColor(),
-      });
-      socket.on('awareness', (aw: Uint8Array) => {
-        awareness.applyUpdate(aw);
-        socket.broadcast.emit('awareness', aw);
+
+        // Awareness (cursors / selection).
+        const awareness = new Awareness(doc);
+        awareness.setLocalStateField('user', {
+          name: socket.id,
+          color: this.randomColor(),
+        });
+        socket.on('awareness', (aw: Uint8Array) => {
+          awareness.applyUpdate(aw);
+          socket.broadcast.emit('awareness', aw);
+        });
+      }).catch(err => {
+        // If the DB load fails, disconnect cleanly rather than leaving
+        // the client in a permanently desynced state.
+        console.error(`[YjsGateway] Failed to load doc for storyId=${storyId}:`, err);
+        socket.emit('error', { message: 'Failed to load document state.' });
+        socket.disconnect(true);
+        // Remove the failed loader so the next connection retries the load.
+        this.docLoaders.delete(storyId);
       });
     });
   }


### PR DESCRIPTION
## What type of PR is this?
Bug fix

## Description
Closes #3873.

### Root cause
`setup()` stored an empty `Y.Doc` in `this.docs` synchronously, then kicked off a MongoDB load in an **unawaited** `.then()`. Two races followed:

**Race 1 — second socket never syncs.**  
A socket connecting while the load was still pending found the doc already in `this.docs` (non-null), skipped the load branch entirely, and never received a `sync` event. It started with a permanently empty document while the first socket eventually received persisted state — immediate divergence.

**Race 2 — in-flight edits silently discarded.**  
Any `update` event that arrived before `.then()` resolved was applied to the empty doc. When `Y.applyUpdate` then ran with the full persisted state it overwrote those in-flight edits without warning.

### Fix
Introduce `getOrLoadDoc(storyId): Promise<Y.Doc>` backed by a `docLoaders: Map<string, Promise<Y.Doc>>` side-map:

- **First connection** — creates the `Y.Doc`, runs the DB load inside the promise, calls `Y.applyUpdate` if state exists, then promotes the doc to the stable `docs` map and removes the loader.
- **Concurrent connections** — find the in-flight promise in `docLoaders` and share it; only one DB fetch ever fires per `storyId`.
- **Subsequent connections** — find the doc already in `docs` and get an immediately-resolved promise.

Every socket calls `.then(doc => { socket.emit('sync', ...); socket.on('update', ...); })`. Because `update` handlers are registered inside `.then()`, they cannot fire before `Y.applyUpdate` has been called. Both races are eliminated.

A failed DB load now disconnects the client with an `error` event and clears the loader so the next connection retries, rather than silently leaving the client with a broken empty doc.

## Changes
- `backend/src/app/modules/collab/yjs.gateway.ts` — replace bare `.then()` load with `getOrLoadDoc()` shared-promise pattern; move all socket event registration into the `.then()` callback; add `.catch()` with graceful disconnect
- `backend/src/__tests__/yjsGateway.test.ts` — five new tests covering: no-storyId disconnect, persisted state applied on sync, single DB call shared across concurrent sockets, update handler not registered before hydration, graceful failure on DB error

## Related issues
Closes #3873

## Added to documentation?
No documentation change required.

## GSSoC '26