### PR TITLE
fix: replace explicit any usage in StoryTradingCard

### DIFF
--- a/frontend/src/components/cards/StoryTradingCard.tsx
+++ b/frontend/src/components/cards/StoryTradingCard.tsx
@@ -103,7 +103,7 @@ const getKeyQuote = (content: string) => {
 };
 
 const getGenreLabel = (story: IStories) =>
-  cleanText((story as any).genre || story.tag || "Story").replace(/^[^\w]+/, "") ||
+  cleanText(story.genre || story.tag || "Story").replace(/^[^\w]+/, "") ||
   "Story";
 
 interface StoryTradingCardProps {
@@ -290,7 +290,7 @@ const StoryTradingCard: React.FC<StoryTradingCardProps> = ({
                 {genre}
               </span>
               <span className="rounded-full border border-white/20 bg-white/10 px-3 py-1 text-[10px] font-bold text-white">
-                {(story as any).language || "English"}
+                {story.language || "English"}
               </span>
             </div>
           </div>

--- a/frontend/src/components/stories/stories.view.component.tsx
+++ b/frontend/src/components/stories/stories.view.component.tsx
@@ -32,6 +32,9 @@ export interface IStories {
   content: string;
   tag: string;
   imageURL: string;
+
+  genre?: string;
+  language?: string;
 }
 
 export type StorySentenceSegment = {


### PR DESCRIPTION
## Description

### Summary

This PR replaces the remaining explicit `any` usages in `StoryTradingCard.tsx` with properly typed properties from the `IStories` interface.

The component previously relied on type assertions to access `genre` and `language`, bypassing TypeScript's type checking. This PR extends the `IStories` interface with the required optional properties and removes the unnecessary `any` casts, improving type safety while preserving existing functionality.

**Closes #4587**

---

### Changes Made

- Added optional `genre` and `language` properties to the `IStories` interface.
- Replaced `(story as any).genre` with `story.genre`.
- Replaced `(story as any).language` with `story.language`.
- Removed the remaining explicit `any` usages from `StoryTradingCard.tsx`.
- Improved TypeScript type safety without changing component behavior.

---

### Files Changed

```text
frontend/src/components/cards/StoryTradingCard.tsx
frontend/src/components/stories/stories.view.component.tsx
```

---

### Testing

#### Performed

- Verified that the component compiles after removing the explicit `any` usages.
- Ran `pnpm lint` to confirm the `@typescript-eslint/no-explicit-any` violations for this component are resolved.

---

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update

---

### Checklist

- [x] Removed explicit `any` usages.
- [x] Added appropriate optional properties to the shared interface.
- [x] Preserved existing functionality.
- [x] Improved TypeScript type safety.
- [x] Limited changes to the files required for this fix.
- [x] No unrelated changes were introduced.