### PR TITLE
refactor: synchronize refresh cookie lifetime with JWT configuration

### DIFF
--- a/backend/src/utils/cookie.util.ts
+++ b/backend/src/utils/cookie.util.ts
@@ -1,6 +1,6 @@
 import { Response } from "express";
 import config from "../config";
-
+import { durationToMilliseconds } from "./duration.util";
 const isProd = config.env === "production";
 
 /**
@@ -24,8 +24,8 @@ export const setRefreshTokenCookie = (
     refreshToken: string
 ): void => {
     res.cookie("refreshToken", refreshToken, {
-        ...cookieOptions,
-        maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
+      ...cookieOptions,
+      maxAge: durationToMilliseconds(config.jwt.refresh_expires_in ?? "7d"),
     });
 };
 

--- a/backend/src/utils/duration.util.ts
+++ b/backend/src/utils/duration.util.ts
@@ -1,0 +1,19 @@
+export const durationToMilliseconds = (duration: string): number => {
+  const match = duration.match(/^(\d+)([smhd])$/);
+
+  if (!match) {
+    throw new Error(`Invalid duration format: ${duration}`);
+  }
+
+  const value = Number(match[1]);
+  const unit = match[2];
+
+  const multipliers: Record<string, number> = {
+    s: 1000,
+    m: 60 * 1000,
+    h: 60 * 60 * 1000,
+    d: 24 * 60 * 60 * 1000,
+  };
+
+  return value * multipliers[unit];
+};


### PR DESCRIPTION
## Description

### Summary

This PR synchronizes the refresh token cookie lifetime with the configured JWT refresh token expiration by introducing a shared duration conversion utility.

Previously, the refresh token cookie used a hard-coded `maxAge` of 7 days, while the JWT refresh token expiration was configured independently through `JWT_REFRESH_EXPIRES_IN`. This could lead to inconsistencies if the configuration changed.

**Closes #4650**

---

### Changes Made

- Added a reusable `durationToMilliseconds` utility to convert JWT-style duration strings (e.g. `15m`, `12h`, `7d`) into milliseconds.
- Updated `setRefreshTokenCookie()` to derive `maxAge` from `config.jwt.refresh_expires_in` instead of using a hard-coded value.
- Preserved the existing fallback behavior by defaulting to `7d` when the configuration is unavailable.
- Kept all authentication and JWT generation logic unchanged.

---

### Files Changed

```text
backend/src/utils/cookie.util.ts
backend/src/utils/duration.util.ts
```

---

### Testing

#### Performed

- Verified that the refresh token cookie now derives its lifetime from `JWT_REFRESH_EXPIRES_IN`.
- Confirmed that the duration conversion utility correctly handles supported duration formats (`s`, `m`, `h`, `d`).
- Ran backend type checking.

#### Notes

The repository currently contains multiple pre-existing TypeScript errors unrelated to this change. These existing issues are outside the scope of this PR, and no new errors were introduced by the updated cookie lifetime implementation.

---

### Type of Change

- [ ] Bug fix
- [x] Refactoring
- [x] New feature
- [ ] Documentation update

---

### Checklist

- [x] Added a reusable duration conversion utility.
- [x] Removed the hard-coded refresh cookie lifetime.
- [x] Derived cookie expiration from the JWT refresh token configuration.
- [x] Preserved existing authentication behavior.
- [x] Limited changes to the relevant utility files.
- [x] No unrelated code changes were introduced.
- [x] Performed a self-review before submitting.