### PR TITLE
fix: swapped play and resume icons in audio player (Resolves #4126)

### DIFF
--- a/frontend/src/components/AudioPlayer.tsx
+++ b/frontend/src/components/AudioPlayer.tsx
@@ -263,7 +263,7 @@ const AudioPlayer = forwardRef<AudioPlayerHandle, AudioPlayerProps>(
                 disabled={!canNarrate}
                 className={`${controlButtonBaseClass} border-indigo-200 bg-indigo-50 text-indigo-700 hover:bg-indigo-100 dark:border-indigo-500/20 dark:bg-indigo-500/10 dark:text-indigo-200 dark:hover:bg-indigo-500/20`}
               >
-                <Play className="h-4 w-4" aria-hidden="true" />
+                <RotateCcw className="h-4 w-4" aria-hidden="true" />
                 Play
               </button>
 
@@ -289,7 +289,7 @@ const AudioPlayer = forwardRef<AudioPlayerHandle, AudioPlayerProps>(
                 disabled={!speech.isPaused}
                 className={`${controlButtonBaseClass} border-emerald-200 bg-emerald-50 text-emerald-700 hover:bg-emerald-100 dark:border-emerald-500/20 dark:bg-emerald-500/10 dark:text-emerald-200 dark:hover:bg-emerald-500/20`}
               >
-                <RotateCcw className="h-4 w-4" aria-hidden="true" />
+                <Play className="h-4 w-4" aria-hidden="true" />
                 Resume
               </button>
 


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Open or link a related issue when there is one (`Closes #4126 `, `Fixes #4126 `** under Related issue below).
- **Description:** Fill in **What this PR does** so a reviewer can understand the change without your local context.
- **Screenshots:** Add screenshots or a short recording when they help (UI changes, confusing flows, or non-code proof). If not needed, say so in the checklist.

## Screenshot (when helpful)

<!-- Drag & drop or paste. For non-UI work, you can use tests output, logs, or API responses. Write “N/A” in the checklist if you skip this section. -->

Before
<img width="1251" height="236" alt="image" src="https://github.com/user-attachments/assets/3bae174f-0a63-46ef-9738-25dcf91142fe" />

After
<img width="935" height="220" alt="image" src="https://github.com/user-attachments/assets/0682a140-d48a-4b6b-b178-182c4ff73a36" />


## What this PR does

This PR fixes a UI bug in the `AudioPlayer` component where the "Play" and "Resume" icons were incorrectly assigned. I swapped the `<Play />` and `<RotateCcw />` icon components in `AudioPlayer.tsx` so that they accurately match their respective button labels.

## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #4126 

## More screenshots (optional)

 

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.