### PR TITLE
fix: remove unused html2canvas import

### DIFF
--- a/frontend/src/components/cards/StoryTradingCard.tsx
+++ b/frontend/src/components/cards/StoryTradingCard.tsx
@@ -1,5 +1,4 @@
 import React, { useMemo, useRef, useState, useEffect } from "react";
-import html2canvas from "html2canvas";
 import toast from "react-hot-toast";
 import type { IStories } from "../stories/stories.view.component";
 import { getWordCount } from "../stories/stories.utils";


### PR DESCRIPTION
## What this PR does

* Removes the unused `html2canvas` import from `StoryTradingCard.tsx`.
* Resolves the `@typescript-eslint/no-unused-vars` ESLint error caused by the unused import.
* Improves code cleanliness by removing an unnecessary dependency import without changing component behavior.

---

## Type of change

* [x] Bug fix
* [ ] New feature
* [x] Code refactor
* [ ] Documentation update

---

## Related issue

Fixes #4473

---


## Checklist

* [x] I have added screenshots or noted **N/A** because this is a non-UI change.
* [x] I have filled in the related issue number.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.
