### PR TITLE
refactor: defer AI provider validation until AI functionality is invoked 

### DIFF
--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -20,7 +20,8 @@ const requiredEnv = (key: string): string => {
   }
   return value;
 };
-const validateAIProviderKeys = (): void => {
+
+export const assertAIProviderConfigured = (): void => {
   const hasOpenAI = !!(process.env.OPEN_AI_KEY || process.env.OPENAI_API_KEY)?.trim();
   const hasGemini = !!process.env.GEMINI_API_KEY?.trim();
   const hasAnthropic = !!process.env.ANTHROPIC_API_KEY?.trim();
@@ -35,8 +36,6 @@ const validateAIProviderKeys = (): void => {
   if (!hasGemini) console.warn("[Config] GEMINI_API_KEY not set — Gemini provider unavailable.");
   if (!hasAnthropic) console.warn("[Config] ANTHROPIC_API_KEY not set — Anthropic provider unavailable.");
 };
-
-validateAIProviderKeys();
 
 export default {
   env: process.env.NODE_ENV,

--- a/backend/src/services/ai.service.ts
+++ b/backend/src/services/ai.service.ts
@@ -6,6 +6,7 @@ import OpenAI from "openai";
 import { GoogleGenerativeAI } from "@google/generative-ai";
 import Anthropic from "@anthropic-ai/sdk";
 import { StoryCache } from "../models/storyCache.model"; // Added Cache Model Import
+import { assertAIProviderConfigured } from "../config";
 
 let openai: OpenAI | null = null;
 let genAI: GoogleGenerativeAI | null = null;
@@ -150,6 +151,9 @@ export async function generateStory(
   provider?: string, 
   options?: PromptOptions
 ): Promise<AIResponse> {
+
+  assertAIProviderConfigured(); 
+
   // ── Security layer: validate and wrap input ─────────────────────────
   const securePrompt = validateAndFormatPrompt(prompt);
 


### PR DESCRIPTION
## Description

### Summary

This PR refactors AI provider validation to occur only when AI functionality is invoked instead of during backend startup.

Previously, the backend validated AI provider configuration during application initialization, preventing the server from starting when no AI provider API keys were configured—even for authentication and other non-AI features.

This change allows the backend to start normally while ensuring AI provider configuration is still validated before executing AI-dependent functionality.

**Closes #4653**

---

### Changes Made

- Removed eager AI provider validation during backend startup.
- Introduced `assertAIProviderConfigured()` for lazy AI provider validation.
- Invoked AI provider validation at the beginning of `generateStory()`.
- Preserved existing provider-specific client validation for OpenAI, Gemini, and Anthropic.
- Left authentication and other non-AI functionality unchanged.

---

### Files Changed

```text
backend/src/config/index.ts
backend/src/services/ai.service.ts
```

---

### Testing

#### Performed

- Verified the backend no longer requires AI provider API keys during startup.
- Confirmed AI provider validation is triggered only when `generateStory()` is invoked.
- Ran backend type checking.

#### Notes

The repository currently contains pre-existing TypeScript issues unrelated to this change. No new issues were introduced by this PR.

---

### Type of Change

- [x] Refactoring
- [x] Backend Improvement
- [ ] Bug Fix
- [ ] New Feature
- [ ] Documentation Update

---

### Checklist

- [x] Removed startup-time AI provider validation.
- [x] Added lazy AI provider validation.
- [x] Restricted validation to AI execution flow.
- [x] Kept changes limited to the affected backend files.
- [x] No unrelated functionality was modified.
- [x] Self-reviewed the implementation before submitting.