### PR TITLE
Fix #4621: Add dynamic social media previews and client-side tab titles

### DIFF
--- a/frontend/api/og-injector.ts
+++ b/frontend/api/og-injector.ts
@@ -1,0 +1,36 @@
+import { VercelRequest, VercelResponse } from '@vercel/node';
+import fs from 'fs';
+import path from 'path';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const { id } = req.query;
+  const API_BASE = process.env.VITE_API_URL || process.env.API_URL || 'http://localhost:5000';
+
+  try {
+    const apiResponse = await fetch(`${API_BASE}/api/stories/${id}`);
+    if (!apiResponse.ok) throw new Error('Story not found');
+    const story = await apiResponse.json();
+
+    const filePath = path.resolve(process.cwd(), 'dist', 'index.html');
+    let html = fs.readFileSync(filePath, 'utf8');
+
+    const title = story?.title || 'Story Spark AI';
+    const description = story?.content ? `${story.content.substring(0, 160)}...` : 'Ignite your imagination.';
+    const image = story?.coverImage || 'https://storysparkai.vercel.app/og-image.jpg';
+    const url = `https://storysparkai.vercel.app/story/${id}`;
+
+    html = html
+      .replace(/<title>.*?<\/title>/, `<title>${title} | Story Spark AI</title>`)
+      .replace(/<meta property="og:title" content=".*?" \/>/, `<meta property="og:title" content="${title}" />`)
+      .replace(/<meta property="og:description" content=".*?" \/>/, `<meta property="og:description" content="${description}" />`)
+      .replace(/<meta property="og:image" content=".*?" \/>/, `<meta property="og:image" content="${image}" />`)
+      .replace(/<meta property="og:url" content=".*?" \/>/, `<meta property="og:url" content="${url}" />`);
+
+    res.setHeader('Content-Type', 'text/html');
+    res.setHeader('Cache-Control', 's-maxage=300, stale-while-revalidate'); 
+    return res.status(200).send(html);
+  } catch (error) {
+    const filePath = path.resolve(process.cwd(), 'dist', 'index.html');
+    return res.status(200).send(fs.readFileSync(filePath, 'utf8'));
+  }
+}

--- a/frontend/api/og-injector.ts
+++ b/frontend/api/og-injector.ts
@@ -2,34 +2,67 @@ import { VercelRequest, VercelResponse } from '@vercel/node';
 import fs from 'fs';
 import path from 'path';
 
+// Helper function to patch Reflected XSS vulnerabilities without adding heavy dependencies
+function escapeHtml(unsafe: string): string {
+  return unsafe.replace(/[&<>"']/g, (match) => {
+    switch (match) {
+      case '&': return '&amp;';
+      case '<': return '&lt;';
+      case '>': return '&gt;';
+      case '"': return '&quot;';
+      case "'": return '&#39;';
+      default: return match;
+    }
+  });
+}
+
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   const { id } = req.query;
+  const idStr = Array.isArray(id) ? id[0] : id;
+
+  // 1. Fix SSRF: Validate input format strictly before using it in a fetch call
+  if (!idStr || !/^[a-zA-Z0-9_-]+$/.test(idStr)) {
+    console.error(`Rejected invalid or malicious ID pattern: ${idStr}`);
+    // Safe fallback: serve unmodified index.html
+    const filePath = path.resolve(process.cwd(), 'dist', 'index.html');
+    return res.status(200).send(fs.readFileSync(filePath, 'utf8'));
+  }
+
   const API_BASE = process.env.VITE_API_URL || process.env.API_URL || 'http://localhost:5000';
 
   try {
-    const apiResponse = await fetch(`${API_BASE}/api/stories/${id}`);
-    if (!apiResponse.ok) throw new Error('Story not found');
+    const apiResponse = await fetch(`${API_BASE}/api/stories/${idStr}`);
+    if (!apiResponse.ok) throw new Error(`Backend returned status ${apiResponse.status}`);
     const story = await apiResponse.json();
 
     const filePath = path.resolve(process.cwd(), 'dist', 'index.html');
     let html = fs.readFileSync(filePath, 'utf8');
 
-    const title = story?.title || 'Story Spark AI';
-    const description = story?.content ? `${story.content.substring(0, 160)}...` : 'Ignite your imagination.';
-    const image = story?.coverImage || 'https://storysparkai.vercel.app/og-image.jpg';
-    const url = `https://storysparkai.vercel.app/story/${id}`;
+    // 2. Fix XSS: Escape raw backend data before string substitution
+    const title = escapeHtml(story?.title || 'Story Spark AI');
+    const description = escapeHtml(
+      story?.content ? `${story.content.substring(0, 160)}...` : 'Ignite your imagination with powerful AI-driven storytelling tools.'
+    );
+    const image = escapeHtml(story?.coverImage || 'https://storysparkai.vercel.app/og-image.jpg');
+    const url = escapeHtml(`https://storysparkai.vercel.app/story/${idStr}`);
 
+    // Replace default Open Graph and Twitter tags safely
     html = html
       .replace(/<title>.*?<\/title>/, `<title>${title} | Story Spark AI</title>`)
       .replace(/<meta property="og:title" content=".*?" \/>/, `<meta property="og:title" content="${title}" />`)
       .replace(/<meta property="og:description" content=".*?" \/>/, `<meta property="og:description" content="${description}" />`)
       .replace(/<meta property="og:image" content=".*?" \/>/, `<meta property="og:image" content="${image}" />`)
-      .replace(/<meta property="og:url" content=".*?" \/>/, `<meta property="og:url" content="${url}" />`);
+      .replace(/<meta property="og:url" content=".*?" \/>/, `<meta property="og:url" content="${url}" />`)
+      .replace(/<meta name="twitter:title" content=".*?" \/>/, `<meta name="twitter:title" content="${title}" />`)
+      .replace(/<meta name="twitter:description" content=".*?" \/>/, `<meta name="twitter:description" content="${description}" />`)
+      .replace(/<meta name="twitter:image" content=".*?">/, `<meta name="twitter:image" content="${image}">`);
 
     res.setHeader('Content-Type', 'text/html');
-    res.setHeader('Cache-Control', 's-maxage=300, stale-while-revalidate'); 
+    res.setHeader('Cache-Control', 's-maxage=60, stale-while-revalidate'); // Lowered to 60s for fresher story updates
     return res.status(200).send(html);
+
   } catch (error) {
+    console.error('OG Injection failed:', error);
     const filePath = path.resolve(process.cwd(), 'dist', 'index.html');
     return res.status(200).send(fs.readFileSync(filePath, 'utf8'));
   }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -38,8 +38,7 @@
     <meta name="twitter:title" content="Story Spark AI" />
     <meta name="twitter:description" content="Ignite your imagination with powerful AI-driven storytelling tools." />
     <meta name="twitter:image" content="https://storysparkai.vercel.app/og-image.jpg">
