### PR TITLE
fix : removed corrupted merge artifacts from frontend/package.json

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -69,10 +69,6 @@
     "@tailwindcss/forms": "^0.5.11",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
- feat/collaboration-1122
-
-    "@tailwindcss/container-queries": "^0.1.1",
- main
     "@types/canvas-confetti": "^1.9.0",
     "@types/d3": "^7.4.3",
     "@types/dompurify": "^3.0.5",


### PR DESCRIPTION
Closes #4794.

Summary of What Has Been Done:
Removed three malformed lines from the devDependencies section of frontend/package.json: a bare orphan string 'feat/collaboration-1122', a duplicate @tailwindcss/container-queries entry, and a bare orphan string 'main'. These were causing pnpm install to fail with JSON parse errors, blocking all CI jobs in the repository.

Changes Made:
- frontend/package.json: Removed the three corrupt entries. Retained one valid @tailwindcss/container-queries entry.

Impact it Made:
- Restores JSON validity so pnpm install succeeds in CI.
- Unblocks lint, typecheck, and build workflows for all frontend PRs.

Note: Please assign this PR to the `tmdeveloper007` account.