### PR TITLE
test(shared): add unit tests for send_response utility

### DIFF
--- a/backend/src/shared/__tests__/send_response.test.ts
+++ b/backend/src/shared/__tests__/send_response.test.ts
@@ -1,0 +1,99 @@
+import { Response } from "express";
+import sendResponse from "../send_response";
+
+const makeRes = (): Partial<Response> => ({
+  status: jest.fn().mockReturnThis(),
+  json: jest.fn().mockReturnThis(),
+});
+
+describe("send_response", () => {
+  it("sends correct JSON structure with all fields", () => {
+    const res = makeRes();
+
+    sendResponse(res as Response, {
+      success: true,
+      statusCode: 200,
+      message: "Fetched successfully",
+      meta: { page: 1, limit: 10, total: 1 },
+      data: { id: "1", name: "Riko" },
+    });
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      statusCode: 200,
+      message: "Fetched successfully",
+      meta: { page: 1, limit: 10, total: 1 },
+      data: { id: "1", name: "Riko" },
+    });
+  });
+
+  it("preserves the correct HTTP status code", () => {
+    const res = makeRes();
+
+    sendResponse(res as Response, {
+      success: false,
+      statusCode: 404,
+      message: "Not found",
+      data: null,
+    });
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.status).toHaveBeenCalledTimes(1);
+    expect((res.json as jest.Mock).mock.calls[0][0]).toMatchObject({
+      statusCode: 404,
+    });
+  });
+
+  it("handles response with meta fields (page, limit, total)", () => {
+    const res = makeRes();
+
+    sendResponse(res as Response, {
+      success: true,
+      statusCode: 200,
+      message: "List fetched",
+      meta: { page: 2, limit: 20, total: 57 },
+      data: [{ id: "1" }, { id: "2" }],
+    });
+
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        meta: { page: 2, limit: 20, total: 57 },
+      })
+    );
+  });
+
+  it("handles response with null data", () => {
+    const res = makeRes();
+
+    sendResponse(res as Response, {
+      success: true,
+      statusCode: 204,
+      message: "No content",
+      data: null,
+    });
+
+    expect(res.status).toHaveBeenCalledWith(204);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: null,
+      })
+    );
+  });
+
+  it("uses null for message when not provided", () => {
+    const res = makeRes();
+
+    sendResponse(res as Response, {
+      success: true,
+      statusCode: 200,
+      data: { id: "1" },
+    });
+
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: null,
+      })
+    );
+  });
+});


### PR DESCRIPTION
## What
Adds unit tests for `send_response.ts`, which is used across all backend
endpoints to standardize the JSON response shape (`success`, `statusCode`,
`message`, `meta`, `data`).

## Tests added
- sends correct JSON structure with all fields
- preserves the correct HTTP status code
- handles response with meta fields (page, limit, total)
- handles response with null data
- uses null for message when not provided

Express's `Response` is mocked (`status`/`json` as jest mocks returning
`this`) so no real server is needed.

## Note on file location
The linked issue specifies `backend/src/shared/tests/send_response.test.ts`,
but this repo's `jest.config.js` only matches `**/__tests__/**/*.test.ts` —
a plain `tests/` folder is never picked up by the test runner. Placed the
file at `backend/src/shared/__tests__/send_response.test.ts` instead, next
to the existing `pick.test.ts`, so it's actually discovered.

## Verification
All 5 tests pass locally against the current implementation.

Closes #4572 