->
-    <link rel="icon" hr`ef="/favicon.ico" sizes="any" />
+    <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { Provider } from "react-redux";
+import { HelmetProvider } from "react-helmet-async";
 import { GoogleOAuthProvider } from "@react-oauth/google";
 import App from "./App.tsx";
 import { store } from "./redux/store.ts";

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -8,7 +8,6 @@ import { store } from "./redux/store.ts";
 import { ThemeProvider } from "./components/theme/theme.context";
 import "./index.css";
 
-
 const GOOGLE_CLIENT_ID = (import.meta.env.VITE_GOOGLE_CLIENT_ID || "").trim();
 
 if (!GOOGLE_CLIENT_ID) {
@@ -25,12 +24,14 @@ if (!container) {
 
 createRoot(container).render(
   <StrictMode>
-    <GoogleOAuthProvider clientId={GOOGLE_CLIENT_ID || "dummy-client-id"}>
-      <Provider store={store}>
-        <ThemeProvider>
-          <App />
-        </ThemeProvider>
-      </Provider>
-    </GoogleOAuthProvider>
+    <HelmetProvider>
+      <GoogleOAuthProvider clientId={GOOGLE_CLIENT_ID || "dummy-client-id"}>
+        <Provider store={store}>
+          <ThemeProvider>
+            <App />
+          </ThemeProvider>
+        </Provider>
+      </GoogleOAuthProvider>
+    </HelmetProvider>
   </StrictMode>
 );

--- a/frontend/src/pages/analytics/StoryPage.jsx
+++ b/frontend/src/pages/analytics/StoryPage.jsx
@@ -1,10 +1,23 @@
+import { Helmet } from 'react-helmet-async';
 import { useCollaboration } from '../hooks/useCollaboration';
 
 export default function StoryPage({ storyId }) {
   const { content, users, sendUpdate } = useCollaboration(storyId);
 
+  // Derive a short preview for the description and title
+  const storyTitle = content ? content.split('\n')[0].substring(0, 40) : "Loading Story...";
+  const storyDescription = content ? `${content.substring(0, 120)}...` : "Collaborate on this story in real-time.";
+
   return (
     <div>
+      {/* Dynamic document head metadata for active users */}
+      <Helmet>
+        <title>{storyTitle} | Story Spark AI</title>
+        <meta property="og:title" content={storyTitle} />
+        <meta property="og:description" content={storyDescription} />
+        <meta property="og:url" content={`https://storysparkai.vercel.app/story/${storyId}`} />
+      </Helmet>
+
       <div className="flex justify-between">
         <h1>Story</h1>
         <div>{users.length} users online</div>

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,7 +1,7 @@
 {
   "rewrites": [
     {
-      "source": "/post/:id",
+      "source": "/story/:id",
       "has": [
         {
           "type": "header",
@@ -9,7 +9,7 @@
           "value": ".*(Twitterbot|LinkedInBot|WhatsApp|Slackbot|Discordbot|facebookexternalhit).*"
         }
       ],
-      "destination": "https://your-backend-url.com/api/post/meta/:id"
+      "destination": "/api/og-injector?id=:id"
     },
     {
       "source": "/(.*)",


### PR DESCRIPTION
Closes #4621 

What this PR does
This PR fixes the classic SPA issue where social media platforms (WhatsApp, Discord, Twitter) scrape a blank/default preview for specific story URLs because they do not execute JavaScript. It also resolves client-side title updates for normal site visitors.

Key implementations:

Vercel Serverless Function (api/og-injector.ts): Intercepts bot traffic (identified by user-agent in vercel.json) on /story/:id routes. It fetches the specific story data from the backend API, dynamically injects the correct Open Graph/Twitter tags into the built index.html, and serves it to the crawler.

Client-Side Meta Tags (react-helmet-async): Wrapped the app in <HelmetProvider> (main.tsx) and added <Helmet> to the StoryPage.jsx component so standard users get dynamic browser tab titles and meta updates while navigating the SPA.

HTML Fix: Corrected a rogue backtick typo in the favicon <link> tag within index.html.

Type of change
Check all that apply (if more than one, explain in “What this PR does”).

[x] Bug fix

[ ] New feature

[ ] Code refactor

[ ] Documentation update

Related issue
Closes #4621

Checklist
[x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason. (N/A - Meta tag and serverless routing changes only)

[x] I have filled in the related issue number when there is one.

[x] I have tested my changes.

[x] I have done a self-review of the code.