### PR TITLE
feat(frontend): add formatFileSize utility

### DIFF
--- a/frontend/src/utils/formatFileSize.ts
+++ b/frontend/src/utils/formatFileSize.ts
@@ -1,0 +1,25 @@
+/*
+ * Formats a byte value into a human-readable string with appropriate unit.
+ * Handles Bytes, KB, MB, GB, and TB.
+ *
+ * @param bytes - The number of bytes
+ * @param decimals - Number of decimal places (default: 2)
+ * @returns A formatted string like "1.5 KB" or "3.2 MB"
+ */
+export const formatFileSize = (bytes: number, decimals = 2): string => {
+  if (bytes === 0) {
+    return "0 Bytes";
+  }
+
+  if (bytes < 0) {
+    return "0 Bytes";
+  }
+
+  const k = 1024;
+  const dm = decimals < 0 ? 0 : decimals;
+  const sizes = ["Bytes", "KB", "MB", "GB", "TB"];
+
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
+};


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Closes #4808
- **Description:** Added a reusable `formatFileSize` utility for the frontend to format byte values into human-readable strings with configurable decimal precision.
- **Screenshots:** N/A (No UI changes)

## Screenshot (when helpful)

N/A - This PR adds a utility function and does not include any UI changes.

## What this PR does

- Added a reusable `formatFileSize` utility in `frontend/src/utils/formatFileSize.ts`.
- Formats byte values into human-readable units (Bytes, KB, MB, GB, and TB).
- Supports configurable decimal precision.
- Handles zero and negative byte values gracefully.
- Provides a centralized utility for consistent file size formatting across the frontend.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #4808

## More screenshots (optional)

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.