### PR TITLE
fix: hide global chat widget on authentication pages

### DIFF
--- a/frontend/src/components/layout/root_layout.component.tsx
+++ b/frontend/src/components/layout/root_layout.component.tsx
@@ -33,7 +33,7 @@ const RootLayout: React.FC<RootLayoutProps> = ({ children }) => {
       <div className="flex-grow min-h-0">{children}</div>
 
       <FooterComponent />
-<ChatComponent />
+      {pathname !== "/login" && pathname !== "/signup" && pathname !== "/forgot-password" && <ChatComponent />}
     </div>
   );
 };


### PR DESCRIPTION
Fixes #4656

### Problem
The global chat widget (ChatComponent) is rendered on authentication pages (login, signup, forgot-password), causing UI clutter and potential distraction.

### Fix
Added conditional rendering to hide ChatComponent on auth routes.