### PR TITLE
test : added unit tests for useScrollDirection hook

### DIFF
--- a/frontend/src/hooks/__tests__/useScrollDirection.test.tsx
+++ b/frontend/src/hooks/__tests__/useScrollDirection.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useScrollDirection } from "../useScrollDirection";
+
+describe("useScrollDirection", () => {
+  afterEach(() => {
+    // Reset scrollY to 0 for next test
+    window.scrollY = 0;
+  });
+
+  it("returns isAtTop=true when scrollY is 0 (initial state)", () => {
+    window.scrollY = 0;
+    const { result } = renderHook(() => useScrollDirection());
+    expect(result.current.isAtTop).toBe(true);
+  });
+
+  it("returns isAtTop=false when scrollY >= 10", () => {
+    window.scrollY = 0;
+    const { result } = renderHook(() => useScrollDirection());
+    // Scroll down to 50 and fire scroll event
+    window.scrollY = 50;
+    act(() => {
+      window.dispatchEvent(new Event("scroll"));
+    });
+    expect(result.current.isAtTop).toBe(false);
+  });
+
+  it("returns scrollDirection='up' initially", () => {
+    window.scrollY = 0;
+    const { result } = renderHook(() => useScrollDirection());
+    expect(result.current.scrollDirection).toBe("up");
+  });
+
+  it("returns scrollDirection='down' when scrollY increases", () => {
+    window.scrollY = 0;
+    const { result } = renderHook(() => useScrollDirection());
+    window.scrollY = 100;
+    act(() => {
+      window.dispatchEvent(new Event("scroll"));
+    });
+    expect(result.current.scrollDirection).toBe("down");
+  });
+
+  it("returns scrollDirection='up' when scrollY decreases", () => {
+    window.scrollY = 0;
+    const { result } = renderHook(() => useScrollDirection());
+    // First scroll down
+    window.scrollY = 200;
+    act(() => {
+      window.dispatchEvent(new Event("scroll"));
+    });
+    expect(result.current.scrollDirection).toBe("down");
+    // Then scroll up
+    window.scrollY = 50;
+    act(() => {
+      window.dispatchEvent(new Event("scroll"));
+    });
+    expect(result.current.scrollDirection).toBe("up");
+  });
+});


### PR DESCRIPTION
Closes #4394.

Summary of What Has Been Done:
Added 5 vitest tests for the useScrollDirection hook covering initial state, scroll down detection, scroll up detection, and isAtTop toggle. Tests use jsdom environment with proper scroll event simulation.

Changes Made:
- frontend/src/hooks/__tests__/useScrollDirection.test.tsx: new test file with 5 test cases

Impact it Made:
- Increases test coverage for a React hook
- 5/5 tests passing via vitest

Note: Please assign this PR to the `tmdeveloper007` account.