### PR TITLE
fix: add try-catch around getToken in analytics controller methods

### DIFF
--- a/backend/src/app/modules/analytics/analytics.controller.ts
+++ b/backend/src/app/modules/analytics/analytics.controller.ts
@@ -74,7 +74,13 @@ try {
 });
 
 const getProductiveHours = catchAsync(async (req: Request, res: Response) => {
-const token = getToken(req);
+let token = null;
+
+try {
+  token = getToken(req);
+} catch (error) {
+  token = null;
+}
   const result = await AnalyticsService.getProductiveHours(token);
   sendResponse(res, {
     statusCode: httpStatus.OK,
@@ -85,7 +91,13 @@ const token = getToken(req);
 });
 
 const getEmotionDistribution = catchAsync(async (req: Request, res: Response) => {
-const token = getToken(req);
+let token = null;
+
+try {
+  token = getToken(req);
+} catch (error) {
+  token = null;
+}
   const result = await AnalyticsService.getEmotionDistribution(token);
   sendResponse(res, {
     statusCode: httpStatus.OK,
@@ -96,7 +108,13 @@ const token = getToken(req);
 });
 
 const getMoodTimeline = catchAsync(async (req: Request, res: Response) => {
-const token = getToken(req);
+let token = null;
+
+try {
+  token = getToken(req);
+} catch (error) {
+  token = null;
+}
   const result = await AnalyticsService.getMoodTimeline(token);
   sendResponse(res, {
     statusCode: httpStatus.OK,


### PR DESCRIPTION
Add consistent error handling for getToken(req) calls in getProductiveHours, getEmotionDistribution, and getMoodTimeline to match the pattern already used by getAnalyticsOverview, getHeatmap, getGenreDistribution, and getWordCloud.
Previously, these three methods called getToken(req) directly without a try-catch block, causing unhandled 500 exceptions when tokens were invalid or missing.
Now all methods default token to null on error and continue processing, ensuring consistent and safe behavior across all analytics endpoints.
## Before you open this PR
- **Issue:** None
- **Description:** Wraps `getToken(req)` in a try-catch in `getProductiveHours`, `getEmotionDistribution`, and `getMoodTimeline`, defaulting `token` to `null` on error — matching the pattern already used by the other four analytics methods.
- **Screenshots:** N/A — backend-only change, no UI affected.
## Screenshot (when helpful)
N/A — backend error handling fix, no UI changes.
## What this PR does
Three analytics controller methods (`getProductiveHours`, `getEmotionDistribution`, `getMoodTimeline`) called `getToken(req)` directly without a try-catch block. When a request arrived with an invalid or missing token, these endpoints threw an unhandled exception and returned a 500 error.
This PR wraps `getToken(req)` in a try-catch in all three methods, defaulting `token` to `null` on error — exactly matching the pattern already used by `getAnalyticsOverview`, `getHeatmap`, `getGenreDistribution`, and `getWordCloud`. No logic beyond error handling was changed.
## Type of change
Check all that apply (if more than one, explain in "What this PR does").
- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
## Related issue
Fixes #4763 

## More screenshots (optional)
N/A
## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.