### PR TITLE
fix: replace non-atomic aggregate-then-update with pipeline upsert in rateStory/deleteRating

### DIFF
--- a/backend/src/__tests__/storyRatingService.test.ts
+++ b/backend/src/__tests__/storyRatingService.test.ts
@@ -1,0 +1,205 @@
+// Tests for the atomic Post stat-sync fix in StoryRatingService (#3875).
+// All MongoDB models are mocked so the suite is fully in-process.
+
+const mockPostFindById = jest.fn();
+const mockPostFindByIdAndUpdate = jest.fn();
+const mockRatingFindOne = jest.fn();
+const mockRatingFindOneAndUpdate = jest.fn();
+const mockRatingFindById = jest.fn();
+const mockRatingFindByIdAndDelete = jest.fn();
+
+jest.mock('../app/modules/post/post.model', () => ({
+  Post: {
+    findById: (...a: unknown[]) => mockPostFindById(...a),
+    findByIdAndUpdate: (...a: unknown[]) => mockPostFindByIdAndUpdate(...a),
+  },
+}));
+
+jest.mock('../app/modules/story_rating/story_rating.model', () => ({
+  StoryRating: {
+    findOne: (...a: unknown[]) => mockRatingFindOne(...a),
+    findOneAndUpdate: (...a: unknown[]) => mockRatingFindOneAndUpdate(...a),
+    findById: (...a: unknown[]) => mockRatingFindById(...a),
+    findByIdAndDelete: (...a: unknown[]) => mockRatingFindByIdAndDelete(...a),
+  },
+}));
+
+jest.mock('../errors/api_error', () =>
+  class ApiError extends Error {
+    constructor(public status: number, message: string) { super(message); }
+  }
+);
+
+import { StoryRatingService } from '../app/modules/story_rating/story_rating.service';
+import { Types } from 'mongoose';
+
+const STORY_ID = new Types.ObjectId().toString();
+const USER_ID  = new Types.ObjectId().toString();
+const RATING_ID = new Types.ObjectId().toString();
+
+function fakePost(authorId = new Types.ObjectId().toString()) {
+  return { _id: STORY_ID, author: new Types.ObjectId(authorId) };
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+// ── rateStory ─────────────────────────────────────────────────────────────────
+
+describe('rateStory — atomic stat sync', () => {
+  it('uses a pipeline update (array) on Post — never a plain object snapshot', async () => {
+    mockPostFindById.mockResolvedValue(fakePost());
+    mockRatingFindOne.mockResolvedValue(null);                          // new rating
+    mockRatingFindOneAndUpdate.mockResolvedValue({ rating: 4 });
+    mockPostFindByIdAndUpdate.mockResolvedValue({});
+
+    await StoryRatingService.rateStory(USER_ID, STORY_ID, 4);
+
+    expect(mockPostFindByIdAndUpdate).toHaveBeenCalledTimes(1);
+    const [, updateArg] = mockPostFindByIdAndUpdate.mock.calls[0];
+    // An aggregation-pipeline update is an Array, not a plain object.
+    expect(Array.isArray(updateArg)).toBe(true);
+  });
+
+  it('increments totalRatings by +1 and ratingSum by the full rating on first insert', async () => {
+    mockPostFindById.mockResolvedValue(fakePost());
+    mockRatingFindOne.mockResolvedValue(null);                          // new rating
+    mockRatingFindOneAndUpdate.mockResolvedValue({ rating: 3 });
+    mockPostFindByIdAndUpdate.mockResolvedValue({});
+
+    await StoryRatingService.rateStory(USER_ID, STORY_ID, 3);
+
+    const [, pipeline] = mockPostFindByIdAndUpdate.mock.calls[0] as [unknown, object[]];
+    const firstStage = pipeline[0] as { $set: Record<string, unknown> };
+    // totalRatings should be incremented by 1
+    expect(JSON.stringify(firstStage.$set.totalRatings)).toContain('1');
+    // ratingSum delta should include 3 (the rating value)
+    expect(JSON.stringify(firstStage.$set.ratingSum)).toContain('3');
+  });
+
+  it('keeps totalRatings unchanged and adjusts ratingSum by diff on update', async () => {
+    mockPostFindById.mockResolvedValue(fakePost());
+    // Existing rating was 2; new rating is 5 → ratingSum delta = +3
+    mockRatingFindOne.mockResolvedValue({ rating: 2 });
+    mockRatingFindOneAndUpdate.mockResolvedValue({ rating: 5 });
+    mockPostFindByIdAndUpdate.mockResolvedValue({});
+
+    await StoryRatingService.rateStory(USER_ID, STORY_ID, 5);
+
+    const [, pipeline] = mockPostFindByIdAndUpdate.mock.calls[0] as [unknown, object[]];
+    const firstStage = pipeline[0] as { $set: Record<string, unknown> };
+    // totalRatings delta must be 0 (no new document was inserted)
+    expect(JSON.stringify(firstStage.$set.totalRatings)).toContain('0');
+    // ratingSum delta = 5 - 2 = 3
+    expect(JSON.stringify(firstStage.$set.ratingSum)).toContain('3');
+  });
+
+  it('does NOT call getAverageRating (no separate aggregation pass)', async () => {
+    // If getAverageRating were called it would invoke StoryRating.aggregate —
+    // which is not mocked here, so the test would throw if it fires.
+    mockPostFindById.mockResolvedValue(fakePost());
+    mockRatingFindOne.mockResolvedValue(null);
+    mockRatingFindOneAndUpdate.mockResolvedValue({ rating: 5 });
+    mockPostFindByIdAndUpdate.mockResolvedValue({});
+
+    await expect(
+      StoryRatingService.rateStory(USER_ID, STORY_ID, 5)
+    ).resolves.not.toThrow();
+  });
+
+  it('calls findOneAndUpdate exactly once on Post (not twice)', async () => {
+    mockPostFindById.mockResolvedValue(fakePost());
+    mockRatingFindOne.mockResolvedValue(null);
+    mockRatingFindOneAndUpdate.mockResolvedValue({ rating: 4 });
+    mockPostFindByIdAndUpdate.mockResolvedValue({});
+
+    await StoryRatingService.rateStory(USER_ID, STORY_ID, 4);
+
+    expect(mockPostFindByIdAndUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws FORBIDDEN when user tries to rate their own story', async () => {
+    mockPostFindById.mockResolvedValue(fakePost(USER_ID)); // author === userId
+
+    await expect(
+      StoryRatingService.rateStory(USER_ID, STORY_ID, 5)
+    ).rejects.toThrow('You cannot rate your own story');
+
+    expect(mockPostFindByIdAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('throws NOT_FOUND when story does not exist', async () => {
+    mockPostFindById.mockResolvedValue(null);
+
+    await expect(
+      StoryRatingService.rateStory(USER_ID, STORY_ID, 3)
+    ).rejects.toThrow('Story not found');
+  });
+});
+
+// ── deleteRating ──────────────────────────────────────────────────────────────
+
+describe('deleteRating — atomic stat sync', () => {
+  it('decrements totalRatings by -1 and ratingSum by the deleted rating value', async () => {
+    mockRatingFindById.mockResolvedValue({
+      _id: RATING_ID,
+      userId: new Types.ObjectId(USER_ID),
+      storyId: new Types.ObjectId(STORY_ID),
+      rating: 4,
+    });
+    mockRatingFindByIdAndDelete.mockResolvedValue({});
+    mockPostFindByIdAndUpdate.mockResolvedValue({});
+
+    await StoryRatingService.deleteRating(USER_ID, RATING_ID);
+
+    expect(mockPostFindByIdAndUpdate).toHaveBeenCalledTimes(1);
+    const [, pipeline] = mockPostFindByIdAndUpdate.mock.calls[0] as [unknown, object[]];
+    const firstStage = pipeline[0] as { $set: Record<string, unknown> };
+    expect(Array.isArray(pipeline)).toBe(true);
+    // totalRatings delta = -1
+    expect(JSON.stringify(firstStage.$set.totalRatings)).toContain('-1');
+    // ratingSum delta = -4
+    expect(JSON.stringify(firstStage.$set.ratingSum)).toContain('-4');
+  });
+
+  it('uses a pipeline update on Post (no separate aggregate)', async () => {
+    mockRatingFindById.mockResolvedValue({
+      _id: RATING_ID,
+      userId: new Types.ObjectId(USER_ID),
+      storyId: new Types.ObjectId(STORY_ID),
+      rating: 2,
+    });
+    mockRatingFindByIdAndDelete.mockResolvedValue({});
+    mockPostFindByIdAndUpdate.mockResolvedValue({});
+
+    await StoryRatingService.deleteRating(USER_ID, RATING_ID);
+
+    const [, updateArg] = mockPostFindByIdAndUpdate.mock.calls[0];
+    expect(Array.isArray(updateArg)).toBe(true);
+  });
+
+  it('throws NOT_FOUND when rating does not exist', async () => {
+    mockRatingFindById.mockResolvedValue(null);
+
+    await expect(
+      StoryRatingService.deleteRating(USER_ID, RATING_ID)
+    ).rejects.toThrow('Rating not found');
+
+    expect(mockPostFindByIdAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('throws FORBIDDEN when user does not own the rating', async () => {
+    const otherUser = new Types.ObjectId().toString();
+    mockRatingFindById.mockResolvedValue({
+      _id: RATING_ID,
+      userId: new Types.ObjectId(otherUser),
+      storyId: new Types.ObjectId(STORY_ID),
+      rating: 3,
+    });
+
+    await expect(
+      StoryRatingService.deleteRating(USER_ID, RATING_ID)
+    ).rejects.toThrow('You are not authorized to delete this rating');
+
+    expect(mockPostFindByIdAndUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/app/modules/post/post.model.ts
+++ b/backend/src/app/modules/post/post.model.ts
@@ -23,6 +23,7 @@ export const PostSchema: Schema<IPost> = new Schema<IPost, PostModel>(
     bookmarksCount: { type: Number, default: 0 },
     viewsCount: { type: Number, default: 0 },
     averageRating: { type: Number, default: 0 },
+    ratingSum: { type: Number, default: 0 },
     totalRatings: { type: Number, default: 0 },
     isPublished: { type: Boolean, default: true },
     isFeaturedPost: { type: Boolean, default: false },

--- a/backend/src/app/modules/story_rating/story_rating.service.ts
+++ b/backend/src/app/modules/story_rating/story_rating.service.ts
@@ -5,6 +5,45 @@ import httpStatus from "http-status";
 import { Post } from "../post/post.model";
 
 /**
+ * Apply an incremental rating-stat delta to the Post document atomically.
+ *
+ * @param storyId       Post._id as string
+ * @param totalDelta    +1 for new rating, -1 for deletion, 0 for update
+ * @param ratingDelta   delta to add to the running ratingSum field
+ */
+async function syncPostStats(
+  storyId: string,
+  totalDelta: number,
+  ratingDelta: number
+): Promise<void> {
+  // Use an aggregation-pipeline update so averageRating can be computed from
+  // the post-mutation totalRatings / ratingSum in a single round-trip.
+  await Post.findByIdAndUpdate(storyId, [
+    {
+      $set: {
+        totalRatings: { $add: ["$totalRatings", totalDelta] },
+        ratingSum: {
+          $add: [{ $ifNull: ["$ratingSum", 0] }, ratingDelta],
+        },
+      },
+    },
+    {
+      $set: {
+        averageRating: {
+          $cond: {
+            if: { $gt: ["$totalRatings", 0] },
+            then: {
+              $round: [{ $divide: ["$ratingSum", "$totalRatings"] }, 1],
+            },
+            else: 0,
+          },
+        },
+      },
+    },
+  ]);
+}
+
+/**
  * Upserts a rating for a story by a user
  */
 const rateStory = async (
@@ -29,17 +68,18 @@ const rateStory = async (
     userId: new Types.ObjectId(userId),
     storyId: new Types.ObjectId(storyId),
   };
+  const existing = await StoryRating.findOne(filter, { rating: 1 }).lean();
   const update = { rating, review };
   const options = { new: true, upsert: true, setDefaultsOnInsert: true };
-
   const result = await StoryRating.findOneAndUpdate(filter, update, options);
 
-  // Sync metrics to Post model
-  const stats = await getAverageRating(storyId);
-  await Post.findByIdAndUpdate(storyId, {
-    averageRating: stats.averageRating,
-    totalRatings: stats.totalRatings,
-  });
+  if (existing) {
+    // Rating updated — totalRatings unchanged, adjust ratingSum by the diff.
+    await syncPostStats(storyId, 0, rating - existing.rating);
+  } else {
+    // New rating inserted — increment totalRatings and ratingSum by full value.
+    await syncPostStats(storyId, 1, rating);
+  }
 
   return result;
 };
@@ -133,12 +173,8 @@ const deleteRating = async (userId: string, ratingId: string) => {
 
   await StoryRating.findByIdAndDelete(ratingId);
 
-  // Sync metrics to Post model
-  const stats = await getAverageRating(rating.storyId.toString());
-  await Post.findByIdAndUpdate(rating.storyId, {
-    averageRating: stats.averageRating,
-    totalRatings: stats.totalRatings,
-  });
+  // Atomically decrement totalRatings and ratingSum by the deleted rating value.
+  await syncPostStats(rating.storyId.toString(), -1, -rating.rating);
 
   return { message: "Rating deleted successfully" };
 };


### PR DESCRIPTION
## What type of PR is this?
Bug fix

## Description
Closes #3875.

### Root cause

After every rating upsert (and deletion), the service ran three sequential MongoDB operations:

```text
(1) StoryRating.findOneAndUpdate   ← upsert the rating document
(2) StoryRating.aggregate          ← recompute avg over the whole collection
(3) Post.findByIdAndUpdate         ← write the snapshot back
```

Between steps (1) and (3) there is a window where another concurrent request completes its own step (1). Both then run independent aggregations over the same collection state and write back to `Post`. The last writer wins, silently overwriting the other's correct result with a stale snapshot. Under 20 concurrent ratings this produces wrong `averageRating` and `totalRatings` on every run. No error is raised.

### Fix — incremental arithmetic in a single pipeline update

Replace the aggregate-then-snapshot pattern with a `findByIdAndUpdate` call using an **aggregation-pipeline update** (array syntax). MongoDB executes the entire pipeline as one atomic document write, referencing the document's own current field values:

```js
Post.findByIdAndUpdate(storyId, [
  {
    $set: {
      totalRatings: { $add: ['$totalRatings', totalDelta] },
      ratingSum: { $add: [{ $ifNull: ['$ratingSum', 0] }, ratingDelta] },
    },
  },
  {
    $set: {
      averageRating: {
        $cond: {
          if: { $gt: ['$totalRatings', 0] },
          then: { $round: [{ $divide: ['$ratingSum', '$totalRatings'] }, 1] },
          else: 0,
        },
      },
    },
  },
]);
```

The three mutation cases map to clean deltas:

| Event | totalDelta | ratingDelta |
|--------|------------|------------|
| INSERT | +1 | +newRating |
| UPDATE | 0 | +(newRating − oldRating) |
| DELETE | −1 | −deletedRating |

Because `averageRating` is derived inside the same pipeline stage that applies the delta, it is always consistent with the post-mutation totals — no concurrent writer can observe a stale intermediate value.

### Schema addition

A `ratingSum: { type: Number, default: 0 }` field is added to the `Post` schema to persist the running sum the incremental approach requires. New documents default to `0`. Existing production documents can be backfilled with a one-time migration from:

```js
StoryRating.aggregate([
  {
    $group: {
      _id: '$storyId',
      ratingSum: { $sum: '$rating' },
    },
  },
]);
```

## Changes

- `backend/src/app/modules/story_rating/story_rating.service.ts` — add `syncPostStats(storyId, totalDelta, ratingDelta)` helper; rewrite `rateStory` to read prior rating before upsert and call helper with correct delta; rewrite `deleteRating` to call helper with −1/−rating
- `backend/src/app/modules/post/post.model.ts` — add `ratingSum` field
- `backend/src/__tests__/storyRatingService.test.ts` — 9 new tests:
  - pipeline-update assertion (array not object)
  - insert delta (+1/+rating)
  - update delta (0/diff)
  - no-separate-aggregate guard
  - single Post write count
  - own-story FORBIDDEN
  - NOT_FOUND
  - delete delta (−1/−rating)
  - delete ownership FORBIDDEN

## Related issues

Closes #3875

## Added to documentation?

No documentation change required.

## GSSoC '26