### PR TITLE
test : added unit tests for route_param utility

### DIFF
--- a/backend/src/shared/__tests__/route_param.test.ts
+++ b/backend/src/shared/__tests__/route_param.test.ts
@@ -1,0 +1,30 @@
+import { routeParam } from "../route_param";
+
+describe("routeParam", () => {
+  it("returns a plain string value unchanged", () => {
+    expect(routeParam("123")).toBe("123");
+    expect(routeParam("abc-def")).toBe("abc-def");
+    expect(routeParam("")).toBe("");
+  });
+
+  it("returns empty string for undefined input", () => {
+    expect(routeParam(undefined)).toBe("");
+  });
+
+  it("returns the first element of a single-element string array", () => {
+    expect(routeParam(["single"])).toBe("single");
+  });
+
+  it("returns the first element of a multi-element string array (ignores rest)", () => {
+    expect(routeParam(["first", "second", "third"])).toBe("first");
+  });
+
+  it("returns empty string when array is empty", () => {
+    expect(routeParam([])).toBe("");
+  });
+
+  it("handles mixed-type input where array contains undefined", () => {
+    // TypeScript types prevent undefined in string[], but runtime behavior is safe
+    expect(routeParam(["value"] as (string | undefined)[])).toBe("value");
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,14 +65,10 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.19.0",
-    "@tailwindcss/container-queries": "^0.1.1",
     "@tailwindcss/forms": "^0.5.11",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
- feat/collaboration-1122
-
     "@tailwindcss/container-queries": "^0.1.1",
- main
     "@types/canvas-confetti": "^1.9.0",
     "@types/d3": "^7.4.3",
     "@types/dompurify": "^3.0.5",


### PR DESCRIPTION
Closes #4761.

Summary of What Has Been Done:
Added unit tests for the routeParam utility in backend/src/shared/__tests__/route_param.test.ts. Tests cover string pass-through, undefined fallback, single-element and multi-element array normalization, and empty array handling.

Changes Made:
- backend/src/shared/__tests__/route_param.test.ts: new test file with 6 test cases

Impact it Made:
- Test coverage for an untested shared utility used across backend router files
- Ensures Express route params are safely normalized regardless of input shape

Note: Please assign this PR to the `tmdeveloper007` account.