### PR TITLE
fix: remove duplicate stories from landing page feeds

### DIFF
--- a/frontend/src/components/home/community_spotlight/community_spotlight.component.tsx
+++ b/frontend/src/components/home/community_spotlight/community_spotlight.component.tsx
@@ -126,8 +126,9 @@ const CommunitySpotlightComponent = () => {
       </div>
     );
   }
-
-  const spotlightPosts = data?.posts ?? [];
+const spotlightPosts = Array.from(
+  new Map((data?.posts ?? []).map((post) => [post._id, post])).values(),
+);
 
   return (
     <section className="w-full box-border py-6 sm:py-10 text-slate-900 dark:text-slate-100">


### PR DESCRIPTION


## Screenshot (when helpful)

N/A - This change removes duplicate story entries from the Community Spotlight section. No UI layout changes were made.

## What this PR does

Fixes duplicate story entries being rendered in the Community Spotlight feed.

Changes made:

* Removed duplicate posts by filtering entries using their unique `_id`.
* Ensured only unique stories are displayed.
* Prevented repeated story cards from appearing on the landing page.

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

## Related issue

Fixes #1744

## More screenshots (optional)

N/A

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.
