### PR TITLE
fix: replace Unicode characters with ASCII alternatives to prevent corrupted UTF-8 rendering

### DIFF
--- a/frontend/src/components/ReadingTimeBadge.tsx
+++ b/frontend/src/components/ReadingTimeBadge.tsx
@@ -8,7 +8,7 @@ export default function ReadingTimeBadge({ text }: Props) {
   const { minutes, wordCount } = getReadingTime(text);
   return (
     <p className="text-sm text-gray-500 dark:text-gray-400">
-      🕐 {minutes} min read · {wordCount} words
+      {minutes} min read - {wordCount} words
     </p>
   );
 }

--- a/frontend/src/components/footer/blog-post.tsx
+++ b/frontend/src/components/footer/blog-post.tsx
@@ -40,7 +40,7 @@ const BlogPost = () => {
 
         {/* META */}
         <div className="text-sm text-gray-500 dark:text-gray-400 mb-6">
-          5 min read • StorySpark AI Editorial Team
+          5 min read - StorySpark AI Editorial Team
         </div>
 
         {/* CONTENT CARD */}

--- a/frontend/src/components/post/post.details.component.tsx
+++ b/frontend/src/components/post/post.details.component.tsx
@@ -495,11 +495,11 @@ const PostDetailsComponent = () => {
   {post?.content && (
     <>
       <span className="inline-flex items-center rounded-full bg-slate-700/60 text-slate-300 border border-slate-600/50 py-1 px-3 text-xs font-semibold gap-1 select-none">
-        ⏱️ {calculateReadingTime(post.content)} min read
+        {calculateReadingTime(post.content)} min read
       </span>
 
       <span className="inline-flex items-center rounded-full bg-slate-800/60 text-slate-400 border border-slate-700/50 py-1 px-3 text-xs font-semibold">
-        📖 {formatReadingStats(post.content)}
+        {formatReadingStats(post.content)}
       </span>
     </>
   )}

--- a/frontend/src/utils/__tests__/story-utils.test.ts
+++ b/frontend/src/utils/__tests__/story-utils.test.ts
@@ -59,7 +59,7 @@ describe("story-utils", () => {
   describe("formatReadingStats", () => {
     it("should format stats correctly", () => {
       const content = "This is a five word story.";
-      expect(formatReadingStats(content)).toBe("1 min read • 6 words"); // "This", "is", "a", "five", "word", "story."
+      expect(formatReadingStats(content)).toBe("1 min read - 6 words"); // "This", "is", "a", "five", "word", "story."
     });
   });
 });

--- a/frontend/src/utils/story-utils.ts
+++ b/frontend/src/utils/story-utils.ts
@@ -20,5 +20,5 @@ export const calculateReadingTime = (content: string | undefined): number => {
 export const formatReadingStats = (content: string | undefined): string => {
   const words = getWordCount(content);
   const time = calculateReadingTime(content);
-  return `${time} min read • ${words} words`;
+  return `${time} min read - ${words} words`;
 };


### PR DESCRIPTION
**Issue:** Featured post metadata displays corrupted UTF-8 characters (e.g. ΓÇó, ΓÅ▒∩╕Å) instead of • and ⏱️ due to UTF-8 double-encoding issues.**Changes:**- Replaced bullet `•` with `-` in story-utils.ts, blog-post.tsx, ReadingTimeBadge.tsx- Replaced emoji `⏱️` and `📖` with plain text in post.details.component.tsx- Updated test expectationFixes #4604