### PR TITLE
fix: correct getOptionalToken return type in collection controller

### DIFF
--- a/backend/src/app/modules/collection/collection.controller.ts
+++ b/backend/src/app/modules/collection/collection.controller.ts
@@ -5,6 +5,7 @@ import { getToken } from "../../middleware/token";
 import sendResponse from "../../../shared/send_response";
 import httpStatus from "http-status";
 import { CollectionService } from "./collection.service";
+import { ITokenPayload } from "../../../interfaces/token";
 
 // --- Interfaces for Request Bodies (Type Safety) ---
 interface CreateCollectionBody {
@@ -25,9 +26,9 @@ interface AddStoryBody {
 }
 
 // --- Helper Utility (Can be moved to your token middleware file) ---
-const getOptionalToken = async (req: Request): Promise<string | null> => {
+const getOptionalToken = (req: Request): ITokenPayload | null => {
   try {
-    return await getToken(req);
+    return getToken(req);
   } catch {
     return null; // Unauthenticated visitor
   }
@@ -66,7 +67,7 @@ const updateCollection = catchAsync(async (req: Request, res: Response) => {
 
 const getCollectionById = catchAsync(async (req: Request, res: Response) => {
   const id = routeParam(req.params.id);
-  const token = await getOptionalToken(req); // Cleaned up DRY logic
+  const token = getOptionalToken(req); // Cleaned up DRY logic
   
   const result = await CollectionService.getCollectionById(id, token);
   
@@ -80,7 +81,7 @@ const getCollectionById = catchAsync(async (req: Request, res: Response) => {
 
 const getUserCollections = catchAsync(async (req: Request, res: Response) => {
   const userId = routeParam(req.params.userId);
-  const token = await getOptionalToken(req); // Cleaned up DRY logic
+  const token = getOptionalToken(req); // Cleaned up DRY logic
   
   const result = await CollectionService.getUserCollections(userId, token);
   


### PR DESCRIPTION
## Summary

Fixes the type mismatch in `collection.controller.ts` by updating `getOptionalToken` to return `ITokenPayload | null` instead of `string | null`.

## Changes

- Imported `ITokenPayload`
- Updated `getOptionalToken` return type
- Removed unnecessary `async`/`await`
- Removed unnecessary `await` when calling `getOptionalToken`

## Testing

Ran:

```bash
npx tsc --noEmit
```

The type errors from `collection.controller.ts` are resolved.

The remaining TypeScript errors reported by the compiler are in unrelated files (`analytics.controller.ts`, `redis.client.ts`, and `server.ts`) and are outside the scope of this issue.

Fixes #4891