### PR TITLE
fix(chat): extract Bearer token before JWT verification

### DIFF
--- a/backend/src/app/modules/chat/chat.middleware.ts
+++ b/backend/src/app/modules/chat/chat.middleware.ts
@@ -4,24 +4,42 @@ import config from "../../../config";
 import { JwtHelpers } from "../../../utils/jwt.helper";
 import chatRateLimiter from "../../middleware/chat.rate-limiter";
 
-export const flexibleChatRateLimiter = async (req: Request, res: Response, next: NextFunction) => {
-  const token = req.headers.authorization;
+export const flexibleChatRateLimiter = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+
+  const authHeader = Array.isArray(req.headers.authorization)
+    ? req.headers.authorization[0]
+    : req.headers.authorization;
+
+  const bearerToken =
+    authHeader?.startsWith("Bearer ")
+      ? authHeader.slice(7).trim()
+      : "";
+
+  const cookieToken =
+    (req as any).cookies?.accessToken ||
+    (req as any).cookies?.token;
+
+  const token = bearerToken || cookieToken;
+
   if (token) {
     try {
-      // Try to verify token. If successful, bypass guest rate limiting.
       const verifiedUser = JwtHelpers.verifyToken(
         token,
         config.jwt.secret as Secret
       );
+
       if (verifiedUser) {
-        req.user = verifiedUser; // Attach verified user to request
+        req.user = verifiedUser;
         return next();
       }
-    } catch (err) {
-      // Token is invalid/expired. Fallback to guest rate limiting.
+    } catch {
+      // Invalid token -> guest limiter
     }
   }
 
-  // Guest or invalid token: apply guest rate limiting
   return chatRateLimiter(req, res, next);
 };


### PR DESCRIPTION
## Summary

This PR fixes the chat middleware incorrectly passing the raw `Authorization` header (`Bearer <jwt>`) directly to `JwtHelpers.verifyToken()`. Since `jsonwebtoken.verify()` expects only the JWT, authenticated users always failed verification and were incorrectly subjected to the guest rate limiter.

### Changes
- Extract the Bearer token from the `Authorization` header before verification.
- Add cookie fallback (`accessToken` / `token`) to align with the existing authentication flow.
- Preserve the existing guest rate limiting behavior for unauthenticated or invalid users.

### Testing
- Verified the middleware extracts the Bearer token before JWT verification.
- Verified the middleware falls back to `accessToken`/`token` cookies when no Authorization header is present.
- Confirmed guest rate limiting logic remains unchanged for unauthenticated requests.

Fixes #4953