### PR TITLE
fix: add server-side prompt length validation for story generation

### DIFF
--- a/backend/src/app/modules/ai_model/ai_model.validation.ts
+++ b/backend/src/app/modules/ai_model/ai_model.validation.ts
@@ -123,6 +123,16 @@ const aiTranslate = z.object({
   }),
 });
 
+const aiStoryGenerate = z.object({
+  body: z.object({
+    prompt: z
+      .string({ required_error: "Prompt is required!" })
+      .trim()
+      .min(1, "Prompt is required!")
+      .max(2000, "Prompt must not exceed 2000 characters"),
+  }).passthrough(),
+});
+
 export const AIModelValidator = {
   aiModel,
   aiAlternateEndings,
@@ -130,4 +140,5 @@ export const AIModelValidator = {
   aiChat,
   aiRemix,
   aiTranslate,
+  aiStoryGenerate,
 };

--- a/backend/src/routes/story.routes.ts
+++ b/backend/src/routes/story.routes.ts
@@ -136,6 +136,7 @@ router.post(
   ),
   generateLimiter,
   checkRequestLimit(),
+  validateRequest(AIModelValidator.aiStoryGenerate),
   catchAsync(async (req: Request, res: Response) => {
     const { prompt, provider, options } = req.body;
     const guard = res.locals.quotaRefundGuard;


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Open or link a related issue when there is one (`Closes #123`, `Fixes #45`, or write **None** under Related issue below).
- **Description:** Fill in **What this PR does** so a reviewer can understand the change without your local context.
- **Screenshots:** Add screenshots or a short recording when they help (UI changes, confusing flows, or non-code proof). If not needed, say so in the checklist.

## Screenshot (when helpful)

<!-- Drag & drop or paste. For non-UI work, you can use tests output, logs, or API responses. Write “N/A” in the checklist if you skip this section. -->

N/A - Backend validation changes only.

## What this PR does

<!-- Short summary: what problem does this solve, and how? -->

This PR adds server-side validation to the story generation endpoint (`/api/v1/story/generate`). It ensures that story prompts are trimmed, non-empty, and do not exceed 2000 characters before the AI provider is called. This prevents excessively large payloads from reaching the AI service and correctly returns a 400 Bad Request if the prompt is invalid.

## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Fixes #4627 

## More screenshots (optional)

<!-- Extra before/after images, flows, or recordings for reviewers. -->



## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason. *(N/A - Backend logic only, no UI changes)*
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
