### PR TITLE
fix: restore incomplete useSpeechSynthesis hook and fix missing state management

### DIFF
--- a/frontend/src/hooks/useSpeechSynthesis.ts
+++ b/frontend/src/hooks/useSpeechSynthesis.ts
@@ -238,12 +238,6 @@ export const useSpeechSynthesis = (
     };
   }, [stop]);
 
-  useEffect(() => {
-    if (isSpeaking || isPaused) {
-      stop();
-    }
-  }, [text, stop, isPaused, isSpeaking]);
-
   const speakText = useCallback(
     (nextText?: string) => {
       const textToSpeak = (nextText ?? textRef.current).trim();
@@ -319,7 +313,7 @@ export const useSpeechSynthesis = (
       synthRef.current.speak(utterance);
       setCurrentWordIndex(0);
     },
-    [browserVoices, isSupported, rateState, pitchState, volumeState, selectedVoiceId, selectedLanguage, stop, resolveBrowserVoice],
+    [isSupported, rateState, pitchState, volumeState, selectedVoiceId, selectedLanguage, stop, resolveBrowserVoice],
   );
 
   const pause = useCallback(() => {


### PR DESCRIPTION
**Issue:** useSpeechSynthesis hook has a problematic useEffect that causes cyclic re-renders: it depends on `isSpeaking` and `isPaused` state while also calling `stop()` which modifies them. The `browserVoices` dependency in `speakText` is also unnecessary since `resolveBrowserVoice` already uses the ref.**Changes:**- Removed the problematic useEffect that auto-stops on `isSpeaking`/`isPaused` state changes (the consumer component already handles text-change cleanup)- Removed unnecessary `browserVoices` from speakText dependency arrayFixes #4586