### PR TITLE
test: add unit tests for rate limit middleware

### DIFF
--- a/backend/src/app/middleware/__tests__/rateLimit.middleware.test.ts
+++ b/backend/src/app/middleware/__tests__/rateLimit.middleware.test.ts
@@ -1,0 +1,79 @@
+import express, { Express, Request, Response } from "express";
+import request from "supertest";
+import { searchRateLimiter, apiRateLimiter } from "../rateLimit.middleware";
+
+function buildApp(limiter: express.RequestHandler): Express {
+  const app = express();
+  app.use(limiter);
+  app.get("/test", (_req: Request, res: Response) => {
+    res.status(200).json({ ok: true });
+  });
+  return app;
+}
+
+describe("searchRateLimiter", () => {
+  let app: Express;
+
+  beforeEach(() => {
+    app = buildApp(searchRateLimiter);
+  });
+
+  it("allows a request within the limit and sets standard rate-limit headers", async () => {
+    const res = await request(app).get("/test");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["ratelimit-limit"]).toBe("30");
+    expect(res.headers["ratelimit-remaining"]).toBeDefined();
+    // legacyHeaders is false, so X-RateLimit-* should NOT be present
+    expect(res.headers["x-ratelimit-limit"]).toBeUndefined();
+  });
+
+  it("blocks the 31st request from the same IP within the 1-minute window", async () => {
+    for (let i = 0; i < 30; i++) {
+      await request(app).get("/test");
+    }
+    const res = await request(app).get("/test");
+
+    expect(res.status).toBe(429);
+    expect(res.text).toContain("Too many search requests");
+  });
+
+  it("uses the first IP in x-forwarded-for as the rate limit key", async () => {
+    const forwardedIp = "203.0.113.5, 70.41.3.18";
+
+    for (let i = 0; i < 30; i++) {
+      await request(app).get("/test").set("x-forwarded-for", forwardedIp);
+    }
+    const blocked = await request(app).get("/test").set("x-forwarded-for", forwardedIp);
+    expect(blocked.status).toBe(429);
+
+    // A different forwarded IP should have its own separate limit
+    const allowed = await request(app).get("/test").set("x-forwarded-for", "198.51.100.7");
+    expect(allowed.status).toBe(200);
+  });
+});
+
+describe("apiRateLimiter", () => {
+  let app: Express;
+
+  beforeEach(() => {
+    app = buildApp(apiRateLimiter);
+  });
+
+  it("allows a request within the limit and sets standard rate-limit headers", async () => {
+    const res = await request(app).get("/test");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["ratelimit-limit"]).toBe("100");
+  });
+
+  it("blocks the 101st request from the same IP within the 15-minute window", async () => {
+    for (let i = 0; i < 100; i++) {
+      await request(app).get("/test");
+    }
+    const res = await request(app).get("/test");
+
+    expect(res.status).toBe(429);
+    expect(res.text).toContain("Too many requests from this IP");
+  }, 20000); // longer timeout since 100 sequential requests take time
+});


### PR DESCRIPTION
## Description
Adds unit tests for the rate limiting middleware (`rateLimit.middleware.ts`), which currently has no test coverage. Tests cover both `searchRateLimiter` and `apiRateLimiter`, verifying request limits, rate-limit headers, and IP resolution via `x-forwarded-for`.

## Changes Made
- Added `backend/src/app/middleware/__tests__/rateLimit.middleware.test.ts`
- Used `supertest` to send real HTTP requests through an Express app wrapping each limiter (mocked req/res isn't reliable here since `express-rate-limit` maintains its own internal store)
- Added `supertest` and `@types/supertest` as dev dependencies

## Test Coverage
**searchRateLimiter (30 req/min)**
- Allows requests within the limit and sets `RateLimit-Limit` / `RateLimit-Remaining` headers
- Blocks the 31st request in the same window with a 429 and the expected message
- Correctly keys requests by the first IP in `x-forwarded-for`, so different forwarded IPs get independent limits

**apiRateLimiter (100 req / 15 min)**
- Allows requests within the limit and sets the correct `RateLimit-Limit` header
- Blocks the 101st request in the same window with a 429 and the expected message

## How to Test
```bash
npm install
npm test -- rateLimit.middleware.test.ts
```

Closes #4430