### PR TITLE
refactor: rename decodedToken → decodeToken for consistent naming

### DIFF
--- a/frontend/src/utils/jwt.ts
+++ b/frontend/src/utils/jwt.ts
@@ -24,7 +24,7 @@ export const isJwtTokenFormat = (token: string): boolean => {
  * Decodes a JWT token and strictly validates its payload structure and claims.
  * Throws an error if validation fails.
  */
-export const decodedToken = (token: string): CustomJwtPayload => {
+export const decodeToken = (token: string): CustomJwtPayload => {
   if (!isJwtTokenFormat(token)) {
     throw new Error("Token format is invalid. A JWT must consist of three dot-separated segments.");
   }


### PR DESCRIPTION
### Description
Renames `decodedToken` to `decodeToken` across the frontend to follow standard
verb-phrase naming for functions. Updates all import and call sites accordingly.
This is a non-breaking refactor within the frontend codebase.

### Related Issues
Closes #5124