### PR TITLE
fix: reduce input width to prevent overflow outside login card

### DIFF
--- a/frontend/src/components/ui-component/ss-input/ss-input.tsx
+++ b/frontend/src/components/ui-component/ss-input/ss-input.tsx
@@ -66,7 +66,7 @@ const SSInput = <T extends FieldValues>({
           autoComplete={autoComplete}
           autoFocus={autoFocus}
           {...register(name, validation)}
-          className={`w-full min-w-0 max-w-full h-11 block box-border rounded-xl border text-sm transition-all duration-200 focus:outline-none focus:ring-2 ${
+          className={`w-[85%] mx-auto min-w-0 h-11 block box-border rounded-xl border text-sm transition-all duration-200 focus:outline-none focus:ring-2 ${
             icon ? "pl-11" : "px-4"
           } ${isPasswordType ? "pr-11" : "pr-4"} ${
             error


### PR DESCRIPTION
## Before you open this PR
- **Issue:** Fixes #3712
- **Description:** See below
- **Screenshots:** N/A — CSS width adjustment on shared input component; verified visually before submitting

## Screenshot (when helpful)
N/A

## What this PR does
Fixes email and password input fields overflowing outside the login card boundary. Both fields use the shared `SSInput` component, which had `w-full max-w-full` on the actual `<input>` element — this allowed the input to stretch past the card's edges. Changed the input width to `w-[85%] mx-auto` (keeping `min-w-0` for correct flex shrink behavior) so the field stays comfortably inside the card.

## Type of change
- [x] Bug fix

## Related issue
Fixes #3712

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.