### PR TITLE
fix(character-network): auto-refresh graph when story content changes

### DIFF
--- a/frontend/src/components/CharacterNetwork.tsx
+++ b/frontend/src/components/CharacterNetwork.tsx
@@ -30,6 +30,7 @@ const edgeTypes: EdgeTypes = {
 
 interface CharacterNetworkProps {
   storyId: string;
+  storyContent: string;
 }
 
 interface Character {
@@ -64,7 +65,7 @@ type RelationshipEdgeData = {
 type CharacterFlowNode = Node<CharacterNodeData, "character">;
 type CharacterFlowEdge = Edge<RelationshipEdgeData, "relationship">;
 
-const CharacterNetwork = ({ storyId }: CharacterNetworkProps) => {
+const CharacterNetwork = ({ storyId, storyContent }: CharacterNetworkProps) => {
   const { data: networkData, isLoading, isFetching, error, refetch } = useGetCharacterNetworkQuery(storyId);
 
   // Filter States
@@ -97,10 +98,10 @@ const CharacterNetwork = ({ storyId }: CharacterNetworkProps) => {
     setMinStrength(1);
   }, []);
 
-  // Sync / Refetch when story content changes
+  // Sync / Refetch when the story changes OR when its content is edited
   useEffect(() => {
     refetch();
-  }, [storyId, refetch]);
+  }, [storyId, storyContent, refetch]);
 
   // Nodes & Edges computing based on active filters
   const rawCharacters = useMemo(() => networkData?.characters || [], [networkData]);

--- a/frontend/src/components/story/StoryWorkspace.tsx
+++ b/frontend/src/components/story/StoryWorkspace.tsx
@@ -217,7 +217,14 @@ const StoryWorkspace = () => {
             </div>
           </>
         ) : (
-          <CharacterNetwork storyId={currentStory.id} />
+           <CharacterNetwork
+           storyId={currentStory.id}
+                       storyContent={
+             currentStory.chapters
+               ?.map((chapter) => chapter.content)
+                .join("\n\n") || ""
+            }
+          />
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
Closes #4966. The character relationship visualization (extraction, relationship
classification, and the interactive React Flow graph) already existed in the
codebase, but the graph only refetched when `storyId` changed — not when the
story's content was edited in place. This PR fixes the auto-update behavior
requested in the issue.

## Problem
`CharacterNetwork.tsx`'s refetch effect only depended on `storyId`:

```tsx
useEffect(() => {
  refetch();
}, [storyId, refetch]);
```

Editing chapters within the same story left the character network stale until
navigating away and back to the story.

## Fix
- `CharacterNetwork.tsx`: added a `storyContent: string` prop and included it
  in the refetch effect's dependency array, so any content change triggers a
  fresh analysis.
- `StoryWorkspace.tsx`: passes `storyContent` down as the joined chapter text
  (`currentStory.chapters.map(c => c.content).join("\n\n")`), consistent with
  how `StoryChecklist` and `StoryRewritePanel` already derive content in this
  file.

## Files changed
- `frontend/src/components/CharacterNetwork.tsx`
- `frontend/src/components/story/StoryWorkspace.tsx`

## Testing
- Verified no other callers of `<CharacterNetwork />` exist, so this is not a
  breaking change to any other usage.
- Manually traced the prop flow from `StoryWorkspace` → `CharacterNetwork` →
  refetch effect.
- [ ] Please run `npm run build` / `tsc --noEmit` in `frontend/` locally to
      confirm a clean type-check before merging.
- [ ] Manual test: open a story, switch to "Character Network" tab, edit a
      chapter, confirm the graph refetches without needing to switch stories.

## Notes / follow-ups
- This assumes chapter edits are reflected in `currentStory.chapters`
  optimistically (in local/Redux state) rather than only after a server
  round-trip. If edits are currently only committed on save, the graph will
  still refresh correctly, just with the same latency as the save itself.