### PR TITLE
fix: replace explicit any usage in CollabRoom

### DIFF
--- a/frontend/src/components/collab/CollabRoom.tsx
+++ b/frontend/src/components/collab/CollabRoom.tsx
@@ -3,6 +3,8 @@ import { useParams, useNavigate } from "react-router-dom";
 import { getToken } from "../../services/auth.service";
 import { isLoggedIn, getUserInfo } from "../../services/auth.service";
 import CollabEditor from './CollabEditor';
+import { io, type Socket } from "socket.io-client";
+
 interface Participant {
   userId: string;
   username: string;
@@ -43,7 +45,7 @@ export default function CollabRoom() {
   const [room, setRoom] = useState<Room | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [collabSocket, setCollabSocket] = useState<any>(null);
+  const [collabSocket, setCollabSocket] = useState<Socket | null>(null);
   const [typingUsers, setTypingUsers] = useState<{ [userId: string]: string }>({});
   const [isAiThinking, setIsAiThinking] = useState(false);
   const [copyFeedback, setCopyFeedback] = useState(false);
@@ -68,7 +70,7 @@ export default function CollabRoom() {
       return;
     }
 
-    let socketInstance: any;
+    let socketInstance: Socket;
 
     try {
       socketInstance = io(`${socketUrl}/collab`, {


### PR DESCRIPTION
## Description

### Summary

This PR improves type safety in `CollabRoom.tsx` by replacing the remaining explicit `any` usages with the appropriate Socket.IO client type.

The component previously used `any` for Socket.IO instances, bypassing TypeScript's type checking and triggering `@typescript-eslint/no-explicit-any` violations. This PR replaces those usages with the `Socket` type provided by `socket.io-client`, improving type safety while preserving the existing collaboration functionality.

**Closes #4588**

---

### Changes Made

- Imported the `Socket` type from `socket.io-client`.
- Replaced `useState<any>` with `useState<Socket | null>`.
- Replaced `let socketInstance: any` with `let socketInstance: Socket`.
- Removed the remaining explicit `any` usages from `CollabRoom.tsx`.
- Improved TypeScript type safety without changing component behavior.

---

### Files Changed

```text
frontend/src/components/collab/CollabRoom.tsx
```

---

### Testing

#### Performed

- Verified that the explicit `any` usages were replaced with the appropriate Socket.IO type.
- Ran `pnpm lint` to confirm that the `@typescript-eslint/no-explicit-any` violations for this component are resolved.

---

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update

---

### Checklist

- [x] Replaced explicit `any` usages with the appropriate Socket.IO type.
- [x] Improved TypeScript type safety.
- [x] Preserved existing functionality.
- [x] Limited changes to the affected component.
- [x] No unrelated code changes were introduced.
- [x] Performed a self-review before submitting.