### PR TITLE
fix: prevent responsive input overflow on signup page

### DIFF
--- a/frontend/src/components/signup/signup.component.tsx
+++ b/frontend/src/components/signup/signup.component.tsx
@@ -272,7 +272,7 @@ const SignUpComponent = () => {
         </div>
 
         {/* Card */}
-        <div className="bg-white dark:bg-slate-800/60 backdrop-blur-xl border border-slate-200 dark:border-slate-700/50 rounded-2xl p-5 sm:p-8 shadow-2xl w-full min-w-0 overflow-hidden box-border">
+        <div className="bg-white dark:bg-slate-800/60 backdrop-blur-xl border border-slate-200 dark:border-slate-700/50 rounded-2xl p-5 sm:p-8 shadow-2xl w-full min-w-0 box-border">
           <button
             onClick={() => navigate("/")}
             className="mb-4 text-sm text-blue-400 hover:text-blue-300 transition-colors duration-200 flex items-center gap-2 cursor-pointer"
@@ -484,11 +484,13 @@ const SignUpComponent = () => {
                   </div>
                 </div>
 
-                <div className="flex justify-center w-full box-border overflow-hidden">
-                  <GoogleLogin
-                    onSuccess={handleGoogleLoginSuccess}
-                    onError={handleGoogleLoginError}
-                  />
+                <div className="flex justify-center w-full box-border">
+                  <div className="w-full max-w-full overflow-hidden">
+                    <GoogleLogin
+                      onSuccess={handleGoogleLoginSuccess}
+                      onError={handleGoogleLoginError}
+                    />
+                  </div>
                 </div>
 
                 <p className="mt-6 text-center text-sm text-slate-500 dark:text-slate-400">


### PR DESCRIPTION
Fixes #4626

### Changes
- Removed `overflow-hidden` from card container that could clip form content on mobile
- Wrapped Google Login button in a constrained container to prevent horizontal overflow
- Ensures inputs do not overflow on small screens