### PR TITLE
fix: correct token return type in collection.controller.ts from strin…

### DIFF
--- a/backend/src/app/modules/collection/collection.controller.ts
+++ b/backend/src/app/modules/collection/collection.controller.ts
@@ -5,6 +5,7 @@ import { getToken } from "../../middleware/token";
 import sendResponse from "../../../shared/send_response";
 import httpStatus from "http-status";
 import { CollectionService } from "./collection.service";
+import { ITokenPayload } from "../../../interfaces/token";
 
 // --- Interfaces for Request Bodies (Type Safety) ---
 interface CreateCollectionBody {
@@ -25,11 +26,11 @@ interface AddStoryBody {
 }
 
 // --- Helper Utility (Can be moved to your token middleware file) ---
-const getOptionalToken = async (req: Request): Promise<string | null> => {
+const getOptionalToken = async (req: Request): Promise<ITokenPayload | null> => {
   try {
-    return await getToken(req);
+    return getToken(req);
   } catch {
-    return null; // Unauthenticated visitor
+    return null;
   }
 };
 


### PR DESCRIPTION
…g to ITokenPayload

## Before you open this PR

- **Issue:** closes #4891 
- **Description:** 
   The getOptionalToken helper function in collection.controller.ts had an 
incorrect return type of Promise<string | null>, but CollectionService 
methods expect ITokenPayload | null. This type mismatch caused 3 TypeScript 
compilation errors. Fixed by correcting the return type to 
Promise<ITokenPayload | null> and adding the missing ITokenPayload import.
## Screenshot (when helpful)
**Before fix:**
src/app/modules/collection/collection.controller.ts:30:5 - error TS2322: Type 'ITokenPayload' is not assignable to type 'string'.
src/app/modules/collection/collection.controller.ts:71:64 - error TS2345: Argument of type 'string | null' is not assignable to parameter of type 'ITokenPayload | null'.
src/app/modules/collection/collection.controller.ts:85:69 - error TS2345: Argument of type 'string | null' is not assignable to parameter of type 'ITokenPayload | null'.
Found 3 errors in src/app/modules/collection/collection.controller.ts

**After fix:**

npx tsc --noEmit 2>&1 | grep "collection" → no errors




## What this PR does

Fixes a TypeScript type mismatch in collection.controller.ts where the 
getOptionalToken helper was returning Promise<string | null> instead of 
Promise<ITokenPayload | null>, causing 3 compilation errors. Fixed by 
updating the return type, adding ITokenPayload import, and removing 
unnecessary await since getToken is synchronous.



## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [ ] Bug fix

## Related issue

closes #4891 


## More screenshots (optional)

<!-- Extra before/after images, flows, or recordings for reviewers. -->



## Checklist

- [ ] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [ ] I have filled in the related issue number when there is one.
- [ ] I have tested my changes.
- [ ] I have done a self-review of the code.
