### PR TITLE
feat: add audience-based story generation

### DIFF
--- a/backend/src/app/modules/ai_model/ai_model.interface.ts
+++ b/backend/src/app/modules/ai_model/ai_model.interface.ts
@@ -11,6 +11,7 @@ export interface IAIModel {
   language?: string;
   tone?: string;
   genre?: string;
+  targetAudience?: string;
   characters?: ICharacter[];
 }
 

--- a/backend/src/app/modules/ai_model/ai_model.service.ts
+++ b/backend/src/app/modules/ai_model/ai_model.service.ts
@@ -42,6 +42,7 @@ const normalizeStoryPayload = (payload: IAIModel) => ({
   language: payload.language ?? "English",
   tone: payload.tone ?? undefined,
   genre: payload.genre ?? undefined,
+  targetAudience: payload.targetAudience ?? undefined,
   characters: payload.characters ?? undefined,
 });
 
@@ -64,7 +65,7 @@ const mapGenerationError = (error: unknown, message: string): never => {
 // Bug fix 1: quota.lifecycle owns rollback — no manual User.updateOne needed.
 // Bug fix 2: _token kept as unused param (quota handled upstream by middleware).
 const aiModelGenerate = async (payload: IAIModel, _token?: ITokenPayload, signal?: AbortSignal) => {
-  const { prompt, wordLength, numStories, language, tone, genre, characters } =
+  const { prompt, wordLength, numStories, language, tone, genre, targetAudience, characters } =
     normalizeStoryPayload(payload);
 
   try {
@@ -78,6 +79,7 @@ const aiModelGenerate = async (payload: IAIModel, _token?: ITokenPayload, signal
           signal,
           tone,
           genre,
+          targetAudience,
           characters,
         ),
       AUTHENTICATED_GENERATION_TIMEOUT_MS,
@@ -91,7 +93,7 @@ const aiModelGenerate = async (payload: IAIModel, _token?: ITokenPayload, signal
 };
 
 const aiFreeModelGenerate = async (payload: IAIModel, signal?: AbortSignal) => {
-  const { prompt, wordLength, numStories, language, tone, genre, characters } =
+  const { prompt, wordLength, numStories, language, tone, genre, targetAudience, characters } =
     normalizeStoryPayload(payload);
 
   try {
@@ -105,6 +107,7 @@ const aiFreeModelGenerate = async (payload: IAIModel, signal?: AbortSignal) => {
           signal,
           tone,
           genre,
+          targetAudience,
           characters,
         ),
       FREE_GENERATION_TIMEOUT_MS,

--- a/backend/src/app/modules/ai_model/ai_model.utils.ts
+++ b/backend/src/app/modules/ai_model/ai_model.utils.ts
@@ -136,6 +136,11 @@ const buildToneInstruction = (tone?: string): string => {
   return `Tone & Style Directive: ${instruction}\n\n`;
 };
 
+const buildAudienceInstruction = (targetAudience?: string): string => {
+  if (!targetAudience) return "";
+  return `Target Audience Directive: Write the story specifically tailored for a ${targetAudience}. Adjust the complexity of the vocabulary, sentence structure, and thematic depth appropriately for this demographic.\n\n`;
+};
+
 const throwIfAborted = (signal?: AbortSignal): void => {
   if (signal?.aborted) {
     throw new GenerationAbortedError();
@@ -214,6 +219,7 @@ export async function generateWithGeminiStories(
   signal?: AbortSignal,
   tone?: string, // NEW: optional tone parameter
   genre?: string, // NEW: optional genre parameter
+  targetAudience?: string,
   characters?: ICharacter[],
 ): Promise<Story[]> {
   throwIfAborted(signal);
@@ -223,6 +229,7 @@ export async function generateWithGeminiStories(
   try {
     const genreInstruction = buildGenreInstruction(genre);
     const toneInstruction = buildToneInstruction(tone);
+    const audienceInstruction = buildAudienceInstruction(targetAudience);
     const charactersInstruction = buildCharactersInstruction(characters);
 
     const response = await executeWithRetryAndFallback(async (activeModel) => {
@@ -234,10 +241,11 @@ export async function generateWithGeminiStories(
 
       const toneInstruction = buildToneInstruction(tone);
       const genreInstruction = buildGenreInstruction(genre);
+      const audienceInstruction = buildAudienceInstruction(targetAudience);
       const charactersInstruction = buildCharactersInstruction(characters);
 
       return chatSession.sendMessage(
-        `${buildGenreInstruction(genre)}${buildToneInstruction(tone)}${buildCharactersInstruction(characters)}You are an expert storyteller and emotion analyst. The user provided the following base prompt: "${prompt}".
+        `${genreInstruction}${toneInstruction}${audienceInstruction}${charactersInstruction}You are an expert storyteller and emotion analyst. The user provided the following base prompt: "${prompt}".
         First, enhance this prompt to be more emotionally engaging and context-sensitive (e.g., add suspense, joy, or mystery).
         Then, generate ${numStories} different short stories based on this ENHANCED prompt.
         The stories MUST be written entirely in the ${language} language.

--- a/backend/src/app/modules/ai_model/ai_model.validation.ts
+++ b/backend/src/app/modules/ai_model/ai_model.validation.ts
@@ -45,6 +45,8 @@ const aiModel = z.object({
       })
       .optional(),
 
+    targetAudience: z.string().max(100).optional(),
+
     characters: z
       .array(
         z.object({

--- a/frontend/src/components/stories/stories.component.tsx
+++ b/frontend/src/components/stories/stories.component.tsx
@@ -661,6 +661,7 @@ useEffect(() => {
 
   const [selectedLength, setSelectedLength] = useState<string>(draft?.length || "medium");
   const [selectedTone, setSelectedTone] = useState<ToneLabel | "">(draft?.tone || "Dramatic");
+  const [selectedAudience, setSelectedAudience] = useState<string>("General Audience");
   const [textareaValue, setTextareaValue] = useState<string>(() => {
     return location.state?.prompt || draft?.prompt || "";
   });
@@ -1016,6 +1017,7 @@ const onSubmit: SubmitHandler<Inputs> = useCallback(async (data) => {
         wordLength: selectedLength === "short" ? 175 : selectedLength === "long" ? 800 : 450,
         language: selectedLanguage,
         tone: selectedTone || undefined,
+        targetAudience: selectedAudience,
         characters: characters.map(({ name, role, personality }) => ({ name, role, personality })),
       };
 
@@ -2096,6 +2098,24 @@ onKeyDown={(e) => {
           }`}
         >
           {length.charAt(0).toUpperCase() + length.slice(1)}
+        </button>
+      ))}
+    </div>
+
+    <div className="flex flex-wrap items-center gap-2 mb-3">
+      <span className="text-xs text-gray-400 mr-1">👥 Audience:</span>
+      {["Children (5-10)", "Young Adult (12-18)", "General Audience", "Professionals"].map((audience) => (
+        <button
+          key={audience}
+          type="button"
+          onClick={() => setSelectedAudience(audience)}
+          className={`px-3 py-1 rounded-full text-xs font-medium transition-all duration-200 ${
+            selectedAudience === audience
+              ? "bg-indigo-500 text-white shadow-lg shadow-indigo-500/30"
+              : "bg-white/10 text-gray-400 hover:bg-white/20 hover:text-gray-200"
+          }`}
+        >
+          {audience}
         </button>
       ))}
     </div>


### PR DESCRIPTION
Adds Target Audience selection dropdown to the frontend, plumbing the selected demographic through the Zod validation layer and injecting it into the Gemini prompt builder to tailor story complexity and vocabulary.

## Before you open this PR

- **Issue:** Closes #5078
- **Description:** Added the "What this PR does" section below to explain the feature and its backend integration.
- **Screenshots:** N/A (UI change is just a standard pill-selector similar to the length selector, easily verifiable in the UI without complex setups).

## Screenshot (when helpful)

<!-- Drag & drop or paste. For non-UI work, you can use tests output, logs, or API responses. Write “N/A” in the checklist if you skip this section. -->



## What this PR does

Currently, stories are generated with a generic tone and vocabulary based solely on the prompt. This PR introduces an "Audience Selection" dropdown on the story generation page, allowing users to specify their target demographic (Children, Young Adults, General Audience, Professionals). 

The backend now ingests this demographic data, validates it through Zod, and injects a specialized behavioral directive into the Gemini prompt builder to adjust the AI's output tone, complexity, and vocabulary accordingly.

## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #5078



## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
