### PR TITLE
fix: add SSR guard to downloadTXT utility (#4611)

### DIFF
--- a/frontend/src/utils/downloadStories.ts
+++ b/frontend/src/utils/downloadStories.ts
@@ -1,4 +1,6 @@
 export const downloadTXT = (story: any) => {
+  if (typeof window === 'undefined') return;
+
   const content = `Title: ${story.title}\nPrompt: ${story.prompt}\nStory: ${story.content}\nGenerated: ${new Date().toLocaleString()}`;
 
   const blob = new Blob([content], { type: "text/plain" });


### PR DESCRIPTION
## What this PR does

Fixes a runtime crash that occurs during server-side rendering (SSR). The `downloadTXT` function in `frontend/src/utils/downloadStories.ts` used browser-only APIs (`URL.createObjectURL`, `document.createElement`) without checking whether `window` exists first. Since `window` is undefined during SSR, this caused a crash. Added a guard at the top of the function that returns early when `window` is undefined, matching the same SSR-safe pattern already used in `story-draft.ts`.

## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue
Closes #4611

## More screenshots (optional)
N/A — this is a non-UI fix (SSR crash prevention). No visual changes to verify.

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
