### PR TITLE
fix: remove merge conflict artifacts from frontend package.json (#4797)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -69,10 +69,6 @@
     "@tailwindcss/forms": "^0.5.11",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
- feat/collaboration-1122
-
-    "@tailwindcss/container-queries": "^0.1.1",
- main
     "@types/canvas-confetti": "^1.9.0",
     "@types/d3": "^7.4.3",
     "@types/dompurify": "^3.0.5",


### PR DESCRIPTION
## Screenshot
N/A — JSON file fix with no visual output.

## What this PR does
Fixes #4797 — frontend/package.json had leftover git merge conflict 
markers from the feat/collaboration-1122 branch merge, making it 
invalid JSON and breaking all CI builds and fresh installs.

Removed the three broken lines:
  feat/collaboration-1122
  "@tailwindcss/container-queries": "^0.1.1",  (duplicate)
  main

## Type of change
- [x] Bug fix

## Related issue
Fixes #4797

## Checklist
- [x] Noted N/A for screenshots with reason
- [x] Filled in related issue number
- [x] Tested my changes
- [x] Self-reviewed the code

Contributing under GSSoC'26 