### PR TITLE
fix: add semantic validation for JWT iat claim

### DIFF
--- a/frontend/src/utils/jwt.ts
+++ b/frontend/src/utils/jwt.ts
@@ -93,6 +93,15 @@ export const decodedToken = (token: string): CustomJwtPayload => {
     throw new Error("Token is missing a valid numeric 'iat' claim.");
   }
 
+  const now = Math.floor(Date.now() / 1000);
+  if (decoded.iat > now + CLOCK_SKEW_TOLERANCE_SECONDS) {
+    throw new Error("Token 'iat' claim is in the future. Token cannot be trusted.");
+  }
+
+  if (decoded.iat >= decoded.exp) {
+    throw new Error("Token 'iat' claim must be before 'exp' claim.");
+  }
+
   // 7. Validate optional name claim type if present
   if (decoded.name !== undefined && typeof decoded.name !== "string") {
     throw new Error("Token 'name' claim must be a string.");


### PR DESCRIPTION
### Description
Extends `iat` validation beyond a type check to include:
- Rejecting tokens with a future `iat` (with clock skew tolerance) to prevent
  forged or pre-generated tokens from being trusted.
- Rejecting tokens where `iat >= exp` since this is structurally invalid —
  a token cannot be issued at or after its expiry time.

### Related Issues
Closes #5111 