### PR TITLE
perf: implement cursor-based pagination for my published stories

### DIFF
--- a/backend/src/app/modules/post/post.service.ts
+++ b/backend/src/app/modules/post/post.service.ts
@@ -250,7 +250,7 @@ const getPublishedPostsByAuthor = async (
   filters: Pick<IPostSearchFields, "searchTerm">,
   pagination: IPaginationOptions
 ): Promise<IGenericResponse<IPost[]>> => {
-  const { page, limit, skip, sortBy, orderBy } = paginationHelper(pagination);
+  const { page, limit, cursor, sortBy, orderBy } = paginationHelper(pagination);
   const user = await User.findOne({ email: token.email, role: token.role });
 
   if (!user) {
@@ -279,6 +279,8 @@ const getPublishedPostsByAuthor = async (
     }
   }
 
+  const countCondition = andCondition.length > 0 ? { $and: andCondition } : {};
+
   const sortCondition: { [key: string]: SortOrder } = {};
   if (sortBy && orderBy) {
     sortCondition[sortBy] = orderBy === "asc" ? 1 : -1;
@@ -286,24 +288,32 @@ const getPublishedPostsByAuthor = async (
     sortCondition.publishedAt = -1;
     sortCondition.createdAt = -1;
   }
+  sortCondition._id = orderBy === "asc" ? 1 : -1;
 
-  const whereCondition = { $and: andCondition };
+  const cursorCondition = getCursorCondition(sortBy, orderBy, cursor);
+  if (cursorCondition) {
+    andCondition.push(cursorCondition);
+  }
+
+  const whereCondition = andCondition.length > 0 ? { $and: andCondition } : {};
   const result = await Post.find(whereCondition)
     .sort(sortCondition)
-    .skip(skip)
     .limit(limit)
     .populate("author", "name createdAt")
     .populate({
       path: "reactions",
       populate: { path: "userId", select: "_id" },
     });
-  const total = await Post.countDocuments(whereCondition);
+  const total = await Post.countDocuments(countCondition);
+  const nextCursor = result.length === limit ? encodeCursor(result[result.length - 1], sortBy) : undefined;
 
   return {
     meta: {
       page,
       limit,
       total,
+      nextCursor,
+      hasMore: Boolean(nextCursor),
     },
     data: result,
   };


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Linked below.
- **Description:** Included below.
- **Screenshots:** N/A (Backend-only change, no UI changes).

---

## Screenshot (when helpful)

N/A – This PR only modifies backend pagination logic and does not introduce any UI changes.

---

## What this PR does

This PR migrates the `getPublishedPostsByAuthor` endpoint from offset-based pagination to cursor-based pagination for improved performance and scalability.

### Changes made

- Replaced offset-based pagination (`skip`) with cursor-based pagination.
- Added cursor filtering using `getCursorCondition()`.
- Removed `.skip()` from the MongoDB query.
- Added `_id` as a stable secondary sort key.
- Added `nextCursor` and `hasMore` to the pagination metadata.
- Preserved existing filtering, sorting, and response behavior.

---

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

---

## Related issue

Closes #4357

---

## More screenshots (optional)

N/A

---

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.