### PR TITLE
fix: apply 60-second clock skew tolerance in JWT expiry validation

### DIFF
--- a/frontend/src/utils/jwt.ts
+++ b/frontend/src/utils/jwt.ts
@@ -84,7 +84,8 @@ export const decodedToken = (token: string): CustomJwtPayload => {
     throw new Error("Token is missing a valid numeric 'exp' claim.");
   }
 
-  if (decoded.exp <= Math.floor(Date.now() / 1000)) {
+  const CLOCK_SKEW_TOLERANCE_SECONDS = 60;
+  if (decoded.exp <= Math.floor(Date.now() / 1000) - CLOCK_SKEW_TOLERANCE_SECONDS) {
     throw new Error("Token has expired.");
   }
 


### PR DESCRIPTION
### Description
Introduces a `CLOCK_SKEW_TOLERANCE_SECONDS` constant (set to 60s) applied to
the `exp` check in `decodedToken`. This follows industry standard JWT handling
(e.g., jsonwebtoken, jose libraries all support leeway) and prevents valid
tokens from being incorrectly rejected due to minor client/server clock drift.

### Related Issues
Closes #5107 