### PR TITLE
feat : added getPostEngagementStats static helper to Post model

### DIFF
--- a/backend/src/app/modules/post/__tests__/post.model.test.ts
+++ b/backend/src/app/modules/post/__tests__/post.model.test.ts
@@ -1,0 +1,81 @@
+import { Types } from "mongoose";
+import { Post } from "../post.model";
+
+jest.mock("../../post/post.model", () => {
+  const actual = jest.requireActual("../../post/post.model");
+  return {
+    ...actual,
+    Post: {
+      findById: jest.fn(),
+    },
+  };
+});
+
+const mockedPost = Post as unknown as {
+  findById: jest.Mock;
+};
+
+describe("PostModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("getEngagementStats", () => {
+    it("returns null when post is not found", async () => {
+      const postId = new Types.ObjectId();
+      mockedPost.findById.mockReturnValue({
+        lean: jest.fn().mockResolvedValue(null),
+      });
+
+      const result = await Post.getEngagementStats(postId);
+      expect(result).toBeNull();
+    });
+
+    it("returns engagement stats when post exists", async () => {
+      const postId = new Types.ObjectId();
+      const fakeStats = {
+        likesCount: 42,
+        commentsCount: 7,
+        bookmarksCount: 15,
+        viewsCount: 300,
+        averageRating: 4.5,
+        totalRatings: 10,
+      };
+      mockedPost.findById.mockReturnValue({
+        lean: jest.fn().mockResolvedValue(fakeStats),
+      });
+
+      const result = await Post.getEngagementStats(postId);
+
+      expect(mockedPost.findById).toHaveBeenCalledWith(
+        postId,
+        {
+          likesCount: 1,
+          commentsCount: 1,
+          bookmarksCount: 1,
+          viewsCount: 1,
+          averageRating: 1,
+          totalRatings: 1,
+        }
+      );
+      expect(result).toEqual(fakeStats);
+    });
+
+    it("calls findById with lean to avoid full document hydration", async () => {
+      const postId = new Types.ObjectId();
+      mockedPost.findById.mockReturnValue({
+        lean: jest.fn().mockResolvedValue({
+          likesCount: 0,
+          commentsCount: 0,
+          bookmarksCount: 0,
+          viewsCount: 0,
+          averageRating: 0,
+          totalRatings: 0,
+        }),
+      });
+
+      await Post.getEngagementStats(postId);
+      expect(mockedPost.findById).toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/app/modules/post/post.interface.ts
+++ b/backend/src/app/modules/post/post.interface.ts
@@ -24,7 +24,7 @@ export interface IPost extends IPostPayload {
   likesCount: number;
   commentsCount: number;
   viewsCount: number;
-  bookmarksCount: number;  
+  bookmarksCount: number;
   averageRating: number;
   totalRatings: number;
   isPublished: boolean;
@@ -42,7 +42,20 @@ export interface IPost extends IPostPayload {
   rootStoryId?: Types.ObjectId;
 }
 
-export type PostModel = Model<IPost, object>;
+export interface IEngagementStats {
+  likesCount: number;
+  commentsCount: number;
+  bookmarksCount: number;
+  viewsCount: number;
+  averageRating: number;
+  totalRatings: number;
+}
+
+export type PostModel = Model<IPost, object> & {
+  getEngagementStats(
+    postId: string | Types.ObjectId
+  ): Promise<IEngagementStats | null>;
+};
 
 export interface IPostSearchFields {
   searchTerm?: string;

--- a/backend/src/app/modules/post/post.model.ts
+++ b/backend/src/app/modules/post/post.model.ts
@@ -1,7 +1,7 @@
 import { model, Schema } from "mongoose";
 import { IPost, PostModel } from "./post.interface";
 
-export const PostSchema: Schema<IPost> = new Schema<IPost, PostModel>(
+export const PostSchema: Schema<IPost, PostModel> = new Schema<IPost, PostModel>(
   {
     title: { type: String, required: true, maxlength: 200 },
     content: { type: String, required: true, maxlength: 50000 },
@@ -77,5 +77,33 @@ PostSchema.index(
   }
 );
 PostSchema.index({ createdAt: -1 });
+
+/**
+ * Fetches engagement statistics for a given post in a single optimized query.
+ * Returns null if the post does not exist.
+ */
+PostSchema.statics.getEngagementStats = async function (postId) {
+  const result = await this.findById(postId, {
+    likesCount: 1,
+    commentsCount: 1,
+    bookmarksCount: 1,
+    viewsCount: 1,
+    averageRating: 1,
+    totalRatings: 1,
+  }).lean();
+
+  if (!result) {
+    return null;
+  }
+
+  return {
+    likesCount: result.likesCount,
+    commentsCount: result.commentsCount,
+    bookmarksCount: result.bookmarksCount,
+    viewsCount: result.viewsCount,
+    averageRating: result.averageRating,
+    totalRatings: result.totalRatings,
+  };
+};
 
 export const Post = model<IPost, PostModel>("Post", PostSchema);


### PR DESCRIPTION
Closes #4880.

Summary of What Has Been Done:
Added a getEngagementStats static method to PostModel that fetches all engagement metrics (likesCount, commentsCount, bookmarksCount, viewsCount, averageRating, totalRatings) for a given post ID in a single lean query, returning null if the post does not exist. Also added unit tests for the new static method.

Changes Made:
- backend/src/app/modules/post/post.interface.ts: Added IEngagementStats interface and extended PostModel type
- backend/src/app/modules/post/post.model.ts: Implemented getEngagementStats using findById with lean projection
- backend/src/app/modules/post/__tests__/post.model.test.ts: Unit tests covering null return, stats return, and lean usage

Impact it Made:
- Provides a single optimized query for post engagement dashboard data
- Reduces N+1 query patterns by aggregating all metrics in one call

Note: Please assign this PR to the tmdeveloper007 account.