### PR TITLE
fix: persist OpenAI's temporary image url server-side (#4284)

### DIFF
--- a/backend/src/utils/__tests__/storyboard_image_generation.test.ts
+++ b/backend/src/utils/__tests__/storyboard_image_generation.test.ts
@@ -1,0 +1,141 @@
+describe("generateStoryboardImage", () => {
+  const OLD_ENV = process.env;
+  const ORIGINAL_FETCH = global.fetch;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV };
+    process.env.IMAGE_GENERATION_PROVIDER = "openai";
+    process.env.IMAGE_GENERATION_API_KEY = "test-api-key";
+  });
+
+  afterEach(() => {
+    global.fetch = ORIGINAL_FETCH;
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  const mockGenerationResponse = (body: unknown) => {
+    return {
+      ok: true,
+      json: async () => body,
+    } as Response;
+  };
+
+  const mockImageDownloadResponse = (
+    bytes: Uint8Array,
+    contentType = "image/png"
+  ) => {
+    return {
+      ok: true,
+      headers: { get: () => contentType },
+      arrayBuffer: async () => bytes.buffer,
+    } as unknown as Response;
+  };
+
+  it("fetches the temporary OpenAI url server-side and returns a persisted data URI instead of the raw url (#4284)", async () => {
+    const temporaryUrl = "https://oaidalleapiprodscus.blob.core.windows.net/temp/image.png";
+    const imageBytes = new Uint8Array([1, 2, 3, 4]);
+
+    const fetchMock = jest
+      .fn()
+      // 1st call: the image generation request
+      .mockResolvedValueOnce(
+        mockGenerationResponse({ data: [{ url: temporaryUrl }] })
+      )
+      // 2nd call: re-fetching the temporary url's bytes
+      .mockResolvedValueOnce(mockImageDownloadResponse(imageBytes));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { generateStoryboardImage } = await import(
+      "../storyboard_image_generation"
+    );
+
+    const result = await generateStoryboardImage("a cat in a hat");
+
+    // The raw temporary url must never be returned/persisted as-is.
+    expect(result).not.toBe(temporaryUrl);
+    expect(result).not.toContain(temporaryUrl);
+
+    // It should be re-persisted as a self-contained base64 data URI.
+    expect(result).toBe(
+      `data:image/png;base64,${Buffer.from(imageBytes).toString("base64")}`
+    );
+
+    // Confirms we actually went back out to the temporary url to fetch bytes.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1][0]).toBe(temporaryUrl);
+  });
+
+  it("returns null (mapped to imageStatus: failed by the caller) when the temporary url can no longer be fetched", async () => {
+    const temporaryUrl = "https://oaidalleapiprodscus.blob.core.windows.net/temp/expired.png";
+
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(
+        mockGenerationResponse({ data: [{ url: temporaryUrl }] })
+      )
+      // Simulates the url having already expired by the time we re-fetch it.
+      .mockResolvedValueOnce({ ok: false } as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { generateStoryboardImage } = await import(
+      "../storyboard_image_generation"
+    );
+
+    const result = await generateStoryboardImage("a cat in a hat");
+
+    expect(result).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("leaves the b64_json branch untouched, since it never returns a temporary link", async () => {
+    const fetchMock = jest.fn().mockResolvedValueOnce(
+      mockGenerationResponse({ data: [{ b64_json: "aGVsbG8=" }] })
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { generateStoryboardImage } = await import(
+      "../storyboard_image_generation"
+    );
+
+    const result = await generateStoryboardImage("a cat in a hat");
+
+    expect(result).toBe("data:image/png;base64,aGVsbG8=");
+    // Only the generation call — no extra fetch, since there's no url to persist.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null when neither url nor b64_json is present", async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(mockGenerationResponse({ data: [{}] }));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { generateStoryboardImage } = await import(
+      "../storyboard_image_generation"
+    );
+
+    const result = await generateStoryboardImage("a cat in a hat");
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null without calling fetch when no provider is configured", async () => {
+    process.env.IMAGE_GENERATION_PROVIDER = "";
+
+    const fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { generateStoryboardImage } = await import(
+      "../storyboard_image_generation"
+    );
+
+    const result = await generateStoryboardImage("a cat in a hat");
+
+    expect(result).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/utils/storyboard_image_generation.ts
+++ b/backend/src/utils/storyboard_image_generation.ts
@@ -2,6 +2,7 @@ import config from "../config";
 
 const OPENAI_IMAGE_GENERATION_URL = "https://api.openai.com/v1/images/generations";
 const IMAGE_REQUEST_TIMEOUT_MS = 45000;
+const IMAGE_DOWNLOAD_TIMEOUT_MS = 20000;
 
 type OpenAIImageResponse = {
   data?: Array<{
@@ -20,6 +21,49 @@ const getApiKey = (): string => {
     config.openai_key ||
     ""
   ).trim();
+};
+const persistTemporaryImageUrl = async (
+  temporaryUrl: string,
+  signal?: AbortSignal
+): Promise<string | null> => {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(
+    () => controller.abort(),
+    IMAGE_DOWNLOAD_TIMEOUT_MS
+  );
+
+  let abortHandler: (() => void) | null = null;
+  if (signal) {
+    if (signal.aborted) {
+      clearTimeout(timeoutId);
+      controller.abort();
+      return null;
+    }
+    abortHandler = () => {
+      controller.abort();
+    };
+    signal.addEventListener("abort", abortHandler);
+  }
+
+  try {
+    const response = await fetch(temporaryUrl, { signal: controller.signal });
+    if (!response.ok) {
+      return null;
+    }
+
+    const contentType = response.headers.get("content-type") || "image/png";
+    const arrayBuffer = await response.arrayBuffer();
+    const base64 = Buffer.from(arrayBuffer).toString("base64");
+
+    return `data:${contentType};base64,${base64}`;
+  } catch (error) {
+    return null;
+  } finally {
+    clearTimeout(timeoutId);
+    if (signal && abortHandler) {
+      signal.removeEventListener("abort", abortHandler);
+    }
+  }
 };
 
 const generateWithOpenAI = async (
@@ -73,8 +117,11 @@ const generateWithOpenAI = async (
 
     const data = (await response.json()) as OpenAIImageResponse;
     const image = data.data?.[0];
+
     if (image?.url) {
-      return image.url;
+      // Fetch and re-persist immediately — OpenAI's `url` is temporary by
+      // design and will eventually stop working if saved as-is (#4284).
+      return await persistTemporaryImageUrl(image.url, signal);
     }
 
     if (image?.b64_json) {
@@ -108,4 +155,3 @@ export const generateStoryboardImage = async (
 
   return null;
 };
-


### PR DESCRIPTION
## Before you open this PR
- **Issue:** Fixes #4284
- **Description:** OpenAI's `url` response is a temporary, expiring link. This PR fetches the image bytes server-side immediately after generation and converts them into a persistent `data:` URI, so storyboard images never silently break after the link expires.

## Screenshot (when helpful)
All 5 unit tests passing locally:

```
PASS src/utils/__tests__/storyboard_image_generation.test.ts
  generateStoryboardImage
    ✓ fetches the temporary OpenAI url server-side and returns a persisted data URI instead of the raw url (#4284)
    ✓ returns null (mapped to imageStatus: failed by the caller) when the temporary url can no longer be fetched
    ✓ leaves the b64_json branch untouched, since it never returns a temporary link
    ✓ returns null when neither url nor b64_json is present
    ✓ returns null without calling fetch when no provider is configured

Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
```

## What this PR does
OpenAI's `url` response field is a short-lived, OpenAI-hosted CDN link. Previously it was saved as-is into `imageUrl`, so storyboard images silently broke once the link expired with no recovery path.

This PR adds a `persistTemporaryImageUrl` helper in `storyboard_image_generation.ts` that fetches the image bytes from the temporary URL immediately after generation while the link is still valid  and converts them into a self-contained `data:` base64 URI. This mirrors how the existing `b64_json` branch already behaves and was never affected by this bug. No schema or caller changes are needed since `imageUrl` already accepts data URIs.

If the re-fetch fails (e.g. URL already expired), the function returns `null`, which the existing caller in `story_visualizer.service.ts` already maps to `imageStatus: "failed"`  so no scene is ever left holding a broken URL.

## Type of change
- [x] Bug fix

## Related issue
Fixes #4284

## More screenshots (optional)
N/A : this is a backend-only bug fix with no UI changes; test output above serves as proof.

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.