### PR TITLE
fix : added missing try-catch for getToken in analytics controller

### DIFF
--- a/backend/src/app/modules/analytics/analytics.controller.ts
+++ b/backend/src/app/modules/analytics/analytics.controller.ts
@@ -74,7 +74,13 @@ try {
 });
 
 const getProductiveHours = catchAsync(async (req: Request, res: Response) => {
-const token = getToken(req);
+let token = null;
+
+try {
+  token = getToken(req);
+} catch (error) {
+  token = null;
+}
   const result = await AnalyticsService.getProductiveHours(token);
   sendResponse(res, {
     statusCode: httpStatus.OK,
@@ -85,7 +91,13 @@ const token = getToken(req);
 });
 
 const getEmotionDistribution = catchAsync(async (req: Request, res: Response) => {
-const token = getToken(req);
+let token = null;
+
+try {
+  token = getToken(req);
+} catch (error) {
+  token = null;
+}
   const result = await AnalyticsService.getEmotionDistribution(token);
   sendResponse(res, {
     statusCode: httpStatus.OK,
@@ -96,7 +108,13 @@ const token = getToken(req);
 });
 
 const getMoodTimeline = catchAsync(async (req: Request, res: Response) => {
-const token = getToken(req);
+let token = null;
+
+try {
+  token = getToken(req);
+} catch (error) {
+  token = null;
+}
   const result = await AnalyticsService.getMoodTimeline(token);
   sendResponse(res, {
     statusCode: httpStatus.OK,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,14 +65,10 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.19.0",
-    "@tailwindcss/container-queries": "^0.1.1",
     "@tailwindcss/forms": "^0.5.11",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
- feat/collaboration-1122
-
     "@tailwindcss/container-queries": "^0.1.1",
- main
     "@types/canvas-confetti": "^1.9.0",
     "@types/d3": "^7.4.3",
     "@types/dompurify": "^3.0.5",


### PR DESCRIPTION
Closes #4763.

Summary of What Has Been Done:
Added consistent try-catch error handling for getToken(req) calls in getProductiveHours, getEmotionDistribution, and getMoodTimeline methods in the analytics controller. Previously these three methods called getToken directly without catching errors, unlike the other analytics controller methods (getAnalyticsOverview, getHeatmap, getGenreDistribution, getWordCloud) which already had proper try-catch blocks. Invalid or missing tokens now gracefully set token=null instead of throwing an unhandled exception.

Changes Made:
- backend/src/app/modules/analytics/analytics.controller.ts: added try-catch around getToken in 3 methods (+21 lines, -3 lines)

Impact it Made:
- Consistent error handling across all 7 analytics controller endpoints
- Prevents unhandled 500 errors when Authorization header is malformed or missing

Note: Please assign this PR to the `tmdeveloper007` account.