### PR TITLE
fix: improve hair color detection in characterConsistency utility

### DIFF
--- a/frontend/src/utils/__tests__/characterConsistency.test.ts
+++ b/frontend/src/utils/__tests__/characterConsistency.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from "vitest";
+import {
+  checkCharacterConsistency,
+  CharacterConflict,
+} from "../characterConsistency";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+const chapter = (content: string) => ({ content });
+
+describe("checkCharacterConsistency – hair color detection", () => {
+  // ── 1. Existing patterns that must keep working ──────────────────────────
+
+  describe("original supported patterns", () => {
+    it("detects 'COLOR hair' (e.g. silver hair)", () => {
+      const result = checkCharacterConsistency([
+        chapter("Elena had silver hair that shimmered in the moonlight."),
+      ]);
+      expect(result).toHaveLength(0); // first mention, no conflict
+    });
+
+    it("raises conflict when same character's hair color changes", () => {
+      const result = checkCharacterConsistency([
+        chapter("Elena had silver hair."),
+        chapter("Elena had black hair."),
+      ]);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject<CharacterConflict>({
+        character: "Elena",
+        attribute: "hair color",
+        previous: "silver",
+        current: "black",
+      });
+    });
+
+    it("does NOT raise conflict when color stays the same across chapters", () => {
+      const result = checkCharacterConsistency([
+        chapter("Marcus had brown hair."),
+        chapter("Marcus still had brown hair."),
+      ]);
+      expect(result).toHaveLength(0);
+    });
+
+    it("tracks multiple characters independently", () => {
+      const result = checkCharacterConsistency([
+        chapter("Aria had blonde hair. Zack had black hair."),
+        chapter("Aria had red hair."), // conflict for Aria only
+      ]);
+      expect(result).toHaveLength(1);
+      expect(result[0].character).toBe("Aria");
+    });
+  });
+
+  // ── 2. New: adjective variants ───────────────────────────────────────────
+
+  describe("adjective / hyphenated variants", () => {
+    it("detects 'silvery hair'", () => {
+      const result = checkCharacterConsistency([
+        chapter("Lyra had silvery hair."),
+        chapter("Lyra had black hair."),
+      ]);
+      expect(result[0]).toMatchObject({ previous: "silvery", current: "black" });
+    });
+
+    it("detects 'silver-colored hair'", () => {
+      const result = checkCharacterConsistency([
+        chapter("Lyra had silver-colored hair."),
+        chapter("Lyra had red hair."),
+      ]);
+      expect(result[0]).toMatchObject({ previous: "silver", current: "red" });
+    });
+  });
+
+  // ── 3. New: possessive / pronoun patterns ────────────────────────────────
+
+  describe("pronoun / possessive patterns", () => {
+    it("detects 'his silver hair'", () => {
+      const result = checkCharacterConsistency([
+        chapter("Ran his fingers through his silver hair."),
+        chapter("Tom had brown hair."),
+      ]);
+      // 'his' is not a capitalized name — no character extracted, no conflict
+      expect(result).toHaveLength(0);
+    });
+
+    it("detects hair color when character name appears in same sentence", () => {
+      const result = checkCharacterConsistency([
+        chapter("Tom pushed his silver hair from his eyes."),
+        chapter("Tom had black hair."),
+      ]);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({ character: "Tom", previous: "silver", current: "black" });
+    });
+  });
+
+  // ── 4. New: 'hair was COLOR' order ──────────────────────────────────────
+
+  describe("hair COLOR order (hair mentioned before color)", () => {
+    it("detects 'hair was silver'", () => {
+      const result = checkCharacterConsistency([
+        chapter("Nina's hair was silver and braided tightly."),
+        chapter("Nina had brown hair."),
+      ]);
+      expect(result[0]).toMatchObject({ previous: "silver", current: "brown" });
+    });
+
+    it("detects 'hair is gray'", () => {
+      const result = checkCharacterConsistency([
+        chapter("Finn's hair is gray from years of worry."),
+        chapter("Finn had blonde hair as a young man."),
+      ]);
+      expect(result[0]).toMatchObject({ previous: "gray", current: "blonde" });
+    });
+  });
+
+  // ── 5. New: extra color keywords ────────────────────────────────────────
+
+  describe("new hair color keywords", () => {
+    const newColors = [
+      { color: "grey", sentence: "Gwen had grey hair." },
+      { color: "gray", sentence: "Gwen had gray hair." },
+      { color: "white", sentence: "Gwen had white hair." },
+      { color: "ginger", sentence: "Gwen had ginger hair." },
+      { color: "auburn", sentence: "Gwen had auburn hair." },
+      { color: "purple", sentence: "Gwen had purple hair." },
+      { color: "blue", sentence: "Gwen had blue hair." },
+      { color: "pink", sentence: "Gwen had pink hair." },
+    ];
+
+    newColors.forEach(({ color, sentence }) => {
+      it(`detects '${color} hair'`, () => {
+        const result = checkCharacterConsistency([
+          chapter(sentence),
+          chapter("Gwen had black hair."),
+        ]);
+        expect(result).toHaveLength(1);
+        expect(result[0].previous).toBe(color);
+      });
+    });
+  });
+
+  // ── 6. Edge cases ────────────────────────────────────────────────────────
+
+  describe("edge cases", () => {
+    it("returns empty array for chapters with no hair descriptions", () => {
+      const result = checkCharacterConsistency([
+        chapter("The sky was clear and the wind blew gently."),
+      ]);
+      expect(result).toHaveLength(0);
+    });
+
+    it("returns empty array for empty chapters array", () => {
+      expect(checkCharacterConsistency([])).toHaveLength(0);
+    });
+
+    it("returns empty array for chapters with empty content", () => {
+      expect(checkCharacterConsistency([chapter("")])).toHaveLength(0);
+    });
+
+    it("is case-insensitive for color names", () => {
+      const result = checkCharacterConsistency([
+        chapter("Mira had SILVER hair."),
+        chapter("Mira had Black Hair."),
+      ]);
+      expect(result[0]).toMatchObject({ previous: "silver", current: "black" });
+    });
+
+    it("does not raise false positive when sentence has no character name", () => {
+      const result = checkCharacterConsistency([
+        chapter("The woman with silver hair walked past."),
+      ]);
+      // "The" is not a valid character name (too short / article), no conflict
+      expect(result).toHaveLength(0);
+    });
+  });
+});

