### PR TITLE
fix: render markdown bold and bullet lists in chat widget (#3861)

### DIFF
--- a/frontend/src/components/chat/Chat.tsx
+++ b/frontend/src/components/chat/Chat.tsx
@@ -101,6 +101,81 @@ const ChatComponent: React.FC = () => {
     setIsConfirming(false);
   };
 
+  // Simple Markdown parser for Bold, Bullet Lists, and Line Breaks.
+  // Messages were previously rendered as raw text ({msg.parts}), so any
+  // markdown syntax from the AI response (e.g. **bold**, "- item" lists)
+  // showed up as literal characters instead of being formatted.
+  const parseInlineBold = (line: string, keyPrefix: string) => {
+    const boldRegex = /\*\*(.*?)\*\*/g;
+    const parts: React.ReactNode[] = [];
+    let lastIndex = 0;
+    let match;
+
+    while ((match = boldRegex.exec(line)) !== null) {
+      if (match.index > lastIndex) {
+        parts.push(line.substring(lastIndex, match.index));
+      }
+      parts.push(
+        <strong key={`${keyPrefix}-${match.index}`}>{match[1]}</strong>
+      );
+      lastIndex = boldRegex.lastIndex;
+    }
+
+    if (lastIndex < line.length) {
+      parts.push(line.substring(lastIndex));
+    }
+
+    return parts.length > 0 ? parts : line;
+  };
+
+  // Matches a leading list marker: *, -, or + followed by a space
+  const listMarkerRegex = /^\s*[*\-+]\s+(.*)$/;
+
+  const renderMessageContent = (content: string) => {
+    const lines = content.split("\n");
+    const blocks: React.ReactNode[] = [];
+    let currentListItems: React.ReactNode[] = [];
+
+    const flushList = (key: string) => {
+      if (currentListItems.length > 0) {
+        blocks.push(
+          <ul key={`ul-${key}`} className="list-disc pl-4 space-y-0.5 mb-1">
+            {currentListItems}
+          </ul>
+        );
+        currentListItems = [];
+      }
+    };
+
+    lines.forEach((line, idx) => {
+      const listMatch = line.match(listMarkerRegex);
+
+      if (listMatch) {
+        currentListItems.push(
+          <li key={`li-${idx}`}>{parseInlineBold(listMatch[1], `li-${idx}`)}</li>
+        );
+        return;
+      }
+
+      flushList(String(idx));
+
+      if (line.trim().length === 0) {
+        blocks.push(<div key={`sp-${idx}`} className="h-1.5" />);
+        return;
+      }
+
+      blocks.push(
+        <p key={`p-${idx}`} className="mb-1 last:mb-0">
+          {parseInlineBold(line, `p-${idx}`)}
+        </p>
+      );
+    });
+
+    flushList("end");
+
+    return blocks;
+  };
+
   return (
     <div className="fixed bottom-6 right-6 z-[9999]">
       <AnimatePresence>
@@ -192,7 +267,7 @@ const ChatComponent: React.FC = () => {
                               : "bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-tl-none"
                           }`}
                         >
-                          {msg.parts}
+                          {renderMessageContent(msg.parts)}
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
## What this PR does
Chat.tsx rendered AI message content as raw text with `{msg.parts}`, so `**bold**` and `*`/`-` list markers showed up as literal characters in the chat widget instead of being rendered as formatted text.

Added `renderMessageContent` + `parseInlineBold` helpers to parse `**bold**` into `<strong>` and group `*`/`-`/`+` list lines into proper `<ul><li>` blocks. Swapped `{msg.parts}` for `{renderMessageContent(msg.parts)}`.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue
Fixes #3861

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [ ] I have tested my changes. *(Could not run the repo locally due to unrelated build-breaking bugs in main; verified the fix logically against the exact broken AI response captured from the live demo.)*
- [x] I have done a self-review of the code.