### PR TITLE
fix: improve handle_cast_error message to be descriptive

### DIFF
--- a/backend/src/errors/handle_cast_error.ts
+++ b/backend/src/errors/handle_cast_error.ts
@@ -6,12 +6,12 @@ const handleCastError = (err: mongoose.Error.CastError) => {
   const errors: IGenericErrorMessage[] = [
     {
       path: err.path,
-      message: "Invalid Id",
+      message: `Invalid value for ${err.path}: "${err.value}" is not a valid ID`,
     },
   ];
   return {
     statusCode,
-    message: err.name,
+    message: `Invalid ${err.path}: "${err.value}" could not be cast to a valid ObjectId`,
     errorMessages: errors,
   };
 };


### PR DESCRIPTION
**Issue:** handle_cast_error returns `err.name` (e.g. "CastError") as the message, which is not descriptive for API consumers.**Changes:**- Changed message from `err.name` to a descriptive string including the field path and invalid value- Updated errorMessages detail to show the invalid valueFixes #4571