--- a/frontend/src/utils/characterConsistency.ts
+++ b/frontend/src/utils/characterConsistency.ts
@@ -5,26 +5,67 @@ export interface CharacterConflict {
   current: string;
 }
 
+// All supported hair color keywords (including fantasy colors)
+const HAIR_COLOR_SET = new Set([
+  "silver", "silvery", "black", "brown", "blonde", "red",
+  "grey", "gray", "white", "ginger", "auburn",
+  "purple", "blue", "pink", "golden", "dark", "light",
+]);
+
+// Pattern 1: "silver hair", "silvery hair", "silver-colored hair"
+const COLOR_THEN_HAIR =
+  /(silver|silvery|black|brown|blonde|red|grey|gray|white|ginger|auburn|purple|blue|pink|golden|dark|light)(?:-colored)?\s+hair/gi;
+
+// Pattern 2: "hair was silver", "hair is gray", "hair: auburn"
+// Captures the word after hair + optional verb, then we validate it's a color
+const HAIR_THEN_COLOR = /hair\s+(?:(?:was|is|were|color[:]?)\s+)?(\w+)/gi;
+
+/**
+ * Extracts hair color from a sentence, trying both
+ * "COLOR hair" and "hair COLOR" orderings.
+ */
+function extractHairColor(sentence: string): string | null {
+  COLOR_THEN_HAIR.lastIndex = 0;
+  HAIR_THEN_COLOR.lastIndex = 0;
+
+  const m1 = COLOR_THEN_HAIR.exec(sentence);
+  if (m1) return m1[1].toLowerCase();
+
+  const m2 = HAIR_THEN_COLOR.exec(sentence);
+  if (m2) {
+    const word = m2[1].toLowerCase();
+    if (HAIR_COLOR_SET.has(word)) return word;
+  }
+
+  return null;
+}
+
+/**
+ * Returns the first capitalized word in a sentence that
+ * looks like a character name (Title-case, length > 1).
+ */
+function extractCharacterName(sentence: string): string | null {
+  const match = sentence.match(/\b([A-Z][a-z]{1,})\b/);
+  return match ? match[1] : null;
+}
+
 export const checkCharacterConsistency = (
   chapters: { content: string }[]
 ): CharacterConflict[] => {
   const conflicts: CharacterConflict[] = [];
 
-  const characterMemory: Record<
-    string,
-    {
-      hair?: string;
-    }
-  > = {};
+  const characterMemory: Record<string, { hair?: string }> = {};
 
   chapters.forEach((chapter) => {
-    const matches = chapter.content.matchAll(
-      /([A-Z][a-z]+).*?(silver|black|brown|blonde|red)\s+hair/gi
-    );
+    // Split into sentences so name + color stay in the same context
+    const sentences = chapter.content.split(/(?<=[.!?])\s+|(?<=\n)/);
 
-    for (const match of matches) {
-      const character = match[1];
-      const hairColor = match[2].toLowerCase();
+    for (const sentence of sentences) {
+      const hairColor = extractHairColor(sentence);
+      if (!hairColor) continue;
+
+      const character = extractCharacterName(sentence);
+      if (!character) continue;
 
       if (!characterMemory[character]) {
         characterMemory[character] = {};

--- a/frontend/tsconfig.test.json
+++ b/frontend/tsconfig.test.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "types": ["vitest/globals"]
+  },
+  "include": ["src/**/__tests__/**", "src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: "jsdom",
+    include: ["src/**/__tests__/**/*.test.ts", "src/**/*.test.tsx"],
+  },
+});


### PR DESCRIPTION
## Before you open this PR
- **Issue:** Fixes #4106
- **Description:** The existing hair color detection regex in `characterConsistency.ts` only matched `COLOR hair` (e.g. `silver hair`) with 5 hardcoded colors, missing many natural writing patterns. This PR broadens the detection logic and adds a full test suite.

## Screenshot (when helpful)
```
 ✓ src/utils/__tests__/characterConsistency.test.ts (23 tests) 15ms
      ✓ detects 'COLOR hair' (e.g. silver hair)
      ✓ raises conflict when same character's hair color changes
      ✓ does NOT raise conflict when color stays the same across chapters
      ✓ tracks multiple characters independently
      ✓ detects 'silvery hair'
      ✓ detects 'silver-colored hair'
      ✓ detects 'his silver hair'
      ✓ detects hair color when character name appears in same sentence
      ✓ detects 'hair was silver'
      ✓ detects 'hair is gray'
      ✓ detects 'grey hair'
      ✓ detects 'gray hair'
      ✓ detects 'white hair'
      ✓ detects 'ginger hair'
      ✓ detects 'auburn hair'
      ✓ detects 'purple hair'
      ✓ detects 'blue hair'
      ✓ detects 'pink hair'
      ✓ returns empty array for chapters with no hair descriptions
      ✓ returns empty array for empty chapters array
      ✓ returns empty array for chapters with empty content
      ✓ is case-insensitive for color names
      ✓ does not raise false positive when sentence has no character name

 Tests  23 passed (23)
```

## What this PR does
The original regex `/([A-Z][a-z]+).*?(silver|black|brown|blonde|red)\s+hair/gi` had two problems:
1. Only 5 color keywords — missed grey, gray, white, ginger, auburn, purple, blue, pink
2. Only matched `COLOR hair` order — missed `"hair was silver"`, `"hair is gray"`, `"silvery hair"`, `"silver-colored hair"`

**Fix:** Replaced the single regex with two focused patterns:
- `COLOR_THEN_HAIR` — catches `silver hair`, `silvery hair`, `silver-colored hair`
- `HAIR_THEN_COLOR` — catches `hair was silver`, `hair is gray` by capturing the word after the verb and validating it against a `Set` of known colors

Also split chapter content by sentence before matching, so a character name and hair color are always evaluated in the same local context (avoids false positives across sentence boundaries).

Added `vitest.config.ts` and `tsconfig.test.json` so the test environment resolves Vitest types correctly in VS Code.

## Type of change
- [x] Bug fix
- [x] New feature

Bug fix (false-negative hair color detection) + new feature (broader color support including fantasy colors, new sentence patterns, test suite).

## Related issue
Fixes #4106

## More screenshots (optional)
N/A — pure utility/logic change with no UI impact.

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason. *(Vitest output above shows all 23 tests passing)*
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.