### PR TITLE
refactor: remove obsolete TokenBlacklist writes from logout flow

### DIFF
--- a/backend/src/app/modules/auth/auth.controller.ts
+++ b/backend/src/app/modules/auth/auth.controller.ts
@@ -6,7 +6,6 @@ import sendResponse from "../../../shared/send_response";
 import { IUser } from "../user/user.interface";
 import catchAsync from "../../../shared/catch_async";
 import { setRefreshTokenCookie, clearRefreshTokenCookie } from "../../../utils/cookie.util";
-import { TokenBlacklist } from "./tokenBlacklist.model";
 import { VerifyEmailService } from "../verify_email/verify_email.service";
 
 const login = catchAsync(async (req: Request, res: Response) => {
@@ -64,16 +63,6 @@ const logout = catchAsync(async (req: Request, res: Response) => {
       : authHeader.trim();
   } else {
     activeToken = req.cookies?.accessToken || req.cookies?.token || "";
-  }
-
-  if (activeToken) {
-    try {
-      await TokenBlacklist.create({
-        token: activeToken,
-      });
-    } catch (err) {
-      console.error("Error blacklisting token on logout:", err);
-    }
   }
 
   const refreshToken = req.cookies?.refreshToken as string | undefined;


### PR DESCRIPTION
## Description

### Summary

This PR removes obsolete `TokenBlacklist` writes from the logout flow after the project migrated to `tokenVersion`-based session invalidation.

The authentication middleware already validates user sessions using `tokenVersion` and no longer queries `TokenBlacklist`. As a result, writing access tokens to the blacklist during logout performs an unnecessary database operation without affecting authentication behavior.

**Closes #4647**

---

### Changes Made

- Removed the unused `TokenBlacklist` import from `auth.controller.ts`.
- Removed the obsolete `TokenBlacklist.create()` call from the logout flow.
- Preserved the existing `tokenVersion`-based authentication mechanism.
- Kept the logout response and refresh token cleanup behavior unchanged.

---

### Files Changed

```text
backend/src/app/modules/auth/auth.controller.ts
```

---

### Testing

#### Performed

- Verified that logout continues to clear the refresh token cookie.
- Confirmed that authentication still relies on `tokenVersion` validation.
- Ran project linting and type checking.

#### Notes

Repository-wide linting/type-checking may still report unrelated pre-existing issues outside the scope of this PR.

---

### Type of Change

- [x] Refactoring
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

---

### Checklist

- [x] Removed obsolete database writes from the logout flow.
- [x] Removed the unused `TokenBlacklist` import.
- [x] Preserved existing logout functionality.
- [x] Left the `tokenVersion` authentication mechanism unchanged.
- [x] Limited changes to the affected controller.
- [x] No unrelated code changes were introduced.