### PR TITLE
feat: add /api/v1/usage/me endpoint (#3998)

### DIFF
--- a/backend/src/__tests__/usage.me.test.ts
+++ b/backend/src/__tests__/usage.me.test.ts
@@ -1,0 +1,80 @@
+import express from "express";
+import request from "supertest";
+
+jest.mock("../app/middleware/auth.middleware", () => ({
+  __esModule: true,
+  default:
+    () =>
+    (_req: any, _res: any, next: any) =>
+      next(),
+}));
+
+jest.mock("../app/modules/usage/usage.service", () => ({
+  UsageService: {
+    getMyUsage: jest.fn(),
+  },
+}));
+
+jest.mock("../app/middleware/token", () => ({
+  getToken: jest.fn().mockResolvedValue({
+    email: "test@example.com",
+  }),
+}));
+
+import { UsageRouter } from "../app/modules/usage/usage.router";
+import { UsageService } from "../app/modules/usage/usage.service";
+
+const app = express();
+
+app.use(express.json());
+app.use("/api/v1/usage", UsageRouter);
+
+describe("UsageRouter", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should load successfully", () => {
+    expect(UsageRouter).toBeDefined();
+  });
+
+  it("should return usage data", async () => {
+    (UsageService.getMyUsage as jest.Mock).mockResolvedValue({
+      plan: "pro",
+      billingPeriodStart: "2026-06-01T00:00:00.000Z",
+      billingPeriodEnd: "2026-06-30T23:59:59.999Z",
+      actions: {
+        story_generate: {
+          used: 12,
+          limit: 50,
+          remaining: 38,
+        },
+      },
+    });
+
+    const response = await request(app).get("/api/v1/usage/me");
+
+   expect(response.status).toBe(200);
+
+expect(response.body.success).toBe(true);
+
+expect(response.body).toHaveProperty("message");
+
+expect(response.body.data).toHaveProperty("actions");
+
+expect(response.body.data.actions).toHaveProperty("story_generate");
+
+expect(response.body.data.plan).toBe("pro");
+
+expect(response.body.data).toHaveProperty("billingPeriodStart");
+
+expect(response.body.data).toHaveProperty("billingPeriodEnd");
+
+expect(response.body.data.actions.story_generate.used).toBe(12);
+
+expect(response.body.data.actions.story_generate.limit).toBe(50);
+
+    
+  
+});
+});

--- a/backend/src/app/modules/usage/usage.controller.ts
+++ b/backend/src/app/modules/usage/usage.controller.ts
@@ -1,0 +1,32 @@
+import { Request, Response } from "express";
+import httpStatus from "http-status";
+
+import catchAsync from "../../../shared/catch_async";
+import sendResponse from "../../../shared/send_response";
+import { getToken } from "../../middleware/token";
+
+import { UsageService } from "./usage.service";
+
+
+const getMyUsage = catchAsync(
+  async (req: Request, res: Response) => {
+
+    const token = await getToken(req);
+
+    const result = await UsageService.getMyUsage(token);
+
+
+    sendResponse(res, {
+      statusCode: httpStatus.OK,
+      success: true,
+      message: "Usage fetched successfully!",
+      data: result,
+    });
+
+  }
+);
+
+
+export const UsageController = {
+  getMyUsage,
+};

--- a/backend/src/app/modules/usage/usage.router.ts
+++ b/backend/src/app/modules/usage/usage.router.ts
@@ -1,0 +1,18 @@
+import express from "express";
+
+import auth from "../../middleware/auth.middleware";
+
+import { UsageController } from "./usage.controller";
+
+
+const router = express.Router();
+
+
+router.get(
+  "/me",
+  auth(),
+  UsageController.getMyUsage
+);
+
+
+export const UsageRouter = router;

--- a/backend/src/app/modules/usage/usage.service.ts
+++ b/backend/src/app/modules/usage/usage.service.ts
@@ -1,0 +1,65 @@
+import { User } from "../user/user.model";
+import { REQUEST_LIMITS } from "../../../interfaces/ai_model_request_limit";
+import ApiError from "../../../errors/api_error";
+import httpStatus from "http-status";
+import { ITokenPayload } from "../../../interfaces/token";
+
+const getMyUsage = async (token: ITokenPayload) => {
+  const user = await User.findOne({
+    email: token.email,
+  });
+
+  if (!user) {
+    throw new ApiError(
+      httpStatus.BAD_REQUEST,
+      "User not found!"
+    );
+  }
+
+  let limit = REQUEST_LIMITS.free;
+
+  if (user.subscriptionType === "pro") {
+    limit = REQUEST_LIMITS.pro;
+  }
+
+  if (user.subscriptionType === "premium") {
+    limit = REQUEST_LIMITS.premium;
+  }
+
+  const billingPeriodStart = new Date(
+    new Date().getFullYear(),
+    new Date().getMonth(),
+    1
+  );
+
+  const billingPeriodEnd = new Date(
+    new Date().getFullYear(),
+    new Date().getMonth() + 1,
+    0,
+    23,
+    59,
+    59,
+    999
+  );
+
+  return {
+    plan: user.subscriptionType,
+
+    billingPeriodStart,
+
+    billingPeriodEnd,
+
+    actions: {
+      story_generate: {
+        used: user.requestsThisMonth,
+        limit,
+        remaining: limit - user.requestsThisMonth,
+      },
+    },
+  };
+};
+
+
+export const UsageService = {
+  getMyUsage,
+};

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -28,7 +28,9 @@ import { PlotHoleRouter } from "../app/modules/plot_hole_detector/plot_hole.rout
 import { StoryRatingRouter } from "../app/modules/story_rating/story_rating.router";
 import PromptAnalysisRouter from "../app/modules/prompt_analysis/prompt_analysis.router";
 import { StoryConsistencyRouter } from "../app/modules/story_consistency/story_consistency.router";
+import { UsageRouter } from "../app/modules/usage/usage.router";
 import characterRouter from "./character.routes";
+
 
 const router = express.Router();
 
@@ -104,6 +106,10 @@ const modules = [
   {
     path: "/characters",
     router: characterRouter,
+  },
+  {
+    path: "/usage",
+    router: UsageRouter,
   },
 ];
 


### PR DESCRIPTION
## Screenshot (when helpful)

N/A - Backend API feature, no UI changes.


## What this PR does

This PR adds the `GET /api/v1/usage/me` endpoint to provide authenticated users with real-time quota and billing usage information.

The endpoint returns:
- Current subscription plan
- Billing period start and end dates
- Per-action usage counts
- Per-action quota limits

This allows the frontend to display usage indicators, remaining quota, upgrade prompts, and improves billing transparency.

The endpoint is protected with authentication and only returns usage information for the logged-in user.


## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update


## Related issue

Closes #3998


## More screenshots (optional)

N/A


## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.