### PR TITLE
fix: resolve undefined variable ReferenceErrors in StoryGenerator.tsx

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -69,10 +69,6 @@
     "@tailwindcss/forms": "^0.5.11",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
- feat/collaboration-1122
-
-    "@tailwindcss/container-queries": "^0.1.1",
- main
     "@types/canvas-confetti": "^1.9.0",
     "@types/d3": "^7.4.3",
     "@types/dompurify": "^3.0.5",

--- a/frontend/src/components/StoryGenerator.tsx
+++ b/frontend/src/components/StoryGenerator.tsx
@@ -16,8 +16,11 @@ export const StoryGenerator: React.FC<StoryGeneratorProps> = ({ onStoryGenerated
   const [stories, setStories] = useState<any[]>([]);
   const [error, setError] = useState<string | null>(null);
 
-  const abortContollerRef = useRef<AbortController | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
   const handleGenerate = async () => {
+
+    const trimmedPrompt = prompt.trim();
+    const promptLength = trimmedPrompt.length;
     if (!trimmedPrompt) {
       setError('Please enter a story prompt.');
       return;
@@ -37,7 +40,7 @@ export const StoryGenerator: React.FC<StoryGeneratorProps> = ({ onStoryGenerated
     setIsLoading(true);
 
     abortControllerRef.current = new AbortController();
-    const timeoutld = setTimeout(() => {
+    const timeoutId = setTimeout(() => {
       abortControllerRef.current?.abort();
       }, 15000);                                             //timeout after 15 seconds
 
@@ -46,9 +49,9 @@ export const StoryGenerator: React.FC<StoryGeneratorProps> = ({ onStoryGenerated
         prompt: trimmedPrompt,
         variations: variationCount,
       }, {
-        signal: abortControlerRef.current.signal,
+        signal: abortControllerRef.current.signal,
       });
-      clearTimeout(timeoutld);
+      clearTimeout(timeoutId);
 
       if (response?.data?.variations) {
         setStories(response.data.variations);

--- a/frontend/src/components/StoryGenerator.tsx
+++ b/frontend/src/components/StoryGenerator.tsx
@@ -16,11 +16,16 @@ export const StoryGenerator: React.FC<StoryGeneratorProps> = ({ onStoryGenerated
   const [stories, setStories] = useState<any[]>([]);
   const [error, setError] = useState<string | null>(null);
 
+  // Derived values used both in JSX and inside handleGenerate
+  const trimmedPrompt = prompt.trim();
+  const promptLength = trimmedPrompt.length;
+  const isPromptInvalid =
+    promptLength < MIN_PROMPT_LENGTH || promptLength > MAX_PROMPT_LENGTH;
+
   const abortControllerRef = useRef<AbortController | null>(null);
   const handleGenerate = async () => {
 
-    const trimmedPrompt = prompt.trim();
-    const promptLength = trimmedPrompt.length;
+    // trimmedPrompt and promptLength are already derived at component scope above
     if (!trimmedPrompt) {
       setError('Please enter a story prompt.');
       return;


### PR DESCRIPTION
## Summary

Fixes **#4835** — Typos/undefined variables in `StoryGenerator.tsx` that cause runtime `ReferenceError`.

## Root Cause

Two variables were used in the JSX render output but were either:
- **Defined only inside `handleGenerate()`** (local scope, invisible to the render): `promptLength`, `trimmedPrompt`
- **Never defined at all**: `isPromptInvalid`

This caused a `ReferenceError` on **every render**, making the character counter and the Generate button completely broken.

## Changes Made

**`frontend/src/components/StoryGenerator.tsx`**

- Moved `trimmedPrompt` and `promptLength` from inside `handleGenerate()` to **component scope** (derived from the `prompt` state), so they are accessible in JSX
- Added `isPromptInvalid` as a **derived boolean** at component scope:
  ```ts
  const trimmedPrompt = prompt.trim();
  const promptLength = trimmedPrompt.length;
  const isPromptInvalid =
    promptLength < MIN_PROMPT_LENGTH || promptLength > MAX_PROMPT_LENGTH;
  ```
- `handleGenerate()` now reuses these component-scope values (no duplicate logic)

## Testing

- [ ] Verified character counter updates correctly as user types
- [ ] Verified Generate button is properly disabled when prompt is too short or too long
- [ ] Verified story generation works end-to-end with a valid prompt
- [ ] No `ReferenceError` in browser console

## Related

Closes #4835