### PR TITLE
fix: validate non-empty segments in isJwtTokenFormat

### DIFF
--- a/frontend/src/utils/jwt.ts
+++ b/frontend/src/utils/jwt.ts
@@ -17,7 +17,7 @@ export interface CustomJwtPayload extends JwtPayload {
 export const isJwtTokenFormat = (token: string): boolean => {
   if (!token || typeof token !== "string") return false;
   const parts = token.split(".");
-  return parts.length === 3;
+  return parts.length === 3 && parts.every((part) => part.length > 0);
 };
 
 /**


### PR DESCRIPTION
### Description
Adds `.every((part) => part.length > 0)` to the format check so tokens with
empty segments (e.g., `"abc..xyz"`) are correctly rejected at the format
validation stage rather than producing a misleading decode error downstream.

### Related Issues
Closes #5105 