### PR TITLE
Improve MongoDB connection cleanup during graceful shutdown

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -39,6 +39,12 @@ async function main() {
 
     try {
       if (mongoose && mongoose.connection && mongoose.connection.readyState !== 0) {
+        await new Promise<void>((resolve, reject) => {
+        httpServer.close((err) => {
+        if (err) reject(err);
+        else resolve();
+  });
+});
         await mongoose.connection.close();
         logger.info('🔌 MongoDB connection safely closed.');
       }
@@ -55,6 +61,13 @@ async function main() {
   });
 
   // Intercept unexpected application crashes before they tear down the system
+  process.on("unhandledRejection", (reason) => {
+  void handleGracefulShutdown("Unhandled Rejection", reason);
+  });
+
+  process.on("uncaughtException", (error) => {
+  void handleGracefulShutdown("Uncaught Exception", error);
+  });
   process.on('uncaughtException', (error: Error) => {
     handleGracefulShutdown('Uncaught Exception', error);
   });


### PR DESCRIPTION
Closes #4857 
This PR improves the MongoDB cleanup process during application shutdown by ensuring the database connection is properly handled before the process exits.

~Changes Made

- Updated the graceful shutdown logic in `server.ts`.
- Improved MongoDB connection cleanup during `unhandledRejection` and `uncaughtException` handling.
- Ensured the shutdown sequence waits for the MongoDB connection cleanup before terminating the application.

A proper shutdown sequence helps prevent resource leaks and ensures MongoDB connections are closed cleanly when the application encounters unexpected failures.

~ Testing

- Triggered an `unhandledRejection` and verified the MongoDB connection is closed before the application exits.
- Triggered an `uncaughtException` and verified graceful database cleanup.