### PR TITLE
fix: align login form fields

### DIFF
--- a/frontend/src/components/login/login.component.tsx
+++ b/frontend/src/components/login/login.component.tsx
@@ -18,6 +18,13 @@ type Inputs = {
   password: string;
 };
 
+type LoginError = {
+  data?: {
+    message?: string;
+  };
+  message?: string;
+};
+
 const LoginComponent = () => {
   const [loginUser] = useLoginUserMutation();
   const [googleLogin] = useGoogleLoginMutation();
@@ -44,10 +51,12 @@ const LoginComponent = () => {
         const from = location.state?.from || "/dashboard";
         navigate(from, { replace: true });
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const loginError = error as LoginError;
+
       toast.error(
-        error?.data?.message ||
-        error?.message ||
+        loginError.data?.message ||
+        loginError.message ||
         "Login failed. Please try again.")
     } finally {
       setIsBusy(false);
@@ -153,7 +162,7 @@ const LoginComponent = () => {
           </div>
         </motion.div>
 
-                <div className="flex justify-center w-full box-border">
+        <div className="flex justify-center w-full box-border">
           <div className="w-full max-w-md bg-slate-50 dark:bg-slate-800/60 backdrop-blur-xl border border-slate-200 dark:border-slate-700/50 rounded-2xl p-6 sm:p-8 lg:p-10 shadow-2xl box-border overflow-hidden relative mx-auto">
             <button
               onClick={() => navigate("/")}
@@ -199,11 +208,11 @@ const LoginComponent = () => {
                   label="Password"
                   name="password"
                   type="password"
-                  placeholder="Enter you password"
+                  placeholder="Enter your password"
                   required
                   icon="fi fi-rr-lock"
                   register={register}
-                    validation={{
+                  validation={{
                     required: "Password is required",
                     minLength: {
                       value: 8,
@@ -225,13 +234,13 @@ const LoginComponent = () => {
               </div>
 
               <div className="pt-2">
-               <SSButton
-                    text="Sign In"
-                    type="submit"
-                    isLoading={isBusy}
-                    disabled={isBusy}
+                <SSButton
+                  text="Sign In"
+                  type="submit"
+                  isLoading={isBusy}
+                  disabled={isBusy}
                 />
-              </div>a
+              </div>
             </form>
 
             <div className="relative my-8 w-full">

--- a/frontend/src/components/ui-component/ss-input/ss-input.tsx
+++ b/frontend/src/components/ui-component/ss-input/ss-input.tsx
@@ -52,7 +52,7 @@ const SSInput = <T extends FieldValues>({
         {label} {required && <span className="text-rose-500">*</span>}
       </label>
 
-      <div className="relative mt-2 flex items-center">
+      <div className="relative mt-2 flex w-full items-center">
         {icon && (
           <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500 flex items-center pointer-events-none">
             <i className={icon}></i>
@@ -66,7 +66,7 @@ const SSInput = <T extends FieldValues>({
           autoComplete={autoComplete}
           autoFocus={autoFocus}
           {...register(name, validation)}
-          className={`w-[85%] mx-auto min-w-0 h-11 block box-border rounded-xl border text-sm transition-all duration-200 focus:outline-none focus:ring-2 ${
+          className={`w-full min-w-0 h-11 block box-border rounded-xl border text-sm transition-all duration-200 focus:outline-none focus:ring-2 ${
             icon ? "pl-11" : "px-4"
           } ${isPasswordType ? "pr-11" : "pr-4"} ${
             error
@@ -79,7 +79,7 @@ const SSInput = <T extends FieldValues>({
           <button
             type="button"
             onClick={() => setShowLocalPassword(!showLocalPassword)}
-            className="absolute right-4 top-1/2 -translate-y-1/2 flex items-center text-slate-400 hover:text-slate-200 dark:text-slate-500 dark:hover:text-slate-300 z-10 focus:outline-none transition-colors cursor-pointer"
+            className="absolute right-3 top-1/2 -translate-y-1/2 flex items-center text-slate-400 hover:text-slate-200 dark:text-slate-500 dark:hover:text-slate-300 z-10 focus:outline-none transition-colors cursor-pointer"
             aria-label={showLocalPassword ? "Hide password" : "Show password"}
             title={showLocalPassword ? "Hide password" : "Show password"}
           >


### PR DESCRIPTION
﻿## Summary
- align login form inputs to the full auth card width so fields, labels, password toggle, and submit button line up consistently
- remove the stray rendered `a` after the sign-in button
- correct the password placeholder text and replace the login catch `any` with a typed error shape

## Root cause
The shared `SSInput` component forced inputs to `w-[85%] mx-auto`, while the surrounding form labels and submit button used the full card width. This made the login form look misaligned and also offset the password visibility control.

## Validation
- `npm.cmd exec -w story-spark-ai-frontend -- eslint src/components/login/login.component.tsx src/components/ui-component/ss-input/ss-input.tsx`
- `git diff --check`

Note: `npm.cmd run build -w story-spark-ai-frontend` currently fails before this change on unrelated existing syntax errors in `src/components/branching/StoryBranchingEditor.ts` and `src/components/stories/stories.component.tsx`.

Closes #3335
