### PR TITLE
fix: add ObjectId validation to notification service functions #4632

### DIFF
--- a/backend/src/app/modules/notification/__tests__/notification.service.test.ts
+++ b/backend/src/app/modules/notification/__tests__/notification.service.test.ts
@@ -76,3 +76,47 @@ describe("NotificationService.resolveUserId", () => {
     expect(mockFindOne).toHaveBeenCalledWith({ email: "ada@example.com" });
   });
 });
+
+describe("NotificationService.markNotificationAsRead", () => {
+  beforeEach(() => {
+    mockFindOneAndUpdate.mockReset();
+    mockFindOne.mockReset();
+    mockEmitNotificationStateToUser.mockReset();
+  });
+
+  it("throws a 400 Bad Request error if the notification ID is invalid", async () => {
+    const token = { _id: "user-123" } as any;
+    await expect(
+      NotificationService.markNotificationAsRead("invalid-id", token)
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: "Invalid notification ID",
+    });
+  });
+
+  it("successfully marks a notification as read with a valid ObjectId", async () => {
+    const validObjectId = "60c72b2f9b1d8e256c8b4567";
+    const token = { _id: "user-123" } as any;
+
+    mockFindOneAndUpdate.mockResolvedValueOnce({
+      _id: validObjectId,
+      userId: "user-123",
+      isRead: true,
+    });
+
+    const result = await NotificationService.markNotificationAsRead(validObjectId, token);
+    expect(result).toBeDefined();
+    expect(result.isRead).toBe(true);
+    expect(mockFindOneAndUpdate).toHaveBeenCalledWith(
+      { _id: validObjectId, userId: "user-123" },
+      { isRead: true },
+      { new: true }
+    );
+    expect(mockEmitNotificationStateToUser).toHaveBeenCalledWith(
+      "user-123",
+      "notification:updated",
+      expect.any(Object)
+    );
+  });
+});
+

--- a/backend/src/app/modules/notification/notification.service.ts
+++ b/backend/src/app/modules/notification/notification.service.ts
@@ -1,4 +1,5 @@
 import httpStatus from "http-status";
+import { Types } from "mongoose";
 import ApiError from "../../../errors/api_error";
 import { ITokenPayload } from "../../../interfaces/token";
 import { User } from "../user/user.model";
@@ -64,6 +65,10 @@ const markNotificationAsRead = async (
   notificationId: string,
   token: ITokenPayload
 ) => {
+  if (!Types.ObjectId.isValid(notificationId)) {
+    throw new ApiError(httpStatus.BAD_REQUEST, "Invalid notification ID");
+  }
+
   const userId = await resolveUserId(token);
   const notification = await Notification.findOneAndUpdate(
     { _id: notificationId, userId },


### PR DESCRIPTION
## Screenshot (when helpful)
N/A - backend logic fix, no UI change. Test case added as proof (see below).

## What this PR does
Added ObjectId validation to the markNotificationAsRead function in 
notification.service.ts. Previously, an invalid notificationId (e.g. "abc" 
instead of a valid 24-char hex string) would cause an unhandled mongoose 
CastError, resulting in a 500 Internal Server Error instead of a proper 
400 Bad Request response.

Changes:
- Added Types.ObjectId.isValid() guard at the top of markNotificationAsRead
- Throws ApiError with 400 BAD_REQUEST and message "Invalid notification ID" 
  for invalid input
- deleteAllNotifications left unchanged since it uses resolved userId, not 
  notificationId directly
- Added a test case covering invalid notificationId input

## Type of change
- [x] Bug fix

## Related issue
Fixes #4632

## More screenshots (optional)
N/A

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.

Note: Local test suite couldn't run due to a pre-existing, unrelated dependency 
issue in the repo (invalid y-quill version in frontend workspace). Logic was 
verified manually against the reported bug scenario.
