### PR TITLE
fix: make MongoDB connection handling resilient with reconnect logic (#4856)

### DIFF
--- a/backend/src/app/modules/reaction/reaction.service.ts
+++ b/backend/src/app/modules/reaction/reaction.service.ts
@@ -82,5 +82,4 @@ const toggleReaction = async (
 
 export const ReactionService = {
   toggleReaction,
-}
-};
+} as const;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -22,11 +22,68 @@ if (config.disable_logs) {
   console.debug = noop;
 }
 
+const MAX_MONGO_RECONNECT_ATTEMPTS = 5;
+const MONGO_RECONNECT_DELAY_MS = 2000;
+let isMongoReconnectInProgress = false;
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function reconnectMongo() {
+  if (isMongoReconnectInProgress) return;
+  isMongoReconnectInProgress = true;
+
+  try {
+    for (let attempt = 1; attempt <= MAX_MONGO_RECONNECT_ATTEMPTS; attempt += 1) {
+      try {
+        logger.info(`MongoDB reconnect attempt ${attempt}/${MAX_MONGO_RECONNECT_ATTEMPTS}`);
+        await mongoose.connect(config.database_url as string, {
+          serverSelectionTimeoutMS: 10000,
+          socketTimeoutMS: 45000,
+          connectTimeoutMS: 10000,
+        });
+        logger.info('MongoDB reconnected successfully.');
+        return;
+      } catch (error) {
+        logger.error(`MongoDB reconnect attempt ${attempt} failed:`, error);
+        if (attempt < MAX_MONGO_RECONNECT_ATTEMPTS) {
+          await delay(MONGO_RECONNECT_DELAY_MS * attempt);
+        }
+      }
+    }
+
+    logger.error(
+      `MongoDB failed to reconnect after ${MAX_MONGO_RECONNECT_ATTEMPTS} attempts. ` +
+        'Database operations may fail until the service becomes available again.'
+    );
+  } finally {
+    isMongoReconnectInProgress = false;
+  }
+}
+
 async function connectDB() {
   if (mongoose.connection.readyState === 1) return;
   // config.database_url is guaranteed non-empty by config/index.ts – if it throws at
   // module load time if DATABASE_URL is missing, so no runtime guard is needed here
-  await mongoose.connect(config.database_url as string);
+  if (!mongoose.connection.listeners('error').length) {
+    mongoose.connection.on('error', (err) => {
+      logger.error('MongoDB runtime connection error:', err);
+    });
+
+    mongoose.connection.on('disconnected', async () => {
+      logger.warn('MongoDB disconnected. Attempting to reconnect...');
+      await reconnectMongo();
+    });
+
+    mongoose.connection.on('reconnected', () => {
+      logger.info('MongoDB connection reestablished.');
+    });
+  }
+
+  await mongoose.connect(config.database_url as string, {
+    serverSelectionTimeoutMS: 10000,
+    socketTimeoutMS: 45000,
+    connectTimeoutMS: 10000,
+  });
 }
 
 async function main() {


### PR DESCRIPTION
## Summary
This pull request improves MongoDB connection resilience in `backend/src/server.ts` by adding runtime error logging and automatic reconnect handling for disconnect events. It preserves existing startup failure handling and graceful shutdown behavior.

## What changed
- Added runtime MongoDB connection error logging for better observability.
- Added automatic reconnect attempts after MongoDB disconnects at runtime.
- Registered reconnect event listeners only once to avoid duplicate handlers across repeated initialization calls.
- Configured Mongoose connect options for a more robust connection lifecycle.

## Why this change is needed
MongoDB disconnections after startup were previously not handled gracefully, which could allow runtime connection failures to cause unstable application behavior. This change makes the backend resilient to transient MongoDB network interruptions while keeping startup and shutdown workflows intact.

## Issue linked
Fixes #4856

## Source
Pushed from `sahitya0xsingh` on branch `fix/mongodb-connection-error-handling-4856`.
