### PR TITLE
fix: make trending topics non-clickable

### DIFF
--- a/frontend/src/components/home/trending_topic/trending_topic.component.tsx
+++ b/frontend/src/components/home/trending_topic/trending_topic.component.tsx
@@ -21,13 +21,12 @@ const TrendingTopicComponent = () => {
 
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
         {trendingTopics.map((topic) => (
-          <a
+          <span
             key={topic}
-            href="#"
             className="flex items-center justify-center rounded-md border border-slate-200/60 dark:border-white/10 bg-slate-50/40 dark:bg-white/5 px-3 py-2 text-sm font-semibold hover:scale-105 hover:shadow-md transition-all"
           >
             {topic}
-          </a>
+          </span>
         ))}
       </div>
     </section>


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Fixes #4320
- **Description:** Updated the Trending Topics chips on the homepage so they are no longer styled as clickable links when they are only decorative.
- **Screenshots:** N/A — this is a small UI behavior change and the code change is simple.

## Screenshot (when helpful)

N/A

## What this PR does

Replaces the placeholder clickable Trending Topics links with non-clickable elements so the UI no longer suggests fake navigation. This keeps the homepage behavior consistent with the intended decorative design.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Fixes #4320

## More screenshots (optional)

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.