### PR TITLE
docs: link Feature Documentation section and undocumented root-level docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 ## 📚 Table of Contents
 - [About 🚀](#about-)
 - [Features 💪](#features-)
+- [Feature Documentation 📄](#feature-documentation-)
 - [Known Behavior & UX Notes](#known-behavior--ux-notes-)
 - [Local Development](#local-development-monorepo)
 - [Environment Variables](#environment-variables)
@@ -58,6 +59,8 @@
 
 - **AI-Powered Story Generation**: Create unique stories instantly using advanced AI models.
 - **Prompt-Based Storytelling**: Provide a prompt and watch it come to life.
+- **AI Prompt Enhancement & Creativity Score System**: Automatically refines user prompts and scores generated stories for creativity — see [Feature Documentation](#feature-documentation-) for details.
+- **Story Comparison & Diff Visualization**: Compare story variations side-by-side and see exactly how they differ — see [Feature Documentation](#feature-documentation-) for details.
 - **Story Bookmarks & History**: Save and revisit your favorite creations.
 - **AI Analysis**: Get summaries, critiques, and insights on your stories.
 - **Creative Writing Assistance**: Overcome writer's block with intelligent suggestions.
@@ -67,6 +70,24 @@
 - **User Reviews**: Share your experience and explore reviews from the community.
 - **Subscription Plans**: Access unlimited story generation and team collaboration with paid plans.
 - **Featured Posts**: Discover featured posts curated from the community.
+
+---
+
+## Feature Documentation 📄
+
+Some features have dedicated, deeper-dive documentation beyond this README. Start here if you want implementation details, checklists, or a quick-start for a specific system:
+
+| Feature | Docs |
+|---------|------|
+| AI Prompt Enhancement & Creativity Score System | [AI_PROMPT_ENHANCEMENT_COMPLETE.md](./AI_PROMPT_ENHANCEMENT_COMPLETE.md) · [QUICK_START.md](./QUICK_START.md) · [FEATURE_IMPLEMENTATION_CHECKLIST.md](./FEATURE_IMPLEMENTATION_CHECKLIST.md) · [FILE_MANIFEST.md](./FILE_MANIFEST.md) |
+| Story Comparison & Diff Visualization | [STORY_COMPARISON_IMPLEMENTATION.md](./STORY_COMPARISON_IMPLEMENTATION.md) · [COMPARISON_QUICK_REFERENCE.md](./COMPARISON_QUICK_REFERENCE.md) |
+| System Architecture | [ARCHITECTURE.md](./ARCHITECTURE.md) |
+| Local Setup & Onboarding | [DEVELOPMENT.md](./DEVELOPMENT.md) · [SETUP.md](./SETUP.md) |
+| Password Visibility & Accessibility | [PASSWORD_VISIBILITY_ACCESSIBILITY.md](./PASSWORD_VISIBILITY_ACCESSIBILITY.md) · [PASSWORD_VISIBILITY_CODE_REFERENCE.md](./PASSWORD_VISIBILITY_CODE_REFERENCE.md) |
+| Security Policy | [SECURITY.md](./SECURITY.md) |
+| Version History | [CHANGELOG.md](./CHANGELOG.md) |
+
+> 💡 If you add a new standalone doc file to the repo root, please add a row here so it stays discoverable.
 
 ---
 


### PR DESCRIPTION
## What
Adds a new **Feature Documentation** section to `README.md` and links it 
from the Table of Contents and Features list.

## Why
Several substantial docs at the repo root weren't referenced anywhere in 
the README, making them undiscoverable for new contributors:

- `AI_PROMPT_ENHANCEMENT_COMPLETE.md`
- `QUICK_START.md`
- `FEATURE_IMPLEMENTATION_CHECKLIST.md`
- `FILE_MANIFEST.md`
- `STORY_COMPARISON_IMPLEMENTATION.md`
- `COMPARISON_QUICK_REFERENCE.md`

The Features list also didn't mention the AI Prompt Enhancement & 
Creativity Score System or the Story Comparison/Diff feature at all, 
despite both having dedicated implementation docs.

Closes #4843

## Changes
- Added **AI Prompt Enhancement & Creativity Score System** and 
  **Story Comparison & Diff Visualization** bullets to Features, each 
  linking to the new docs section
- Added a **Feature Documentation** table mapping each feature to its 
  existing markdown docs (also includes Architecture, Setup, Security, 
  and Changelog for completeness)
- Updated the Table of Contents to include the new section
- No changes to setup instructions, env vars, or troubleshooting content

## Screenshots / Preview
N/A — docs-only change, renders as standard GitHub markdown.

## Checklist
- [x] Verified all linked files exist at the paths referenced
- [x] No code changes, no build impact
- [x] Table of Contents anchors match new section heading