### PR TITLE
fix(backend): patch IDOR vulnerability in remixStory and translateStory

### DIFF
--- a/backend/src/app/modules/post/post.service.ts
+++ b/backend/src/app/modules/post/post.service.ts
@@ -529,9 +529,13 @@ const remixStory = async (postId: string, prompt: string, token: ITokenPayload) 
     throw new ApiError(httpStatus.BAD_REQUEST, "User not found!");
   }
 
-  const originalPost = await Post.findOne({ _id: postId, isDeleted: { $ne: true } });
+  const originalPost = await Post.findOne({
+    _id: postId,
+    isDeleted: { $ne: true },
+    $or: [{ isPublished: true }, { author: user._id }],
+  });
   if (!originalPost) {
-    throw new ApiError(httpStatus.NOT_FOUND, "Original story post not found!");
+    throw new ApiError(httpStatus.NOT_FOUND, "Original story post not found or access denied!");
   }
 
   const remixedContent = `[AI Remixed Version based on prompt: "${safePrompt}"]\n\n${originalPost.content}`;
@@ -567,9 +571,13 @@ const translateStory = async (postId: string, language: string, token: ITokenPay
     throw new ApiError(httpStatus.BAD_REQUEST, "User not found!");
   }
 
-  const originalPost = await Post.findOne({ _id: postId, isDeleted: { $ne: true } });
+  const originalPost = await Post.findOne({
+    _id: postId,
+    isDeleted: { $ne: true },
+    $or: [{ isPublished: true }, { author: user._id }],
+  });
   if (!originalPost) {
-    throw new ApiError(httpStatus.NOT_FOUND, "Original story post not found!");
+    throw new ApiError(httpStatus.NOT_FOUND, "Original story post not found or access denied!");
   }
 
   const translatedContent = `[Translated to ${safeLanguage}]\n\n${originalPost.content}`;


### PR DESCRIPTION
Fix: #4520 under gssoc'26

**Description:**

**What this PR does:**
This PR patches a critical Insecure Direct Object Reference (IDOR) vulnerability in the `remixStory` and `translateStory` backend services that allowed any authenticated user to read the contents of another user's unpublished, private drafts.

**Why it's needed:**
Previously, when a user attempted to remix or translate a story via `POST /api/v1/posts/remix` or `/api/v1/posts/translate`, the `PostService` fetched the original post using the provided `postId` but failed to verify authorization or visibility status (`isPublished`). 
```typescript
const originalPost = await Post.findOne({ _id: postId, isDeleted: { $ne: true } });
```
Because the remixed/translated copy is subsequently saved under the requester's account with the original content embedded, an attacker could supply the `postId` of another user's private draft. The server would blindly duplicate the private content into the attacker's account, resulting in a full data leak of private user data.

**Changes made:**
- Updated the `findOne` queries in both `remixStory` and `translateStory` within `backend/src/app/modules/post/post.service.ts` to include a secure `$or` authorization check:
```typescript
$or: [{ isPublished: true }, { author: user._id }]
```
- This ensures that a story can only be fetched for remixing/translation if it is either publicly published or if the requesting user is the actual author of the private draft.
- Added a more explicit error message (`"Original story post not found or access denied!"`) to safely handle denied requests without leaking existence metadata.

**Checklist:**
- [x] I have read the contribution guidelines.
- [x] I have tested the changes locally.
- [x] My code follows the project's style guidelines.

@ronisarkarexe please check it