### PR TITLE
BUG: Unresolved merge conflict markers in frontend/package.json break pnpm install

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -69,10 +69,6 @@
     "@tailwindcss/forms": "^0.5.11",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
- feat/collaboration-1122
-
-    "@tailwindcss/container-queries": "^0.1.1",
- main
     "@types/canvas-confetti": "^1.9.0",
     "@types/d3": "^7.4.3",
     "@types/dompurify": "^3.0.5",


### PR DESCRIPTION
## Before you open this PR
- **Issue:** Fixes #4643 
- **Description:** Filled below.
- **Screenshots:** N/A — config fix, verified via terminal output below.

## Screenshot (when helpful)
N/A. Verification via terminal:

Before fix:
ERR_PNPM_JSON_PARSE  Expected double-quoted property name in JSON at position 2069 (line 72 column 2) while parsing frontend/package.json

After fix:
Get-Content package.json | ConvertFrom-Json | Out-Null   -> no errors
pnpm install                                              -> completes successfully

## What this PR does
Leftover branch markers (`feat/collaboration-1122`, `main`) and a duplicate `@tailwindcss/container-queries` entry were committed to `package.json`, breaking JSON parsing and blocking `pnpm install` for all contributors.

This PR removes the two stray branch-marker lines and the duplicate dependency entry from the `devDependencies` block, restoring valid JSON. No dependency versions were changed — this is purely a syntax/structure fix.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue
Fixes #4643 

## More screenshots (optional)
N/A

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.