### PR TITLE
fix: return 400 instead of 500 for mongoose validation errors

### DIFF
--- a/backend/src/errors/handle_validation_error.ts
+++ b/backend/src/errors/handle_validation_error.ts
@@ -13,7 +13,7 @@ const handleValidationError = (
       };
     }
   );
-  const statusCode = 500;
+  const statusCode = 400;
   return {
     statusCode,
     message: "Validation Error",


### PR DESCRIPTION
**Issue:** Mongoose validation errors return HTTP 500 (Internal Server Error) but should return 400 (Bad Request) since the error is caused by invalid client input.

**Changes:**
- Changed statusCode from 500 to 400 in handle_validation_error.ts

Fixes #4568