### PR TITLE
fix : added typeof window guards to session-bookmarks utility

### DIFF
--- a/frontend/src/utils/session-bookmarks.ts
+++ b/frontend/src/utils/session-bookmarks.ts
@@ -3,6 +3,9 @@ import { IStories } from "../components/stories/stories.view.component";
 const SESSION_KEY = "story_spark_session_bookmarks";
 
 export const getSessionBookmarks = (): IStories[] => {
+  if (typeof window === "undefined") {
+    return [];
+  }
   try {
     const data = sessionStorage.getItem(SESSION_KEY);
     return data ? JSON.parse(data) : [];
@@ -13,6 +16,9 @@ export const getSessionBookmarks = (): IStories[] => {
 };
 
 export const addSessionBookmark = (story: IStories): void => {
+  if (typeof window === "undefined") {
+    return;
+  }
   try {
     const bookmarks = getSessionBookmarks();
     if (!bookmarks.some((b) => b.uuid === story.uuid)) {
@@ -26,6 +32,9 @@ export const addSessionBookmark = (story: IStories): void => {
 };
 
 export const removeSessionBookmark = (uuid: string): void => {
+  if (typeof window === "undefined") {
+    return;
+  }
   try {
     const bookmarks = getSessionBookmarks();
     const updated = bookmarks.filter((b) => b.uuid !== uuid);
@@ -37,6 +46,9 @@ export const removeSessionBookmark = (uuid: string): void => {
 };
 
 export const isSessionBookmarked = (uuid: string): boolean => {
+  if (typeof window === "undefined") {
+    return false;
+  }
   const bookmarks = getSessionBookmarks();
   return bookmarks.some((b) => b.uuid === uuid);
 };


### PR DESCRIPTION
Closes #4739.

Summary of What Has Been Done:
Added  guards to all four exported functions in : , , , and . This prevents SSR crashes when these functions are called in Next.js or other server-side environments where  and  are not defined.

Changes Made:
- frontend/src/utils/session-bookmarks.ts: Added SSR guard at the top of each exported function, returning safe defaults on the server (empty array for reads, void for writes).

Impact it Made:
- Fixes SSR crashes in Next.js / server-side rendering environments
- Session bookmarks utility is now safe to import in any rendering context

Note: Please assign this PR to the `tmdeveloper007` account.