### PR TITLE
fix: add SSR guard to downloadStories utility

### DIFF
--- a/frontend/src/utils/downloadStories.ts
+++ b/frontend/src/utils/downloadStories.ts
@@ -1,5 +1,9 @@
+const isBrowser = typeof window !== "undefined" && typeof document !== "undefined";
+
 export const downloadTXT = (story: any) => {
-  if (typeof window === 'undefined') return;
+  if (!isBrowser) {
+    return;
+  }
 
   const content = `Title: ${story.title}\nPrompt: ${story.prompt}\nStory: ${story.content}\nGenerated: ${new Date().toLocaleString()}`;
 


### PR DESCRIPTION
**Issue:** downloadStories.ts uses browser APIs (document, Blob, URL.createObjectURL) that are not available in SSR (Server-Side Rendering), causing build/runtime errors in Next.js.**Changes:**- Added `isBrowser` check at the top of the utility- Added early return if not in browser environmentFixes #4611