### PR TITLE
fix(layout): hide global chat widget on authentication pages

### DIFF
--- a/frontend/src/components/layout/root_layout.component.tsx
+++ b/frontend/src/components/layout/root_layout.component.tsx
@@ -22,6 +22,8 @@ const RootLayout: React.FC<RootLayoutProps> = ({ children }) => {
     setCookieBannerHeight(height);
   }, []);
 
+  const isAuthPage = pathname === '/login' || pathname === '/signup' || pathname === '/forgot-password';
+
   return (
     <div
       className={`flex min-h-screen flex-col bg-slate-50 text-slate-900 transition-colors duration-300 dark:bg-slate-950 dark:text-slate-100 pb-20 lg:pb-0`}
@@ -33,7 +35,7 @@ const RootLayout: React.FC<RootLayoutProps> = ({ children }) => {
       <div className="flex-grow min-h-0">{children}</div>
 
       <FooterComponent />
-<ChatComponent />
+      {!isAuthPage && <ChatComponent />}
     </div>
   );
 };


### PR DESCRIPTION
The ChatComponent was rendered unconditionally in RootLayout, causing it to appear on /login, /signup, and /forgot-password pages where it creates an inconsistent authentication experience.

**Changes:**
- Add an  check based on  in 
- Conditionally render  only on non-authentication routes

**Verification:**
-  was already imported in RootLayout
- No new imports required

Closes #4656