### PR TITLE
fix(perf): throttle scroll event in ScrollToTopButton to resolve render jank

### DIFF
--- a/frontend/src/components/ScrollToTopButton.tsx
+++ b/frontend/src/components/ScrollToTopButton.tsx
@@ -4,8 +4,17 @@ const ScrollToTopButton = () => {
   const [isVisible, setIsVisible] = useState(false);
 
   useEffect(() => {
+    let ticking = false;
+
     const handleScroll = () => {
-      setIsVisible(window.scrollY > 200);
+      // Only execute if a frame isn't already waiting to be painted
+      if (!ticking) {
+        window.requestAnimationFrame(() => {
+          setIsVisible(window.scrollY > 200);
+          ticking = false;
+        });
+        ticking = true;
+      }
     };
 
     window.addEventListener("scroll", handleScroll, { passive: true });


### PR DESCRIPTION
## Description
This PR optimizes the scroll event listener in ScrollToTopButton.tsx to prevent excessive React state updates and main-thread jank during rapid scrolling.

## What this PR does
Replaced the unthrottled state update with requestAnimationFrame throttle lock. This ensures the scroll handler only executes in sync with the browser's native repaint cycle (max ~60fps) drastically reducing function executions & entirely eliminating the scroll jank

## Changes Made
1. Refactored the useEffect hook in ScrollToTopButton.tsx
2. Implemented a ticking boolean flag alongside window.requestAnimationFrame.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue
Closes: #4365 

## Checklist
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
