### PR TITLE
Enhance privacy policy and terms pages

### DIFF
--- a/frontend/src/components/footer/Privacy.tsx
+++ b/frontend/src/components/footer/Privacy.tsx
@@ -1,160 +1,101 @@
 import React from "react";
+import { Link } from "react-router-dom";
+
+const privacySections = [
+  {
+    title: "1. Information We Collect",
+    body: [
+      "Account details such as name, email address, profile information, and authentication identifiers used to create and protect your StorySparkAI account.",
+      "Story prompts, generated drafts, saved stories, comments, bookmarks, and other creative content you choose to submit or store on the platform.",
+      "Technical data such as browser type, device information, IP-derived region, error logs, and usage events that help us keep the service reliable.",
+    ],
+  },
+  {
+    title: "2. Authentication and Account Privacy",
+    body: [
+      "We use authentication tokens, encrypted credentials, and session data to keep users signed in and to prevent unauthorized account access.",
+      "You are responsible for keeping your login credentials private. If you believe your account was accessed without permission, contact support promptly.",
+      "Role-based access controls may be used for writer, user, and admin areas so that account features are shown only to authorized users.",
+    ],
+  },
+  {
+    title: "3. Cookies and Local Storage",
+    body: [
+      "StorySparkAI may use cookies, local storage, and similar browser storage for sign-in sessions, cookie preferences, theme settings, saved drafts, and feature personalization.",
+      "Some browser storage is necessary for core platform functionality. Optional analytics or personalization storage can be limited through browser settings where supported.",
+    ],
+  },
+  {
+    title: "4. How We Use Data",
+    body: [
+      "We use data to operate the platform, generate and save stories, personalize writing workflows, troubleshoot bugs, prevent abuse, and communicate important product or policy updates.",
+      "We do not sell your personal information. Where third-party services are used, they are limited to functions such as hosting, authentication, analytics, email delivery, payments, or AI processing.",
+    ],
+  },
+  {
+    title: "5. User Content Handling",
+    body: [
+      "Your prompts, drafts, and stories remain associated with your account unless you delete them or publish them through platform features.",
+      "Content may be processed by application services to provide story generation, editing, collaboration, export, moderation, and recovery features.",
+      "Avoid adding private, sensitive, or confidential information to prompts or shared stories unless you are comfortable with that information being processed by the platform.",
+    ],
+  },
+  {
+    title: "6. Security and Retention",
+    body: [
+      "We apply reasonable safeguards to protect personal data, including access controls, secure transport, and abuse monitoring.",
+      "We retain account and content data only as long as needed for platform operation, legal obligations, dispute resolution, or legitimate security purposes.",
+    ],
+  },
+  {
+    title: "7. Your Choices and Rights",
+    body: [
+      "You may request access, correction, export, or deletion of personal information associated with your account.",
+      "You can manage cookies through your browser and update communication preferences from available account or email controls.",
+    ],
+  },
+];
 
 const PrivacyPolicy: React.FC = () => {
   return (
     <div className="min-h-screen bg-[#0f172a] text-white px-6 py-24 pt-28 sm:pt-32">
       <div className="max-w-5xl mx-auto">
-        
         <div className="text-center mb-14">
-          <h1 className="text-4xl md:text-5xl font-bold mb-4">
-            Privacy Policy
-          </h1>
-          <p className="text-gray-400 text-lg">
-            Your privacy matters to us at StorySpark AI.
+          <p className="text-blue-300 text-sm font-semibold uppercase tracking-[0.28em] mb-3">
+            Legal Center
           </p>
-          <p className="text-sm text-gray-500 mt-2">
-            Last Updated: May 2026
+          <h1 className="text-4xl md:text-5xl font-bold mb-4">Privacy Policy</h1>
+          <p className="text-gray-300 text-lg max-w-3xl mx-auto leading-8">
+            This policy explains how StorySparkAI collects, uses, stores, and protects information while users create, save, and share AI-assisted stories.
           </p>
+          <p className="text-sm text-gray-500 mt-3">Last Updated: July 2026</p>
         </div>
 
-        <div className="space-y-10">
+        <div className="grid gap-6">
+          {privacySections.map((section) => (
+            <section key={section.title} className="bg-[#1e293b] rounded-2xl p-6 sm:p-8 shadow-lg border border-white/5">
+              <h2 className="text-2xl font-semibold mb-4">{section.title}</h2>
+              <ul className="list-disc pl-5 text-gray-300 space-y-3 leading-7">
+                {section.body.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </section>
+          ))}
 
-          <section className="bg-[#1e293b] rounded-2xl p-8 shadow-lg">
-            <h2 className="text-2xl font-semibold mb-4">
-              1. Introduction
-            </h2>
-            <p className="text-gray-300 leading-7">
-              Welcome to StorySpark AI. We value your privacy and are committed
-              to protecting your personal information. This Privacy Policy
-              explains how we collect, use, and safeguard your data while you
-              use our platform and services.
+          <section className="bg-gradient-to-r from-blue-600 to-purple-600 rounded-2xl p-8 shadow-lg text-center">
+            <h2 className="text-3xl font-bold mb-4">Contact and Support</h2>
+            <p className="text-lg text-white/90 mb-5 leading-8">
+              For privacy questions, account requests, or data concerns, contact the StorySparkAI team through the support page or email support@storyspark.ai.
             </p>
-          </section>
-
-          <section className="bg-[#1e293b] rounded-2xl p-8 shadow-lg">
-            <h2 className="text-2xl font-semibold mb-4">
-              2. Information We Collect
-            </h2>
-
-            <ul className="list-disc list-inside text-gray-300 space-y-3 leading-7">
-              <li>Name and email address during account creation</li>
-              <li>Story prompts, generated content, and uploaded media</li>
-              <li>Usage analytics and interaction data</li>
-              <li>Device and browser information</li>
-              <li>Cookies and session tracking information</li>
-            </ul>
-          </section>
-
-          <section className="bg-[#1e293b] rounded-2xl p-8 shadow-lg">
-            <h2 className="text-2xl font-semibold mb-4">
-              3. How We Use Your Information
-            </h2>
-
-            <div className="grid md:grid-cols-2 gap-5">
-              <div className="bg-[#334155] p-5 rounded-xl">
-                <h3 className="font-semibold mb-2 text-lg">
-                  Platform Improvement
-                </h3>
-                <p className="text-gray-300">
-                  We use data to improve AI story generation, user experience,
-                  and overall platform performance.
-                </p>
-              </div>
-
-              <div className="bg-[#334155] p-5 rounded-xl">
-                <h3 className="font-semibold mb-2 text-lg">
-                  Personalization
-                </h3>
-                <p className="text-gray-300">
-                  Your preferences help us generate better and more relevant
-                  stories and recommendations.
-                </p>
-              </div>
-
-              <div className="bg-[#334155] p-5 rounded-xl">
-                <h3 className="font-semibold mb-2 text-lg">
-                  Security
-                </h3>
-                <p className="text-gray-300">
-                  We monitor suspicious activity and protect accounts from
-                  unauthorized access.
-                </p>
-              </div>
-
-              <div className="bg-[#334155] p-5 rounded-xl">
-                <h3 className="font-semibold mb-2 text-lg">
-                  Communication
-                </h3>
-                <p className="text-gray-300">
-                  We may send important updates, policy changes, and service
-                  announcements.
-                </p>
-              </div>
+            <div className="flex flex-wrap justify-center gap-3">
+              <Link to="/contact-us" className="rounded-full bg-white text-slate-900 px-5 py-2.5 font-semibold hover:bg-blue-50 transition-colors">
+                Contact Support
+              </Link>
+              <Link to="/terms" className="rounded-full border border-white/50 px-5 py-2.5 font-semibold hover:bg-white/10 transition-colors">
+                View Terms
+              </Link>
             </div>
-          </section>
-
-          <section className="bg-[#1e293b] rounded-2xl p-8 shadow-lg">
-            <h2 className="text-2xl font-semibold mb-4">
-              4. Cookies & Tracking Technologies
-            </h2>
-
-            <p className="text-gray-300 leading-7">
-              StorySpark AI uses cookies and similar technologies to improve
-              functionality, analyze traffic, and enhance user experience. You
-              can disable cookies through your browser settings if preferred.
-            </p>
-          </section>
-
-          <section className="bg-[#1e293b] rounded-2xl p-8 shadow-lg">
-            <h2 className="text-2xl font-semibold mb-4">
-              5. Data Protection
-            </h2>
-
-            <p className="text-gray-300 leading-7">
-              We implement industry-standard security measures to protect your
-              personal information from unauthorized access, misuse, or
-              disclosure.
-            </p>
-          </section>
-
-          <section className="bg-[#1e293b] rounded-2xl p-8 shadow-lg">
-            <h2 className="text-2xl font-semibold mb-4">
-              6. Third-Party Services
-            </h2>
-
-            <p className="text-gray-300 leading-7">
-              We may use trusted third-party tools and analytics services to
-              improve our platform. These services may collect limited technical
-              information in accordance with their own privacy policies.
-            </p>
-          </section>
-
-          <section className="bg-[#1e293b] rounded-2xl p-8 shadow-lg">
-            <h2 className="text-2xl font-semibold mb-4">
-              7. Your Rights
-            </h2>
-
-            <ul className="list-disc list-inside text-gray-300 space-y-3 leading-7">
-              <li>Request access to your personal data</li>
-              <li>Request correction or deletion of your data</li>
-              <li>Withdraw consent at any time</li>
-              <li>Request account deletion</li>
-            </ul>
-          </section>
-
-          <section className="bg-gradient-to-r from-purple-600 to-pink-600 rounded-2xl p-8 shadow-lg text-center">
-            <h2 className="text-3xl font-bold mb-4">
-              Contact Us
-            </h2>
-
-            <p className="text-lg text-white/90 mb-3">
-              If you have any questions regarding this Privacy Policy,
-              feel free to contact us.
-            </p>
-
-            <p className="font-semibold">
-              support@storysparkai.com
-            </p>
           </section>
         </div>
       </div>

--- a/frontend/src/components/footer/terms.tsx
+++ b/frontend/src/components/footer/terms.tsx
@@ -1,11 +1,49 @@
 import logo from "../../assets/logoNew.png";
 import { Link } from "react-router-dom";
 
+const termsSections = [
+  {
+    title: "1. Acceptance of Terms",
+    body: "By accessing or using StorySparkAI, you agree to these Terms & Conditions and any related policies referenced from the platform. If you do not agree, do not use the service.",
+  },
+  {
+    title: "2. Acceptable Platform Usage",
+    body: "Use StorySparkAI for lawful, respectful, and creative storytelling activities. Do not use the platform to create, upload, or distribute illegal, hateful, harassing, exploitative, infringing, deceptive, or harmful content.",
+  },
+  {
+    title: "3. User Responsibilities",
+    body: "You are responsible for your account activity, the prompts you submit, the stories you publish, and the information you choose to share. Keep credentials secure and provide accurate account information.",
+  },
+  {
+    title: "4. Content Ownership and Copyright",
+    body: "You retain responsibility for the original content you provide and the stories you choose to save or publish. You must have the rights needed for any submitted material and must respect copyrights, trademarks, and third-party intellectual property.",
+  },
+  {
+    title: "5. AI-Generated Content",
+    body: "AI-assisted outputs may require human review. You are responsible for checking generated stories for accuracy, originality, suitability, and compliance before publishing or sharing them outside the platform.",
+  },
+  {
+    title: "6. Account and Community Guidelines",
+    body: "Accounts may be limited, suspended, or removed when users abuse platform features, attempt unauthorized access, spam other users, violate community expectations, or repeatedly submit prohibited content.",
+  },
+  {
+    title: "7. Privacy and Data Practices",
+    body: "Use of StorySparkAI is also governed by the Privacy Policy, which explains how account data, authentication details, cookies, local storage, and user-generated content are handled.",
+  },
+  {
+    title: "8. Limitations of Liability",
+    body: "StorySparkAI is provided on an as-is and as-available basis. The platform team is not liable for indirect, incidental, special, consequential, or punitive damages resulting from use of the service.",
+  },
+  {
+    title: "9. Changes to These Terms",
+    body: "We may update these terms as the platform evolves. Continued use after updated terms are posted means you accept the revised terms.",
+  },
+];
+
 const Terms = () => {
   return (
     <div className="min-h-screen bg-black text-white px-4 sm:px-6 py-24 pt-28 sm:pt-32 flex items-start">
       <div className="max-w-4xl mx-auto w-full text-center lg:text-left">
-        {/* Logo */}
         <Link to="/" className="inline-block">
           <img
             src={logo}
@@ -13,100 +51,45 @@ const Terms = () => {
             className="h-16 sm:h-20 mx-auto mb-5 transition-transform duration-300 hover:scale-105"
           />
         </Link>
-        {/* Heading */}
+
+        <p className="text-blue-300 text-sm font-semibold uppercase tracking-[0.28em] mb-3">
+          Legal Center
+        </p>
         <h1 className="text-3xl sm:text-5xl font-extrabold mb-4 tracking-tight">
           Terms & <span className="text-blue-500">Conditions</span>
         </h1>
-
-        {/* Description */}
-        <p className="text-gray-300 text-base sm:text-lg leading-7 sm:leading-8 max-w-2xl mx-auto mb-8">
-          Please read these terms carefully before using StorySparkAI to ensure a safe and inspiring community.
+        <p className="text-gray-300 text-base sm:text-lg leading-7 sm:leading-8 max-w-2xl mx-auto lg:mx-0 mb-3">
+          These terms define acceptable use, content responsibilities, ownership expectations, and account rules for the StorySparkAI community.
         </p>
+        <p className="text-sm text-gray-500 mb-8">Last Updated: July 2026</p>
 
-        {/* Content Section */}
         <div className="bg-zinc-900/80 border border-zinc-800 shadow-2xl rounded-3xl p-6 sm:p-8 sm:px-10 backdrop-blur-sm transition-all duration-300 hover:border-blue-500/40 text-left">
-          
-          <section className="mb-8 mt-2">
-            <h2 className="text-2xl font-semibold mb-3 text-blue-400">1. Introduction</h2>
-            <p className="text-gray-300 text-base leading-relaxed">
-              Welcome to StorySparkAI. By accessing or using our platform, you agree to be bound by these Terms and Conditions. Our platform provides AI-assisted storytelling tools to help you create, edit, and explore engaging narratives.
-            </p>
-          </section>
-
-          <section className="mb-8">
-            <h2 className="text-2xl font-semibold mb-3 text-blue-400">2. Acceptance of Terms</h2>
-            <p className="text-gray-300 text-base leading-relaxed">
-              By registering an account, accessing, or otherwise utilizing StorySparkAI, you acknowledge that you have read, understood, and agree to be bound by these Terms. If you do not agree, please do not use the service.
-            </p>
-          </section>
-
-          <section className="mb-8">
-            <h2 className="text-2xl font-semibold mb-3 text-blue-400">3. User Responsibilities</h2>
-            <p className="text-gray-300 text-base leading-relaxed">
-              As a user, you agree not to misuse our services. You are responsible for safeguarding your account information and for any activities or actions under your account. You agree to provide accurate information when registering.
-            </p>
-          </section>
-
-          <section className="mb-8">
-            <h2 className="text-2xl font-semibold mb-3 text-blue-400">4. Intellectual Property</h2>
-            <p className="text-gray-300 text-base leading-relaxed">
-              StorySparkAI respects intellectual property rights and expects users to do the same. Any content generated using our AI tools is subject to the licensing and usage policies defined by the respective underlying AI models. The platform itself, including its original code, design, and branding, is owned by StorySparkAI.
-            </p>
-          </section>
-
-          <section className="mb-8">
-            <h2 className="text-2xl font-semibold mb-3 text-blue-400">5. Limitation of Liability</h2>
-            <p className="text-gray-300 text-base leading-relaxed">
-              StorySparkAI and its affiliates shall not be liable for any indirect, incidental, special, consequential, or punitive damages arising from your use of the platform. The service is provided "as is" without representations or warranties of any kind.
-            </p>
-          </section>
-
-          <section className="mb-8">
-            <h2 className="text-2xl font-semibold mb-3 text-blue-400">6. Privacy Policy Reference</h2>
-            <p className="text-gray-300 text-base leading-relaxed">
-              Your usage of the platform is also governed by our Privacy Policy, which outlines how we collect, use, and protect your personal information. Please review it carefully to understand our data practices.
-            </p>
-          </section>
-
-          <section className="mb-8">
-            <h2 className="text-2xl font-semibold mb-3 text-blue-400">7. Prohibited Activities</h2>
-            <p className="text-gray-300 text-base leading-relaxed">
-              You agree not to use the platform to generate or distribute hateful, explicit, illegal, or abusive content. We reserve the right to suspend or terminate accounts that violate these guidelines without prior notice.
-            </p>
-          </section>
-
-          <section className="mb-8">
-            <h2 className="text-2xl font-semibold mb-3 text-blue-400">8. Changes to Terms</h2>
-            <p className="text-gray-300 text-base leading-relaxed">
-              We reserve the right to modify these Terms & Conditions at any time. We will notify users of any significant changes by posting the updated terms on this page. Your continued use of the platform after changes have been made constitutes acceptance of the new Terms.
-            </p>
-          </section>
-
-          <section className="mb-2">
-            <h2 className="text-2xl font-semibold mb-3 text-blue-400">9. Contact Information</h2>
-            <p className="text-gray-300 text-base leading-relaxed">
-              If you have any questions or concerns regarding these Terms, please contact us through our dedicated Contact page or at support@storyspark.ai.
-            </p>
-          </section>
-
+          {termsSections.map((section) => (
+            <section key={section.title} className="mb-8 last:mb-2">
+              <h2 className="text-2xl font-semibold mb-3 text-blue-400">{section.title}</h2>
+              <p className="text-gray-300 text-base leading-relaxed">{section.body}</p>
+            </section>
+          ))}
         </div>
 
-        {/* CTA */}
-        <div className="mt-12">
+        <div className="mt-12 flex flex-wrap gap-3 justify-center lg:justify-start">
           <Link
             to="/"
-            className="
-                inline-flex items-center gap-2
-                px-6 py-3
-                bg-blue-500 hover:bg-blue-600
-                text-white font-semibold
-                rounded-full
-                shadow-lg hover:shadow-blue-500/30
-                transition-all duration-300
-                hover:scale-105
-            "
+            className="inline-flex items-center gap-2 px-6 py-3 bg-blue-500 hover:bg-blue-600 text-white font-semibold rounded-full shadow-lg hover:shadow-blue-500/30 transition-all duration-300 hover:scale-105"
           >
-            ⬅ Back to Home
+            Back to Home
+          </Link>
+          <Link
+            to="/privacy-policy"
+            className="inline-flex items-center gap-2 px-6 py-3 border border-blue-500/60 text-blue-200 hover:bg-blue-500/10 font-semibold rounded-full transition-all duration-300"
+          >
+            View Privacy Policy
+          </Link>
+          <Link
+            to="/contact-us"
+            className="inline-flex items-center gap-2 px-6 py-3 border border-white/20 text-gray-200 hover:bg-white/10 font-semibold rounded-full transition-all duration-300"
+          >
+            Contact Support
           </Link>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Expands the Privacy Policy page with account data, authentication/session privacy, cookies/local storage, content handling, retention, and user-rights sections
- Expands the Terms & Conditions page with acceptable use, user responsibilities, content ownership, AI-generated content review, community guidelines, and liability language
- Adds legal-page cross-links to support, terms, and privacy pages

Closes #250

## Tests
- git diff --check
- npm run typecheck -w story-spark-ai-frontend (blocked locally: fresh clone has no node_modules/tsc and this machine has only ~544 MB free, so dependency install is not safe)