### PR TITLE
test: add unit tests for jwt utility functions (#4610)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -69,10 +69,6 @@
     "@tailwindcss/forms": "^0.5.11",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
- feat/collaboration-1122
-
-    "@tailwindcss/container-queries": "^0.1.1",
- main
     "@types/canvas-confetti": "^1.9.0",
     "@types/d3": "^7.4.3",
     "@types/dompurify": "^3.0.5",

--- a/frontend/src/utils/tests/jwt.test.ts
+++ b/frontend/src/utils/tests/jwt.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { jwtDecode } from "jwt-decode";
+import { isJwtTokenFormat, decodedToken } from "../jwt";
+
+vi.mock("jwt-decode", () => ({
+  jwtDecode: vi.fn(),
+}));
+
+const mockedJwtDecode = vi.mocked(jwtDecode);
+
+const FUTURE_EXP = Math.floor(Date.now() / 1000) + 3600;
+const PAST_EXP = Math.floor(Date.now() / 1000) - 3600;
+const NOW_IAT = Math.floor(Date.now() / 1000) - 10;
+
+const VALID_PAYLOAD = {
+  userId: "user-123",
+  email: "alice@example.com",
+  role: "user",
+  subscriptionType: "free",
+  exp: FUTURE_EXP,
+  iat: NOW_IAT,
+};
+
+// A dummy 3-part token string; the actual payload comes from the mocked jwtDecode.
+const FAKE_TOKEN = "header.payload.signature";
+
+describe("isJwtTokenFormat", () => {
+  it("returns false for null", () => {
+    expect(isJwtTokenFormat(null as unknown as string)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isJwtTokenFormat(undefined as unknown as string)).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isJwtTokenFormat("")).toBe(false);
+  });
+
+  it("returns false for non-string input", () => {
+    expect(isJwtTokenFormat(12345 as unknown as string)).toBe(false);
+  });
+
+  it("returns false for a string with fewer than 3 parts", () => {
+    expect(isJwtTokenFormat("header.payload")).toBe(false);
+  });
+
+  it("returns false for a string with more than 3 parts", () => {
+    expect(isJwtTokenFormat("a.b.c.d")).toBe(false);
+  });
+
+  it("returns true for a valid 3-part JWT format", () => {
+    expect(isJwtTokenFormat("header.payload.signature")).toBe(true);
+  });
+});
+
+describe("decodedToken", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("throws for invalid format (not 3 parts)", () => {
+    expect(() => decodedToken("not-a-jwt")).toThrow(
+      "Token format is invalid. A JWT must consist of three dot-separated segments."
+    );
+    expect(mockedJwtDecode).not.toHaveBeenCalled();
+  });
+
+  it("throws when userId and _id are both missing or empty", () => {
+    mockedJwtDecode.mockReturnValue({
+      ...VALID_PAYLOAD,
+      userId: undefined,
+      _id: undefined,
+    } as any);
+
+    expect(() => decodedToken(FAKE_TOKEN)).toThrow(
+      "Token is missing a valid 'userId' or '_id' claim."
+    );
+  });
+
+  it("throws when email is missing or invalid format (no @, no domain)", () => {
+    mockedJwtDecode.mockReturnValue({
+      ...VALID_PAYLOAD,
+      email: "not-an-email",
+    } as any);
+
+    expect(() => decodedToken(FAKE_TOKEN)).toThrow(
+      "Token 'email' claim is not a valid email address."
+    );
+  });
+
+  it("throws when email claim is missing entirely", () => {
+    mockedJwtDecode.mockReturnValue({
+      ...VALID_PAYLOAD,
+      email: undefined,
+    } as any);
+
+    expect(() => decodedToken(FAKE_TOKEN)).toThrow(
+      "Token is missing a valid 'email' claim."
+    );
+  });
+
+  it("throws when role is missing or invalid (not one of user/admin/super_admin/writer/guest)", () => {
+    mockedJwtDecode.mockReturnValue({
+      ...VALID_PAYLOAD,
+      role: "hacker",
+    } as any);
+
+    expect(() => decodedToken(FAKE_TOKEN)).toThrow(
+      "Token 'role' claim must be one of: user, admin, super_admin, writer, guest"
+    );
+  });
+
+  it("throws when role claim is missing entirely", () => {
+    mockedJwtDecode.mockReturnValue({
+      ...VALID_PAYLOAD,
+      role: undefined,
+    } as any);
+
+    expect(() => decodedToken(FAKE_TOKEN)).toThrow(
+      "Token is missing a valid 'role' claim."
+    );
+  });
+
+  it("throws when subscriptionType is missing or invalid (not one of free/pro/premium)", () => {
+    mockedJwtDecode.mockReturnValue({
+      ...VALID_PAYLOAD,
+      subscriptionType: "enterprise",
+    } as any);
+
+    expect(() => decodedToken(FAKE_TOKEN)).toThrow(
+      "Token 'subscriptionType' claim must be one of: free, pro, premium"
+    );
+  });
+
+  it("throws when exp is in the past", () => {
+    mockedJwtDecode.mockReturnValue({
+      ...VALID_PAYLOAD,
+      exp: PAST_EXP,
+    } as any);
+
+    expect(() => decodedToken(FAKE_TOKEN)).toThrow("Token has expired.");
+  });
+
+  it("throws when exp is not a number", () => {
+    mockedJwtDecode.mockReturnValue({
+      ...VALID_PAYLOAD,
+      exp: "not-a-number",
+    } as any);
+
+    expect(() => decodedToken(FAKE_TOKEN)).toThrow(
+      "Token is missing a valid numeric 'exp' claim."
+    );
+  });
+
+  it("throws when iat is not a number", () => {
+    mockedJwtDecode.mockReturnValue({
+      ...VALID_PAYLOAD,
+      iat: "not-a-number",
+    } as any);
+
+    expect(() => decodedToken(FAKE_TOKEN)).toThrow(
+      "Token is missing a valid numeric 'iat' claim."
+    );
+  });
+
+  it("returns decoded payload when all claims are valid", () => {
+    mockedJwtDecode.mockReturnValue(VALID_PAYLOAD as any);
+
+    const result = decodedToken(FAKE_TOKEN);
+
+    expect(result).toEqual(VALID_PAYLOAD);
+    expect(mockedJwtDecode).toHaveBeenCalledWith(FAKE_TOKEN);
+  });
+
+  it("accepts _id as a fallback when userId is absent", () => {
+    mockedJwtDecode.mockReturnValue({
+      ...VALID_PAYLOAD,
+      userId: undefined,
+      _id: "mongo-id-456",
+    } as any);
+
+    const result = decodedToken(FAKE_TOKEN);
+    expect(result._id).toBe("mongo-id-456");
+  });
+});


