### PR TITLE
fix: remove duplicate imports and unused import from App.tsx

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,9 +3,7 @@ import { createBrowserRouter, Outlet, RouterProvider, Navigate } from "react-rou
 
 import { USER_ROLE } from "./constants/role";
 
-import React from "react";
-import { createBrowserRouter, Navigate, Outlet, RouterProvider } from "react-router-dom";
-import ScrollToTop from "./components/ScrollToTop";
+
 import StoryInspirationWrapper from "./components/StoryInspirationWrapper";
 import WritingAssistantComponent from "./components/writing-assistant/writing_assistant.component";
 import CollabHome from "./components/collab/CollabHome";
@@ -24,8 +22,7 @@ import ScrollToTop from "./components/ScrollToTop";
 import PageTitleUpdater from "./components/PageTitleUpdater";
 import MagicCursorComponent from "./components/magic-cursor/magic_cursor.component";
 import ThemeSwitcher from "./components/theme-switcher/ThemeSwitcher";
-import HeroSectionComponent from "./components/hero/hero_section.component";
-import HomeComponent from "./components/home/home.component";
+
 
 import NotFoundComponent from "./components/not-found.component";
 import Leaderboard from "./pages/Leaderboard";
@@ -39,11 +36,9 @@ import PublishedStoriesComponent from "./components/dashboard/posts/published_st
 import ReportBug from "./components/report-bug/ReportBug";
 import ResourceDetailComponent from "./components/community/resource_detail.component";
 import ResourcesListComponent from "./components/community/resources_list.component";
-import ScrollToTop from "./components/ScrollToTop";
-import ScrollToTopButton from "./components/ScrollToTopButton";
+
 import SettingComponent from "./components/dashboard/settings/settings.component";
-import SignUpComponent from "./components/signup/signup.component";
-import SimpleProtectedRoute from "./components/ProtectedRoute";
+
 import StoriesComponent from "./components/stories/stories.component";
 import ChatPage from "./components/chat/ChatPage";
 


### PR DESCRIPTION
## Overview

This PR cleans up duplicate and unused imports in `frontend/src/App.tsx` to improve code readability and maintainability.

### Description

- Removed duplicate `React` import.
- Removed duplicate `react-router-dom` import.
- Removed duplicate component imports:
  - ScrollToTop
  - HeroSectionComponent
  - HomeComponent
  - SignUpComponent
  - ScrollToTopButton
- Removed the unused `SimpleProtectedRoute` import.

### Core Motivation

The file contained multiple duplicate imports and an unused import, increasing clutter and making maintenance more difficult. This cleanup keeps the import section concise without changing application behavior.

### Proposed Changes

1. Eliminated duplicate imports.
2. Removed the unused `SimpleProtectedRoute` import.
3. Preserved existing functionality and routing logic.

### Related Issue

Closes #4362

## Type of Change

- [x] Code cleanup
- [x] Refactoring (non-functional change)
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Checklist

- [x] Code follows the project's style.
- [x] No functional changes introduced.
- [x] Existing behavior preserved.