### PR TITLE
fix: hide global chat widget on authentication pages

### DIFF
--- a/frontend/src/components/layout/root_layout.component.tsx
+++ b/frontend/src/components/layout/root_layout.component.tsx
@@ -13,16 +13,17 @@ interface RootLayoutProps {
   children: ReactNode;
 }
 
+const AUTH_PATHS = ["/login", "/signup", "/forgot-password"];
+
 const RootLayout: React.FC<RootLayoutProps> = ({ children }) => {
   const { pathname } = useLocation();
+  const isAuthPage = AUTH_PATHS.includes(pathname);
 
   const [cookieBannerHeight, setCookieBannerHeight] = useState(0);
 
   const handleCookieLayoutChange = useCallback((height: number) => {
     setCookieBannerHeight(height);
   }, []);
-
-  const isAuthPage = pathname === '/login' || pathname === '/signup' || pathname === '/forgot-password';
 
   return (
     <div


### PR DESCRIPTION
**Issue:** The floating ChatComponent widget is rendered globally across all pages, including authentication pages (login, signup, forgot-password) where it distracts users.**Changes:**- Added `AUTH_PATHS` constant listing auth page paths- Check `pathname` against auth paths and conditionally render ChatComponentFixes #4656