### PR TITLE
fix: remove duplicate JWT_REFRESH_EXPIRES_IN in .env.example

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -15,7 +15,6 @@ SALT_ROUNDS=10
 JWT_SECRET=replace_with_access_token_secret
 JWT_REFRESH_SECRET=replace_with_refresh_token_secret
 JWT_EXPIRES_IN=15m
-JWT_REFRESH_EXPIRES_IN=30d
 JWT_REFRESH_EXPIRES_IN=120d
 DEFAULT_ADMIN_PASSWORD=replace_with_default_admin_password
 ADMIN_EMAIL=your-admin@example.com


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Open or link a related issue when there is one (`Closes #123`, `Fixes #45`, or write **None** under Related issue below).
- **Description:** Fill in **What this PR does** so a reviewer can understand the change without your local context.
- **Screenshots:** Add screenshots or a short recording when they help (UI changes, confusing flows, or non-code proof). If not needed, say so in the checklist.

## Screenshot (when helpful)

N/A — one-line deletion in a config file, no UI changes.



## What this PR does

Removes the duplicate `JWT_REFRESH_EXPIRES_IN` variable in 
`backend/.env.example` that had two conflicting values (30d and 120d). 
Kept 120d and removed the duplicate 30d entry.




## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

## Related issue
Closes #2689


## More screenshots (optional)

<!-- Extra before/after images, flows, or recordings for reviewers. -->



## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
