### PR TITLE
fix : return 400 instead of 500 for mongoose validation errors

### DIFF
--- a/backend/src/errors/handle_validation_error.ts
+++ b/backend/src/errors/handle_validation_error.ts
@@ -13,7 +13,7 @@ const handleValidationError = (
       };
     }
   );
-  const statusCode = 500;
+  const statusCode = 400;
   return {
     statusCode,
     message: "Validation Error",


### PR DESCRIPTION
Closes #4568.

Summary of What Has Been Done:
Changed the statusCode returned by handle_validation_error from 500 (Internal Server Error) to 400 (Bad Request). Mongoose validation errors are caused by invalid client input and should return 400, not 500.

Changes Made:
- backend/src/errors/handle_validation_error.ts: Changed const statusCode = 500 to const statusCode = 400.

Impact it Made:
- Correct HTTP semantics: clients can now distinguish between bad input (HTTP 400) and server faults (HTTP 500).
- Matches the status code used by handle_zod_error and handle_duplicate_error for consistency.
- Improves API consumer experience with actionable error codes.

Note: Please assign this PR to the `tmdeveloper007` account.