### PR TITLE
fix: validate nbf (not before) claim in decodeToken per RFC 7519

### DIFF
--- a/frontend/src/utils/jwt.ts
+++ b/frontend/src/utils/jwt.ts
@@ -93,6 +93,16 @@ export const decodedToken = (token: string): CustomJwtPayload => {
     throw new Error("Token is missing a valid numeric 'iat' claim.");
   }
 
+  // 6b. Validate nbf (not before) claim if present — RFC 7519 §4.1.5
+  if (decoded.nbf !== undefined) {
+    if (typeof decoded.nbf !== "number") {
+      throw new Error("Token 'nbf' claim must be a number.");
+    }
+    if (decoded.nbf > Math.floor(Date.now() / 1000) + CLOCK_SKEW_TOLERANCE_SECONDS) {
+      throw new Error("Token is not yet valid (nbf claim is in the future).");
+    }
+  }
+
   // 7. Validate optional name claim type if present
   if (decoded.name !== undefined && typeof decoded.name !== "string") {
     throw new Error("Token 'name' claim must be a string.");


### PR DESCRIPTION
### Description
Adds validation of the optional `nbf` claim in `decodeToken`. If present, the
current timestamp (with clock skew tolerance) must be past `nbf` before the
token is accepted, matching the JWT specification and the existing `exp` validation
pattern.

### Related Issues
Closes #5129 