### PR TITLE
fix: align registration validation with verification token flow

### DIFF
--- a/backend/src/app/modules/user/user.validation.ts
+++ b/backend/src/app/modules/user/user.validation.ts
@@ -11,12 +11,16 @@ const passwordSchema = z
 
   const register = z.object({
     body: z.object({
-      email: z.string({ required_error: "Email is required" }).email("Invalid email address"),
+      email: z
+        .string({ required_error: "Email is required" })
+        .email("Invalid email address"),
       name: z
         .string({ required_error: "Name is required" })
         .min(2, "Name must be at least 2 characters long"),
       password: passwordSchema,
-      otp: z.string({ required_error: "OTP is required" }).length(6, "OTP must be 6 digits"),
+      verificationToken: z.string({
+        required_error: "Verification token is required",
+      }),
     }),
   });
 


### PR DESCRIPTION
## Description

### Summary

This PR aligns the registration request validation with the authentication service by replacing the outdated `otp` field in the registration validation schema with `verificationToken`.

The registration flow currently validates an `otp` field, while `AuthService.register()` expects a `verificationToken`. This mismatch can cause valid registration requests to fail validation before reaching the service layer. This change standardizes the request payload and ensures consistency across the registration flow.

**Closes #4648**

---

### Changes Made

- Updated the registration validation schema to require `verificationToken` instead of `otp`.
- Aligned the validation layer with the existing `AuthService.register()` implementation.
- Preserved the existing authentication and registration logic.
- Limited the changes to the validation schema without modifying the service layer.

---

### Files Changed

```text
backend/src/app/modules/user/user.validation.ts
```

---

### Testing

#### Performed

- Verified that the registration validation schema now accepts `verificationToken`.
- Confirmed that the validation schema matches the payload expected by `AuthService.register()`.
- Ran the project's lint command.

#### Notes

The repository currently contains multiple pre-existing frontend ESLint errors unrelated to this backend validation change. These existing issues are outside the scope of this PR, and no additional lint errors were introduced by this change.

---

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update

---

### Checklist

- [x] Updated the registration validation schema to use `verificationToken`.
- [x] Aligned the validation layer with the authentication service.
- [x] Preserved the existing registration flow.
- [x] Limited changes to the affected validation file.
- [x] No unrelated code changes were introduced.
- [x] Performed a self-review before submitting.