### PR TITLE
feat: add getEngagementStats static method to PostModel

### DIFF
--- a/backend/src/app/modules/post/__tests__/post.model.test.ts
+++ b/backend/src/app/modules/post/__tests__/post.model.test.ts
@@ -1,0 +1,46 @@
+import { Post } from "../post.model";
+
+describe("Post.getEngagementStats", () => {
+  const postId = "507f1f77bcf86cd799439011";
+  const projection =
+    "likesCount commentsCount bookmarksCount viewsCount averageRating totalRatings";
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("returns all engagement metrics using one projected post query", async () => {
+    const lean = jest.fn().mockResolvedValue({
+      likesCount: 12,
+      commentsCount: 4,
+      bookmarksCount: 3,
+      viewsCount: 250,
+      averageRating: 4.6,
+      totalRatings: 8,
+    });
+    const select = jest.fn().mockReturnValue({ lean });
+    const findById = jest.spyOn(Post, "findById").mockReturnValue({ select } as never);
+
+    await expect(Post.getEngagementStats(postId)).resolves.toEqual({
+      likesCount: 12,
+      commentsCount: 4,
+      bookmarksCount: 3,
+      viewsCount: 250,
+      averageRating: 4.6,
+      totalRatings: 8,
+    });
+
+    expect(findById).toHaveBeenCalledTimes(1);
+    expect(findById).toHaveBeenCalledWith(postId);
+    expect(select).toHaveBeenCalledWith(projection);
+    expect(lean).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null when the post does not exist", async () => {
+    const lean = jest.fn().mockResolvedValue(null);
+    const select = jest.fn().mockReturnValue({ lean });
+    jest.spyOn(Post, "findById").mockReturnValue({ select } as never);
+
+    await expect(Post.getEngagementStats(postId)).resolves.toBeNull();
+  });
+});

--- a/backend/src/app/modules/post/post.interface.ts
+++ b/backend/src/app/modules/post/post.interface.ts
@@ -42,7 +42,21 @@ export interface IPost extends IPostPayload {
   rootStoryId?: Types.ObjectId;
 }
 
-export type PostModel = Model<IPost, object>;
+/** The engagement counters stored with a post for dashboard use. */
+export interface IPostEngagementStats {
+  likesCount: number;
+  commentsCount: number;
+  bookmarksCount: number;
+  viewsCount: number;
+  averageRating: number;
+  totalRatings: number;
+}
+
+export interface PostModel extends Model<IPost> {
+  getEngagementStats(
+    postId: string | Types.ObjectId,
+  ): Promise<IPostEngagementStats | null>;
+}
 
 export interface IPostSearchFields {
   searchTerm?: string;

--- a/backend/src/app/modules/post/post.model.ts
+++ b/backend/src/app/modules/post/post.model.ts
@@ -1,7 +1,7 @@
-import { model, Schema } from "mongoose";
-import { IPost, PostModel } from "./post.interface";
+import { model, Schema, Types } from "mongoose";
+import { IPost, IPostEngagementStats, PostModel } from "./post.interface";
 
-export const PostSchema: Schema<IPost> = new Schema<IPost, PostModel>(
+export const PostSchema: Schema<IPost, PostModel> = new Schema<IPost, PostModel>(
   {
     title: { type: String, required: true, maxlength: 200 },
     content: { type: String, required: true, maxlength: 50000 },
@@ -77,5 +77,36 @@ PostSchema.index(
   }
 );
 PostSchema.index({ createdAt: -1 });
+
+/**
+ * Reads every dashboard engagement metric from the denormalized post document
+ * in one query, rather than issuing an individual query per metric.
+ */
+PostSchema.static(
+  "getEngagementStats",
+  async function getEngagementStats(
+    this: PostModel,
+    postId: string | Types.ObjectId,
+  ): Promise<IPostEngagementStats | null> {
+    const post = await this.findById(postId)
+      .select(
+        "likesCount commentsCount bookmarksCount viewsCount averageRating totalRatings",
+      )
+      .lean();
+
+    if (!post) {
+      return null;
+    }
+
+    return {
+      likesCount: post.likesCount ?? 0,
+      commentsCount: post.commentsCount ?? 0,
+      bookmarksCount: post.bookmarksCount ?? 0,
+      viewsCount: post.viewsCount ?? 0,
+      averageRating: post.averageRating ?? 0,
+      totalRatings: post.totalRatings ?? 0,
+    };
+  },
+);
 
 export const Post = model<IPost, PostModel>("Post", PostSchema);


### PR DESCRIPTION
- Add IPostEngagementStats interface with dashboard metrics
- Implement single-query getEngagementStats on PostModel
- Add unit tests for existing/non-existing post cases

## Before you open this PR

- **Issue:** Open or link a related issue when there is one (`Closes #123`, `Fixes #45`, or write **None** under Related issue below).
- **Description:** Fill in **What this PR does** so a reviewer can understand the change without your local context.
- **Screenshots:** Add screenshots or a short recording when they help (UI changes, confusing flows, or non-code proof). If not needed, say so in the checklist.

## Screenshot (when helpful)

<!-- Drag & drop or paste. For non-UI work, you can use tests output, logs, or API responses. Write “N/A” in the checklist if you skip this section. -->



## What this PR does

<!-- Short summary: what problem does this solve, and how? -->




## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

<!-- Example: Closes #123 or Fixes #45. Use “None” if there is no issue. -->



## More screenshots (optional)

<!-- Extra before/after images, flows, or recordings for reviewers. -->



## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
