### PR TITLE
fix: server-render OG tags for social crawlers + dynamic client-side Helmet

### DIFF
--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,89 +1,98 @@
-import { NextRequest, NextResponse } from "next/server";
+const CRAWLER_RE = /Twitterbot|LinkedInBot|WhatsApp|Slackbot|Discordbot|facebookexternalhit|Slack-ImgProxy|facebot|Pinterest/i;
 
-const STORY_ROUTE = /^\/stor(?:y|ies)\/([^/?#]+)/;
+const STORY_ROUTE = /^\/post\/([^/?#]+)/;
 
-const API_BASE =
-  process.env.VITE_API_BASE_URL || "https://storysparkai.vercel.app/api/v1";
+const API_BASE = process.env.API_BASE_URL || process.env.VITE_BASE_URL || "";
 
-// Module-scoped cache — persists across invocations on the same edge instance  
-let cachedHtml: string | null = null;
-let cachedHtmlExpiry = 0;
-const HTML_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const FALLBACK_OG_IMAGE = "https://storysparkai.vercel.app/og-image.jpg";
+
+const HTML_CACHE_TTL_MS = 300_000;
+
+let cachedIndexHtml: string | null = null;
+let cachedIndexExpiry = 0;
 
 export const config = {
-  matcher: ["/story/:id*", "/stories/:id*"],
+  matcher: ["/post/:id"],
 };
 
-export default async function middleware(req: NextRequest) {
-  const { pathname } = req.nextUrl;
-  const match = pathname.match(STORY_ROUTE);
+export default async function middleware(request: Request): Promise<Response | undefined> {
+  const url = new URL(request.url);
+  const match = url.pathname.match(STORY_ROUTE);
 
-  if (!match) return NextResponse.next();
+  if (!match) return;
+
+  const ua = request.headers.get("user-agent") || "";
+  if (!CRAWLER_RE.test(ua)) return;
 
   const storyId = match[1];
+  const apiUrl = API_BASE
+    ? `${API_BASE.replace(/\/+$/, "")}/post/${storyId}`
+    : null;
 
-  try {
-    const now = Date.now();
-    const needsFreshHtml = !cachedHtml || now > cachedHtmlExpiry;
+  let story: { title?: string; content?: string; imageURL?: string } | null = null;
 
-    // Run story fetch and (conditionally) html fetch in parallel
-    const [res, html] = await Promise.all([
-      fetch(`${API_BASE}/stories/${storyId}`, {
+  if (apiUrl) {
+    try {
+      const res = await fetch(apiUrl, {
         headers: { Accept: "application/json" },
-        signal: AbortSignal.timeout(3000),
-      }),
-      needsFreshHtml
-        ? fetch(new URL("/index.html", req.url).toString()).then((r) =>
-            r.text()
-          )
-        : Promise.resolve(cachedHtml as string),
-    ]);
-
-    if (!res.ok) return NextResponse.next();
-
-    const story = await res.json();
-
-    if (needsFreshHtml) {
-      cachedHtml = html;
-      cachedHtmlExpiry = now + HTML_CACHE_TTL_MS;
+        signal: AbortSignal.timeout(4_000),
+      });
+      if (res.ok) story = await res.json();
+    } catch {
+      // backend unreachable — serve generic fallback
     }
-
-    const title = story.title ?? "Story Spark AI";
-    const description = (story.content ?? story.description ?? "")
-      .replace(/<[^>]+>/g, "")
-      .slice(0, 160);
-    const image =
-      story.coverImage ??
-      story.imageUrl ??
-      "https://storysparkai.vercel.app/og-default.png";
-    const url = `https://storysparkai.vercel.app${pathname}`;
-
-    const ogTags = `
-    <meta property="og:type"        content="article" />
-    <meta property="og:title"       content="${escapeAttr(title)}" />
-    <meta property="og:description" content="${escapeAttr(description)}" />
-    <meta property="og:image"       content="${escapeAttr(image)}" />
-    <meta property="og:url"         content="${escapeAttr(url)}" />
-    <meta property="og:site_name"   content="Story Spark AI" />
-    <meta name="twitter:card"        content="summary_large_image" />
-    <meta name="twitter:title"       content="${escapeAttr(title)}" />
-    <meta name="twitter:description" content="${escapeAttr(description)}" />
-    <meta name="twitter:image"       content="${escapeAttr(image)}" />
-    <meta name="description"         content="${escapeAttr(description)}" />`;
-
-    const patched = html
-      .replace(/<meta\s+(?:property|name)="(?:og:|twitter:)[^"]*"[^>]*>/gi, "")
-      .replace("</head>", `${ogTags}\n  </head>`);
-
-    return new NextResponse(patched, {
-      headers: {
-        "Content-Type": "text/html; charset=utf-8",
-        "Cache-Control": "public, s-maxage=300, stale-while-revalidate=60",
-      },
-    });
-  } catch {
-    return NextResponse.next();
   }
+
+  const title = story?.title || "Story Spark AI";
+  const description = (story?.content || "")
+    .replace(/<[^>]+>/g, "")
+    .slice(0, 160);
+  const image = story?.imageURL || FALLBACK_OG_IMAGE;
+  const pageUrl = `https://storysparkai.vercel.app${url.pathname}`;
+
+  let html: string;
+
+  const now = Date.now();
+  if (cachedIndexHtml && now < cachedIndexExpiry) {
+    html = cachedIndexHtml;
+  } else {
+    html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Story Spark AI</title>
+  <meta property="og:type" content="article" />
+  <meta name="twitter:card" content="summary_large_image" />
+</head>
+<body>
+  <script>window.location.href = ${JSON.stringify(pageUrl)};</script>
+  <noscript><meta http-equiv="refresh" content="0;url=${pageUrl}" /></noscript>
+</body>
+</html>`;
+    cachedIndexHtml = html;
+    cachedIndexExpiry = now + HTML_CACHE_TTL_MS;
+  }
+
+  const ogTags = [
+    `<meta property="og:title"       content="${escapeAttr(title)}" />`,
+    `<meta property="og:description" content="${escapeAttr(description)}" />`,
+    `<meta property="og:image"       content="${escapeAttr(image)}" />`,
+    `<meta property="og:url"         content="${escapeAttr(pageUrl)}" />`,
+    `<meta name="twitter:title"       content="${escapeAttr(title)}" />`,
+    `<meta name="twitter:description" content="${escapeAttr(description)}" />`,
+    `<meta name="twitter:image"       content="${escapeAttr(image)}" />`,
+    `<meta name="description"         content="${escapeAttr(description)}" />`,
+  ].join("\n    ");
+
+  const patched = html.replace("</head>", `    ${ogTags}\n  </head>`);
+
+  return new Response(patched, {
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+      "Cache-Control": "public, s-maxage=300, stale-while-revalidate=60",
+    },
+  });
 }
 
 function escapeAttr(str: string): string {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -69,10 +69,6 @@
     "@tailwindcss/forms": "^0.5.11",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
- feat/collaboration-1122
-
-    "@tailwindcss/container-queries": "^0.1.1",
- main
     "@types/canvas-confetti": "^1.9.0",
     "@types/d3": "^7.4.3",
     "@types/dompurify": "^3.0.5",

--- a/frontend/src/components/post/StoryMetaTags.tsx
+++ b/frontend/src/components/post/StoryMetaTags.tsx
@@ -1,4 +1,4 @@
-// import { Helmet } from "react-helmet-async";
+import { Helmet } from "react-helmet-async";
 
 interface Props {
   title?: string;
@@ -10,20 +10,21 @@ interface Props {
 export const StoryMetaTags = ({ title, content, imageURL, postId }: Props) => {
   const description = (content || "").slice(0, 150);
   const url = `${window.location.origin}/post/${postId}`;
+  const siteTitle = "Story Spark AI";
+  const pageTitle = title ? `${title} – ${siteTitle}` : siteTitle;
 
   return (
-    // <Helmet>
-    //   <title>{title || "Story Spark AI"}</title>
-    //   <meta property="og:title" content={title || "Story Spark AI"} />
-    //   <meta property="og:description" content={description} />
-    //   <meta property="og:image" content={imageURL || ""} />
-    //   <meta property="og:url" content={url} />
-    //   <meta property="og:type" content="article" />
-    //   <meta name="twitter:card" content="summary_large_image" />
-    //   <meta name="twitter:title" content={title || "Story Spark AI"} />
-    //   <meta name="twitter:description" content={description} />
-    //   <meta name="twitter:image" content={imageURL || ""} />
-    // </Helmet>
-    <></>
+    <Helmet>
+      <title>{pageTitle}</title>
+      <meta property="og:title" content={title || siteTitle} />
+      <meta property="og:description" content={description} />
+      <meta property="og:image" content={imageURL || "https://storysparkai.vercel.app/og-image.jpg"} />
+      <meta property="og:url" content={url} />
+      <meta property="og:type" content="article" />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={title || siteTitle} />
+      <meta name="twitter:description" content={description} />
+      <meta name="twitter:image" content={imageURL || "https://storysparkai.vercel.app/og-image.jpg"} />
+    </Helmet>
   );
 };

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { Provider } from "react-redux";
+import { HelmetProvider } from "react-helmet-async";
 import { GoogleOAuthProvider } from "@react-oauth/google";
 import App from "./App.tsx";
 import { store } from "./redux/store.ts";
@@ -24,12 +25,14 @@ if (!container) {
 
 createRoot(container).render(
   <StrictMode>
-    <GoogleOAuthProvider clientId={GOOGLE_CLIENT_ID || "dummy-client-id"}>
-      <Provider store={store}>
-        <ThemeProvider>
-          <App />
-        </ThemeProvider>
-      </Provider>
-    </GoogleOAuthProvider>
+    <HelmetProvider>
+      <GoogleOAuthProvider clientId={GOOGLE_CLIENT_ID || "dummy-client-id"}>
+        <Provider store={store}>
+          <ThemeProvider>
+            <App />
+          </ThemeProvider>
+        </Provider>
+      </GoogleOAuthProvider>
+    </HelmetProvider>
   </StrictMode>
 );

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,20 +1,6 @@
 {
   "rewrites": [
-    {
-      "source": "/post/:id",
-      "has": [
-        {
-          "type": "header",
-          "key": "user-agent",
-          "value": ".*(Twitterbot|LinkedInBot|WhatsApp|Slackbot|Discordbot|facebookexternalhit).*"
-        }
-      ],
-      "destination": "https://your-backend-url.com/api/post/meta/:id"
-    },
-    {
-      "source": "/(.*)",
-      "destination": "/"
-    }
+    { "source": "/(.*)", "destination": "/" }
   ],
   "headers": [
     {


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Open or link a related issue when there is one (`Closes #123`, `Fixes #45`, or write **None** under Related issue below).
- **Description:** Fill in **What this PR does** so a reviewer can understand the change without your local context.
- **Screenshots:** Add screenshots or a short recording when they help (UI changes, confusing flows, or non-code proof). If not needed, say so in the checklist.

## Screenshot (when helpful)

<!-- Drag & drop or paste. For non-UI work, you can use tests output, logs, or API responses. Write "N/A" in the checklist if you skip this section. -->

N/A — server-side change, no UI to capture.

## What this PR does

<!-- Short summary: what problem does this solve, and how? -->

Shared story URLs (`/post/:id`) show no social preview because the Vite SPA returns the same static `index.html` for all routes. Social crawlers (Twitterbot, Facebook, LinkedIn, Discord, WhatsApp, Slack) don't execute JavaScript, so client-side Helmet tags are invisible to them.

**Fix (two layers):**

1. **Vercel Edge Middleware** (`frontend/middleware.ts`) — intercepts `/post/:id` requests from known crawler User-Agents, fetches story data from the backend API, and returns a full HTML document with `og:title`, `og:description`, `og:image`, `twitter:*` tags baked into the server response. Non-crawlers pass through to the SPA. Configurable via `API_BASE_URL` env var.

2. **react-helmet-async** (`StoryMetaTags.tsx` + `main.tsx`) — sets the same tags client-side for real users browsing in a browser (document title, share-sheet metadata, JavaScript-rendered previews).

Also removed the broken `vercel.json` crawler rewrite that pointed to an unset placeholder URL, and fixed a merge-conflict artifact in `frontend/package.json`.

## Type of change

Check all that apply (if more than one, explain in "What this PR does").

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

<!-- Example: Closes #123 or Fixes #45. Use "None" if there is no issue. -->

Closes #2656

## More screenshots (optional)

<!-- Extra before/after images, flows, or recordings for reviewers. -->



## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
