### PR TITLE
fix: improve hero section heading visibility in light mode

### DIFF
--- a/frontend/src/components/story-inspiration/story_inspiration.component.tsx
+++ b/frontend/src/components/story-inspiration/story_inspiration.component.tsx
@@ -79,7 +79,16 @@ const StoryInspirationComponent: React.FC = () => {
 
           <h1 className="text-5xl md:text-7xl xl:text-8xl font-black tracking-tight leading-[0.95] mb-8">
             <span className="block text-slate-900 dark:text-white">Story</span>
-            <span className="block text-transparent bg-clip-text bg-gradient-to-r from-indigo-600 via-blue-600 to-purple-600 dark:from-indigo-300 dark:via-blue-300 dark:to-purple-300">
+            <span
+  className="block
+  text-indigo-700
+  dark:text-transparent
+  dark:bg-clip-text
+  dark:bg-gradient-to-r
+  dark:from-indigo-300
+  dark:via-blue-300
+  dark:to-purple-300"
+>
               Inspiration Hub
             </span>
           </h1>


### PR DESCRIPTION
## Summary

This PR improves the visibility of the **"Inspiration Hub"** heading on the Story Inspiration page in **light mode**.

### Changes
- Replaced the low-contrast transparent gradient text in light mode with a solid indigo text color.
- Preserved the existing gradient effect for dark mode.

### Why
The heading appeared faded against the light background, reducing readability and visual hierarchy.
## Notes

I could not verify the change by running the application because the current `main` branch contains unrelated TypeScript/JSX compilation errors in other components. This change is isolated to the Story Inspiration component.

Fixes #1264