### PR TITLE
feat: Add PDF and EPUB export options with custom formatting

### DIFF
--- a/frontend/src/components/stories/ExportStoryModal.tsx
+++ b/frontend/src/components/stories/ExportStoryModal.tsx
@@ -1,0 +1,130 @@
+import React, { useState } from 'react';
+import toast from 'react-hot-toast';
+import {
+  exportStoryToPDF,
+  exportStoryToEPUB,
+  fetchImageAsBlob,
+  blobToBase64,
+  IExportStory,
+  IExportOptions
+} from '../../services/export.service';
+
+interface ExportStoryModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  story: IExportStory;
+}
+
+const ExportStoryModal: React.FC<ExportStoryModalProps> = ({ isOpen, onClose, story }) => {
+  const [format, setFormat] = useState<'pdf' | 'epub'>('pdf');
+  const [fontSize, setFontSize] = useState<IExportOptions['fontSize']>('medium');
+  const [isExporting, setIsExporting] = useState(false);
+
+  if (!isOpen) return null;
+
+  const handleExport = async () => {
+    setIsExporting(true);
+    try {
+      const options: IExportOptions = { fontSize };
+      
+      let imageBlob: Blob | null = null;
+      let base64Image: string | null = null;
+      
+      if (story.imageURL) {
+        try {
+          imageBlob = await fetchImageAsBlob(story.imageURL);
+          if (format === 'pdf' && imageBlob) {
+            base64Image = await blobToBase64(imageBlob);
+          }
+        } catch (error) {
+          console.error("Failed to fetch image for export", error);
+          toast.error("Failed to include cover image, but exporting anyway...");
+        }
+      }
+
+      if (format === 'pdf') {
+        await exportStoryToPDF(story, base64Image, options);
+      } else {
+        await exportStoryToEPUB(story, imageBlob, options);
+      }
+
+      toast.success(`${format.toUpperCase()} exported successfully!`);
+      onClose();
+    } catch (error) {
+      console.error(error);
+      toast.error(`Failed to export ${format.toUpperCase()}.`);
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div className="bg-slate-800 border border-slate-700 p-6 rounded-2xl shadow-2xl w-full max-w-md animate-fade-in-up">
+        <h2 className="text-2xl font-bold text-slate-100 mb-6">Export Story</h2>
+        
+        <div className="space-y-4">
+          <div>
+            <label className="block text-slate-300 mb-2 font-medium">Format</label>
+            <div className="flex gap-4">
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="radio"
+                  name="format"
+                  value="pdf"
+                  checked={format === 'pdf'}
+                  onChange={() => setFormat('pdf')}
+                  className="form-radio text-indigo-500 bg-slate-700 border-slate-600"
+                />
+                <span className="text-slate-200">PDF</span>
+              </label>
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="radio"
+                  name="format"
+                  value="epub"
+                  checked={format === 'epub'}
+                  onChange={() => setFormat('epub')}
+                  className="form-radio text-indigo-500 bg-slate-700 border-slate-600"
+                />
+                <span className="text-slate-200">EPUB</span>
+              </label>
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-slate-300 mb-2 font-medium">Font Size</label>
+            <select
+              value={fontSize}
+              onChange={(e) => setFontSize(e.target.value as any)}
+              className="w-full bg-slate-700 text-slate-200 border border-slate-600 rounded-lg p-2.5 focus:ring-2 focus:ring-indigo-500 focus:outline-none"
+            >
+              <option value="small">Small</option>
+              <option value="medium">Medium</option>
+              <option value="large">Large</option>
+            </select>
+          </div>
+        </div>
+
+        <div className="mt-8 flex justify-end gap-3">
+          <button
+            onClick={onClose}
+            disabled={isExporting}
+            className="px-4 py-2 rounded-lg text-slate-300 hover:bg-slate-700 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleExport}
+            disabled={isExporting}
+            className="px-4 py-2 rounded-lg bg-indigo-600 text-white hover:bg-indigo-500 transition-colors disabled:opacity-50 flex items-center gap-2"
+          >
+            {isExporting ? 'Exporting...' : 'Export'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ExportStoryModal;

--- a/frontend/src/components/stories/stories.view.component.tsx
+++ b/frontend/src/components/stories/stories.view.component.tsx
@@ -15,11 +15,11 @@ import StoryTitleSuggestions from "./StoryTitleSuggestions";
 import StoryVersionHistory from "./StoryVersionHistory";
 import { formatReadingStats } from "../../utils/story-utils";
 import { useCreatePostMutation } from "../../redux/apis/post.api";
-import jsPDF from "jspdf";
 import toast, { Toaster } from "react-hot-toast";
 import StoryTranslator from "../translate/StoryTranslator";
 import AudioPlayer, { type AudioPlayerHandle, type NarrationPlaybackState } from "../AudioPlayer";
 import { useLocation } from "react-router-dom";
+import ExportStoryModal from "./ExportStoryModal";
 
 export interface IStories {
   uuid: string;
@@ -97,6 +97,7 @@ const StoriesViewComponent: React.FC<StoriesComponentProps> = ({
   const [characterProfiles, setCharacterProfiles] = useState<CharacterProfile[]>([]);
   const [profileLoading, setProfileLoading] = useState<boolean>(false);
   const [showTranslator, setShowTranslator] = useState<boolean>(false);
+  const [showExportModal, setShowExportModal] = useState<boolean>(false);
   const [createPost] = useCreatePostMutation();
   const [showGenreTransformation, setShowGenreTransformation] = useState<boolean>(false);
 
@@ -191,34 +192,6 @@ const handleCopyStory = async () => {
        }
     };
 
-const handleExportPDF = () => {
-  if (!selectedStory) {
-    toast.error("No story available to export.");
-    return;
-  }
-
-  try {
-    const doc = new jsPDF();
-
-    const title = selectedStory.title || "Story";
-    const content = selectedStory.content || "";
-
-    doc.setFontSize(18);
-    doc.text(title, 15, 20);
-
-    doc.setFontSize(12);
-
-    const splitText = doc.splitTextToSize(content, 180);
-    doc.text(splitText, 15, 35);
-
-    doc.save(`${title}.pdf`);
-
-    toast.success("PDF downloaded!");
-  } catch (error) {
-    console.error(error);
-    toast.error("Failed to export PDF.");
-  }
-};
 
 const handleGenerateCharacterProfile = async () => {
   if (!selectedStory) {
@@ -384,9 +357,9 @@ if (!stories || stories.length === 0) {
                     <button
                       type="button"
                       className="rounded-lg px-4 py-2 bg-purple-700 text-slate-200 font-semibold cursor-pointer hover:bg-purple-600 transition-colors"
-                      onClick={handleExportPDF}
+                      onClick={() => setShowExportModal(true)}
                     >
-                      📄 Export PDF
+                      📄 Export
                     </button>
                     <button
                       type="button"
@@ -623,6 +596,14 @@ if (!stories || stories.length === 0) {
           story={selectedStory}
           isLogin={isLogin}
           onClose={() => setShowTranslator(false)}
+        />
+      )}
+
+      {showExportModal && selectedStory && (
+        <ExportStoryModal
+          isOpen={showExportModal}
+          onClose={() => setShowExportModal(false)}
+          story={selectedStory as any}
         />
       )}
     </div>

--- a/frontend/src/services/export.service.ts
+++ b/frontend/src/services/export.service.ts
@@ -11,6 +11,10 @@ export interface IExportStory {
   language?: string;
 }
 
+export interface IExportOptions {
+  fontSize?: 'small' | 'medium' | 'large';
+}
+
 /**
  * Asynchronous asset pipeline to fetch images from cloud storage
  * with a canvas CORS fallback.
@@ -107,7 +111,8 @@ export const blobToBase64 = (blob: Blob): Promise<string> => {
  */
 export const exportStoryToPDF = async (
   story: IExportStory,
-  base64Image: string | null
+  base64Image: string | null,
+  options?: IExportOptions
 ): Promise<void> => {
   const doc = new jsPDF({ orientation: "portrait", unit: "mm", format: "a4" });
   
@@ -228,7 +233,9 @@ export const exportStoryToPDF = async (
 
   // Story Text rendering
   doc.setFont("helvetica", "normal");
-  doc.setFontSize(11);
+  const fontSizeMap = { small: 9, medium: 11, large: 13 };
+  const contentFontSize = options?.fontSize ? fontSizeMap[options.fontSize] : 11;
+  doc.setFontSize(contentFontSize);
   doc.setTextColor(51, 65, 85); // slate-700
   
   const paragraphs = story.content.split(/\n+/);
@@ -285,7 +292,8 @@ export const exportStoryToPDF = async (
  */
 export const exportStoryToEPUB = async (
   story: IExportStory,
-  imageBlob: Blob | null
+  imageBlob: Blob | null,
+  options?: IExportOptions
 ): Promise<void> => {
   const zip = new JSZip();
   const uuid = story.uuid || Math.random().toString(36).substring(2, 15);
@@ -316,6 +324,7 @@ export const exportStoryToEPUB = async (
   margin: 20px;
   color: #111111;
   background-color: #ffffff;
+  font-size: ${options?.fontSize === 'small' ? '0.9em' : options?.fontSize === 'large' ? '1.2em' : '1em'};
 }
 h1, h2 {
   text-align: center;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "typecheck": "npm run typecheck -w story-spark-ai-backend && npm run typecheck -w story-spark-ai-frontend",
     "start:backend": "npm run start -w story-spark-ai-backend",
     "start:frontend": "npm run start -w story-spark-ai-frontend",
-    "lint": "npm run lint -w story-spark-ai-frontend"
+    "lint": "npm run lint -w story-spark-ai-frontend",
+    "test": "npm run test -w story-spark-ai-backend && npm run test -w story-spark-ai-frontend",
+    "test:coverage": "npm run test:coverage -w story-spark-ai-backend && npm run test:coverage -w story-spark-ai-frontend"
   },
   "packageManager": "pnpm@9.15.9",
   "devDependencies": {


### PR DESCRIPTION
## Description
Closes #5077 

This PR introduces a new export feature that allows users to download their generated stories as offline files (PDF and EPUB). To enhance the reading experience, it also provides basic typography customization, letting users select a font size (Small, Medium, Large) before exporting.

### Changes Made
- **Created `ExportStoryModal.tsx`**: A responsive modal containing format (PDF/EPUB) selection and font size options.
- **Updated `export.service.ts`**: 
  - Added an `IExportOptions` interface to parse configuration from the frontend.
  - Modified `exportStoryToPDF` to dynamically set the document's font size based on the user's choice.
  - Modified `exportStoryToEPUB` to inject a CSS `font-size` rule into the generated EPUB's styling.
- **Refactored `stories.view.component.tsx`**: Replaced the basic "Export PDF" button (which was tightly coupled to `jsPDF`) with a generic "Export" button that opens the new modal.

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/ronisarkarexe/story-spark-ai/blob/master/CONTRIBUTING.md) guide.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.


#### This PR is done under ECSoC 2026.
