### PR TITLE
test: add unit tests for escapeRegex utility (#4450)

### DIFF
--- a/backend/src/__tests__/regex.util.test.ts
+++ b/backend/src/__tests__/regex.util.test.ts
@@ -69,13 +69,39 @@ describe("escapeRegex", () => {
   it("escapes all metacharacters in a combined string", () => {
     const result = escapeRegex("[a-z]{1,3}(foo|bar)+?bar$");
     expect(result).toBe(
-      "\\[a\\-z\\]\\{1\\,3\\}\\(foo\\|bar\\)\\+?bar\\$"
+      "\\[a\\-z\\]\\{1\\,3\\}\\(foo\\|bar\\)\\+\\?bar\\$"
     );
   });
 
   it("output can be safely used as pattern in RegExp constructor", () => {
     const userInput = "users[id]: (test|example)*";
     const escaped = escapeRegex(userInput);
+    expect(() => new RegExp(escaped)).not.toThrow();
+  });
+
+  it("preserves whitespace and alphanumeric characters unchanged", () => {
+    expect(escapeRegex("plain text 123")).toBe("plain text 123");
+    expect(escapeRegex("hello world 2024")).toBe("hello world 2024");
+    expect(escapeRegex("  leading and trailing  ")).toBe("  leading and trailing  ");
+  });
+
+  it("is idempotent — already-escaped strings remain unchanged on second call", () => {
+    const first = escapeRegex("user.name[0]");
+    const second = escapeRegex(first);
+    expect(second).toBe(first);
+  });
+
+  it("handles MongoDB query-like field paths containing dots", () => {
+    const input = "user.email";
+    const escaped = escapeRegex(input);
+    expect(escaped).toBe("user\\.email");
+    expect(() => new RegExp(escaped)).not.toThrow();
+  });
+
+  it("handles MongoDB query-like strings with combined special characters", () => {
+    const input = "users.[0].name#tag";
+    const escaped = escapeRegex(input);
+    expect(escaped).toBe("users\\.\\[0\\]\\.name\\#tag");
     expect(() => new RegExp(escaped)).not.toThrow();
   });
 


### PR DESCRIPTION
## Summary

Adds unit tests for the \escapeRegex\ utility function at \ackend/src/utils/regex.util.ts\.

### Changes
- **Fix** combined string test: \?\ after \+\ was not escaped in the expected value (existing test had an incorrect expectation)
- **Add** test for whitespace and alphanumeric character preservation
- **Add** idempotency test — ensures already-escaped strings remain unchanged on second call
- **Add** MongoDB query-like field path test (\user.email\)
- **Add** MongoDB query-like combined characters test (\users.[0].name#tag\)

### Coverage
| Requirement | Status |
|-------------|--------|
| Normal strings returned unchanged | ✓ (existing) |
| All 12 special chars escaped individually | ✓ (existing, 12 tests) |
| Combined special chars | ✓ (fixed) |
| Whitespace/alphanumeric preserved | ✓ (new) |
| Empty string | ✓ (existing) |
| Idempotency (double-escape safe) | ✓ (new) |
| MongoDB query-like strings | ✓ (new, 2 tests) |

Closes #4450