### PR TITLE
fix: remove redundant sub declaration and clean up CustomJwtPayload interface

### DIFF
--- a/frontend/src/utils/jwt.ts
+++ b/frontend/src/utils/jwt.ts
@@ -1,14 +1,14 @@
 import { jwtDecode, JwtPayload } from "jwt-decode";
 
 export interface CustomJwtPayload extends JwtPayload {
-  email?: string | undefined;
-  userId?: string | undefined;
-  _id?: string | undefined;
-  sub?: string | undefined;
-  name?: string | undefined;
-  postsCount?: number | undefined;
-  role?: string | undefined;
-  subscriptionType?: string | undefined;
+  // Standard JWT claim `sub` is inherited from JwtPayload — not redeclared here
+  email?: string;
+  userId?: string;
+  _id?: string;
+  name?: string;
+  postsCount?: number;
+  role?: string;
+  subscriptionType?: string;
 }
 
 /**


### PR DESCRIPTION
### Description
Removes the redundant `sub` redeclaration from `CustomJwtPayload` since it is
already defined in the extended `JwtPayload` base interface. Also removes the
redundant `| undefined` from all optional interface properties.

### Related Issues
Closes #5133 