### PR TITLE
fix: add scroll to top hover feedback

### DIFF
--- a/frontend/src/components/ScrollToTopButton.tsx
+++ b/frontend/src/components/ScrollToTopButton.tsx
@@ -42,6 +42,8 @@ const ScrollToTopButton = () => {
         flex items-center justify-center
         shadow-[0_4px_15px_rgba(59,130,246,0.4)]
         transition-all duration-300 ease-in-out
+        hover:scale-110 hover:shadow-[0_6px_22px_rgba(59,130,246,0.6)]
+        active:scale-95
         z-[9999]
         ${isVisible
           ? "opacity-100 translate-y-0 pointer-events-auto"


### PR DESCRIPTION
Closes #4286

## Summary
- add hover scale and elevated shadow feedback to the scroll-to-top button
- add a pressed-state scale for pointer and keyboard activation

## Validation
- git diff --check
- focused ESLint unavailable because frontend dependencies are not installed locally