### PR TITLE
fix : handled empty path in handle_zod_error utility

### DIFF
--- a/backend/src/errors/handle_zod_error.ts
+++ b/backend/src/errors/handle_zod_error.ts
@@ -6,7 +6,7 @@ const handleZodError = (err: ZodError) => {
   const errors: IGenericErrorMessage[] = err.issues.map(
     (issue: ZodIssue): IGenericErrorMessage => {
       return {
-        path: issue.path[issue.path.length - 1],
+        path: issue.path.length > 0 ? issue.path[issue.path.length - 1] : "",
         message: issue.message,
       };
     }


### PR DESCRIPTION
Closes #4511.

Summary of What Has Been Done:
Fixed a bug in backend/src/errors/handle_zod_error.ts where issue.path[issue.path.length - 1] would return undefined when the Zod issue has an empty path array. The fix adds a guard to default to an empty string in that case.

Changes Made:
- backend/src/errors/handle_zod_error.ts: Added empty-path guard in path extraction (1 line change)

Impact it Made:
- Fixes incorrect API error response shape when Zod validation errors have empty paths
- Prevents undefined values appearing in the error path field

Note: Please assign this PR to the tmdeveloper007 account.