### PR DESCRIPTION
## Screenshot (when helpful)
N/A — test file with no UI changes. Test run output:
✓ src/utils/tests/jwt.test.ts (19 tests) 25ms
✓ isJwtTokenFormat (7)
✓ decodedToken (12)
Test Files  1 passed (1)
Tests  19 passed (19)

## What this PR does
Adds comprehensive unit tests for the JWT utility functions `isJwtTokenFormat` and `decodedToken` in `frontend/src/utils/jwt.ts`. `jwtDecode` is mocked so `decodedToken` can be tested against controlled payloads without real signed tokens.

- `isJwtTokenFormat`: covers null/undefined/empty/non-string/wrong-part-count inputs, plus the valid 3-part case.
- `decodedToken`: covers every throw condition — invalid format, missing/invalid userId or `_id`, missing/invalid email, missing/invalid role, missing/invalid subscriptionType, expired `exp`, non-numeric `exp`/`iat` — plus the happy path and the `_id` fallback when `userId` is absent.

Also fixes an unrelated but blocking issue: `frontend/package.json` on `main` contains leftover, unresolved git-merge-conflict artifacts (a duplicate dependency line and stray branch-name text), producing invalid JSON that makes `npm install` fail with `EJSONPARSE`. This had to be fixed locally just to install dependencies and run the test suite — flagging it here since it likely blocks anyone else pulling latest `main` too.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

(Primarily test coverage; checked "Bug fix" for the `package.json` JSON-corruption fix bundled in since it was required to run the tests.)

## Related issue
Closes #4610

## More screenshots (optional)
N/A

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.