### PR TITLE
fix(frontend): clean password placeholder and fix forgot link focus

### DIFF
--- a/frontend/src/components/login/login.component.tsx
+++ b/frontend/src/components/login/login.component.tsx
@@ -190,7 +190,7 @@ const LoginComponent = () => {
                   label="Password"
                   name="password"
                   type="password"
-                  placeholder="Enter your password"
+                  placeholder="Enter you password"
                   required
                   icon="fi fi-rr-lock"
                   register={register}
@@ -202,7 +202,7 @@ const LoginComponent = () => {
                 <div className="flex justify-end pt-2">
                   <Link
                     to="/forgot-password"
-                    className="text-xs font-semibold text-blue-600 dark:text-blue-400 hover:underline transition-colors"
+                    className="text-xs font-semibold text-blue-600 dark:text-blue-400 hover:underline transition-colors focus:underline focus:outline-none focus:ring-2 focus:ring-blue-500 rounded-sm "
                   >
                     Forgot Password?
                   </Link>

--- a/frontend/src/components/login/login.component.tsx
+++ b/frontend/src/components/login/login.component.tsx
@@ -202,7 +202,7 @@ const LoginComponent = () => {
                 <div className="flex justify-end pt-2">
                   <Link
                     to="/forgot-password"
-                    className="text-xs font-semibold text-blue-600 dark:text-blue-400 hover:underline transition-colors focus:underline focus:outline-none focus:ring-2 focus:ring-blue-500 rounded-sm "
+                    className="text-xs font-semibold text-blue-600 dark:text-blue-400 hover:underline transition-colors focus:underline focus:outline-none focus:ring-2 focus:ring-blue-500 rounded-sm"
                   >
                     Forgot Password?
                   </Link>


### PR DESCRIPTION
### Description
- Cleaned the password input placeholder by removing hidden/invisible BELL characters that were breaking screen readers.
- Added explicit Tailwind focus states (`focus:underline focus:ring-2 focus:ring-blue-500`) to the "Forgot Password?" link to ensure it is visually distinguishable when navigating via keyboard Tab.

### Related Issue
Closes #4959

### Checklist
-  My code follows the style guidelines of this project
-  I have performed a self-review of my own code
-  My changes generate no new warnings