### PR TITLE
fix(backend): Patch Application-Level DoS via unbounded N+1 query loop in story versions

### DIFF
--- a/backend/src/app/modules/story_version/story_version.service.ts
+++ b/backend/src/app/modules/story_version/story_version.service.ts
@@ -109,6 +109,13 @@ const createBranchVersion = async (
     );
   }
 
+  if ((parentVersion.branchDepth ?? 0) >= 100) {
+    throw new ApiError(
+      httpStatus.BAD_REQUEST,
+      "Maximum branch depth (100) reached. Cannot create deeper branches."
+    );
+  }
+
   const latestVersion = await StoryVersion.findOne({
     storyId: parentVersion.storyId,
   })
@@ -202,18 +209,31 @@ const getBranchPath = async (
     );
   }
 
-  const path: IStoryVersion[] = [];
-  let current: IStoryVersion | null = version;
+  // Defend against N+1 query DoS using an optimized aggregation pipeline
+  const aggregated = await StoryVersion.aggregate([
+    { $match: { _id: version._id } },
+    {
+      $graphLookup: {
+        from: "storyversions",
+        startWith: "$parentVersionId",
+        connectFromField: "parentVersionId",
+        connectToField: "_id",
+        as: "ancestors",
+        maxDepth: 100, // Hard limit on graph depth
+      },
+    },
+  ]);
 
-  while (current) {
-    path.unshift(current);
-    if (!current.parentVersionId) {
-      break;
-    }
-    current = await StoryVersion.findById(current.parentVersionId);
+  if (!aggregated || aggregated.length === 0) {
+    return [version];
   }
 
-  return path;
+  const ancestors: IStoryVersion[] = aggregated[0].ancestors || [];
+  
+  // Sort ancestors by branchDepth (root downwards)
+  ancestors.sort((a, b) => (a.branchDepth || 0) - (b.branchDepth || 0));
+
+  return [...ancestors, version];
 };
 
 const getVersionsByStoryId = async (


### PR DESCRIPTION
Fix: #4780 

**Description:**

**What this PR does:**
This PR patches a critical Denial of Service (DoS) vector inside the Story Versioning service (`story_version.service.ts`) where a maliciously deep story branch tree could exhaust the MongoDB connection pool and crash the Node.js event loop due to unbounded N+1 sequential database queries.

**Why it's needed:**
Previously, `getBranchPath` fetched a story's hierarchical path by iterating upwards through the version tree using a `while` loop, executing a synchronous `findById` query on every iteration:
```typescript
while (current) {
  // ...
  current = await StoryVersion.findById(current.parentVersionId);
}
```
Because `createBranchVersion` did not restrict how deep a user could branch, an attacker could artificially generate a story branch with a depth of 10,000+. Requesting the path for that branch would force the backend to execute 10,000 sequential blocking database queries on a single request thread, triggering an Application-Level DoS.

**Changes made:**
- **Added Depth Limit:** `createBranchVersion` now enforces a strict upper limit on graph depth (`MAX_BRANCH_DEPTH` = 100). If a user attempts to create a branch deeper than 100, the server safely responds with a `400 Bad Request`.
- **Replaced N+1 with Aggregation:** Refactored `getBranchPath` to replace the unbounded `while` loop with a single, optimized MongoDB `$graphLookup` aggregation pipeline. This recursively fetches the entire path in one go, dramatically improving database performance and completely neutralizing the N+1 query vulnerability.

**Checklist:**
- [x] I have read the contribution guidelines.
- [x] I have tested the changes locally.
- [x] My code follows the project's style guidelines.
@ronisarkarexe  please check it