### PR TITLE
fix: wire CircuitBreaker recordSuccess/recordFailure into generation timeout wrapper

### DIFF
--- a/backend/src/utils/generation_timeout.ts
+++ b/backend/src/utils/generation_timeout.ts
@@ -1,3 +1,5 @@
+import { aiCircuitBreaker } from "../app/modules/ai_model/circuit_breaker";
+
 export class GenerationTimeoutError extends Error {
   constructor(message = "Generation timed out") {
     super(message);
@@ -20,6 +22,9 @@ export const raceGenerationWithTimeout = async <T>(
   timeLimitMs: number,
   externalSignal?: AbortSignal
 ): Promise<T> => {
+  // Fail fast if the AI provider circuit is currently open.
+  aiCircuitBreaker.check();
+
   const controller = new AbortController();
   let timedOut = false;
 
@@ -54,12 +59,22 @@ export const raceGenerationWithTimeout = async <T>(
         if (externalSignal && abortHandler) {
           externalSignal.removeEventListener("abort", abortHandler);
         }
+        // Successful AI provider response — reset the circuit breaker.
+        aiCircuitBreaker.recordSuccess();
         resolve(result);
       })
       .catch((error) => {
         clearTimeout(timeoutId);
         if (externalSignal && abortHandler) {
           externalSignal.removeEventListener("abort", abortHandler);
+        }
+        // recordFailure() re-throws by design; it only increments the
+        // breaker's counter for real provider errors (status 429/5xx),
+        // so timeouts/aborts (no status) pass through without tripping it.
+        try {
+          aiCircuitBreaker.recordFailure(error);
+        } catch {
+          // side effect already applied above; rejection handled below
         }
         // Check aborted BEFORE calling abort() so we can distinguish
         // a genuine timeout (already aborted by setTimeout) from a real


### PR DESCRIPTION
…timeout wrapper

Fixes #3981

CircuitBreaker.recordSuccess() existed but was never called anywhere, so failure counts never reset after the AI provider recovered from transient errors, eventually tripping the breaker permanently.

Wired aiCircuitBreaker.check() / recordSuccess() / recordFailure() into raceGenerationWithTimeout, since all AI generation calls already route through this single wrapper. recordFailure() only counts real provider errors (status 429/5xx), so timeouts and aborts don't trip the breaker.

## Before you open this PR

- **Issue:** Open or link a related issue when there is one (`Closes #123`, `Fixes #45`, or write **None** under Related issue below).
- **Description:** Fill in **What this PR does** so a reviewer can understand the change without your local context.
- **Screenshots:** Add screenshots or a short recording when they help (UI changes, confusing flows, or non-code proof). If not needed, say so in the checklist.

## Screenshot (when helpful)

N/A — backend logic fix, no UI change. Covered by reasoning below instead of a screenshot.

<!-- Drag & drop or paste. For non-UI work, you can use tests output, logs, or API responses. Write “N/A” in the checklist if you skip this section. -->



## What this PR does

`CircuitBreaker.recordSuccess()` existed in `circuit_breaker.ts` but was never called anywhere in the codebase, so failure counts never reset after the AI provider recovered from transient errors — eventually tripping the breaker into a permanent open state.

All AI generation calls already route through a single shared wrapper, `raceGenerationWithTimeout` (backend/src/utils/generation_timeout.ts), so I wired the circuit breaker in there instead of touching every individual call site:
- `aiCircuitBreaker.check()` — fails fast if the circuit is already open
- `aiCircuitBreaker.recordSuccess()` — called on successful generation
- `aiCircuitBreaker.recordFailure(error)` — called on failure

`recordFailure()` only counts real provider errors (status 429/5xx), so `GenerationTimeoutError`/`GenerationAbortedError` (which carry no `status`) pass through without tripping the breaker.

Kept the change minimal and scoped to this one file to avoid overlapping with #4270/#4403, which are working in the same catch block on a separate issue.

<!-- Short summary: what problem does this solve, and how? -->




## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Fixes #3981
<!-- Example: Closes #123 or Fixes #45. Use “None” if there is no issue. -->



## More screenshots (optional)

<!-- Extra before/after images, flows, or recordings for reviewers. -->



## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
