### PR TITLE
fix: preserve selected theme on auth pages

### DIFF
--- a/frontend/src/components/theme-switcher/ThemeSwitcher.tsx
+++ b/frontend/src/components/theme-switcher/ThemeSwitcher.tsx
@@ -50,6 +50,12 @@ function getStoredTheme() {
       const parsed = JSON.parse(saved);
       return themes.find((t) => t.id === parsed.id) || themes[0];
     }
+
+    // Keep the palette switcher aligned with the shared light/dark preference.
+    // This prevents mounting the switcher from resetting a light theme to dark.
+    if (localStorage.getItem("theme") === "light") {
+      return themes.find((theme) => theme.name === "Light") || themes[0];
+    }
   } catch {
     // ignore parse errors, fall through to default
   }


### PR DESCRIPTION
## Summary
- respect the shared `theme=light` preference when the palette switcher has no saved `selectedTheme`
- prevent mounting the dashboard palette switcher from resetting a previously selected light mode to Dark
- preserve the selected mode while navigating to Login and Sign Up

The input-overflow portion of #4560 is already fixed on `main` by the existing SSInput change; this PR addresses the remaining theme-persistence regression.

Closes #4560

## Validation
- `git diff --check`
- Frontend TypeScript/ESLint/build not run locally: dependencies are not installed in this checkout; repository CI should provide the full toolchain.
