### PR TITLE
fix: validate JWT expiration environment variables during startup

### DIFF
--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -59,8 +59,8 @@ export default {
   jwt: {
     secret: requiredEnv("JWT_SECRET"),
     refresh_secret: requiredEnv("JWT_REFRESH_SECRET"),
-    expires_in: process.env.JWT_EXPIRES_IN,
-    refresh_expires_in: process.env.JWT_REFRESH_EXPIRES_IN,
+    expires_in: requiredEnv("JWT_EXPIRES_IN"),
+    refresh_expires_in: requiredEnv("JWT_REFRESH_EXPIRES_IN"),
   },
   default_admin_password: process.env.DEFAULT_ADMIN_PASSWORD,
   openai_key: process.env.OPEN_AI_KEY,


### PR DESCRIPTION
## Description

### Summary

This PR ensures that the backend validates all required JWT configuration values during application startup by requiring both JWT expiration environment variables.

Previously, only the JWT secrets were validated using `requiredEnv()`, while `JWT_EXPIRES_IN` and `JWT_REFRESH_EXPIRES_IN` were treated as optional. Missing expiration values could lead to misconfigured deployments and unexpected authentication behavior.

**Closes #4651**

---

### Changes Made

- Updated the JWT configuration to require `JWT_EXPIRES_IN` during startup.
- Updated the JWT configuration to require `JWT_REFRESH_EXPIRES_IN` during startup.
- Reused the existing `requiredEnv()` helper for consistent environment validation.
- Preserved the existing configuration structure without modifying authentication logic.

---

### Files Changed

```text
backend/src/config/index.ts
```

---

### Testing

#### Performed

- Verified that both JWT expiration environment variables are now validated during application startup.
- Confirmed that startup fails with a descriptive error when either `JWT_EXPIRES_IN` or `JWT_REFRESH_EXPIRES_IN` is missing.
- Ran backend type checking.

#### Notes

The repository currently contains pre-existing TypeScript errors unrelated to this configuration change. No additional errors were introduced by this PR.

---

### Type of Change

- [x] Bug fix
- [ ] Refactoring
- [ ] New feature
- [ ] Documentation update

---

### Checklist

- [x] Required `JWT_EXPIRES_IN` during backend startup.
- [x] Required `JWT_REFRESH_EXPIRES_IN` during backend startup.
- [x] Reused the existing `requiredEnv()` helper.
- [x] Preserved existing authentication behavior.
- [x] Limited changes to the configuration file.
- [x] No unrelated code changes were introduced.
- [x] Performed a self-review before submitting.