### PR TITLE
fix: align feedback and contact form layouts

### DIFF
--- a/frontend/src/components/contactus/contactus.tsx
+++ b/frontend/src/components/contactus/contactus.tsx
@@ -624,7 +624,7 @@ export default function Contact() {
 
           {/* RIGHT COLUMN — FORM */}
           <div
-            className={`contact-col-right w-full lg:sticky lg:top-24 transition-all duration-700 delay-150 ${
+            className={`contact-col-right w-full lg:mx-auto lg:max-w-2xl lg:sticky lg:top-24 transition-all duration-700 delay-150 ${
               isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"
             }`}
           >


### PR DESCRIPTION
Closes #4561

## Summary
- cap the desktop contact form to the same `max-w-2xl` width used by the feedback form
- center the contact form within its grid column while keeping mobile layouts full width

## Validation
- git diff --check
- focused ESLint unavailable because frontend dependencies are not installed locally