### PR TITLE
fix : return 400 instead of 500 for mongoose validation errors

### DIFF
--- a/backend/src/errors/handle_validation_error.ts
+++ b/backend/src/errors/handle_validation_error.ts
@@ -13,7 +13,7 @@ const handleValidationError = (
       };
     }
   );
-  const statusCode = 500;
+  const statusCode = 400;
   return {
     statusCode,
     message: "Validation Error",


### PR DESCRIPTION
Closes #4568.

Summary of What Has Been Done:
Changed the statusCode returned by handle_validation_error from 500 to 400.

Changes Made:
- backend/src/errors/handle_validation_error.ts: 1-line status code fix

Impact it Made:
- Correct HTTP semantics for validation errors.

Note: Please assign this PR to the `tmdeveloper007` account.