### PR TITLE
docs: consolidate duplicate README navigation into a single Table of Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,26 +32,17 @@
 - [Feature Documentation 📄](#feature-documentation-)
 - [Known Behavior & UX Notes](#known-behavior--ux-notes-)
 - [Local Development](#local-development-monorepo)
+- [Deployment (Vercel)](#deploying-on-vercel)
 - [Environment Variables](#environment-variables)
 - [Minimal Working Example (Story Generation API)](#minimal-working-example-story-generation-api)
 - [API Reference 📡](#api-reference-)
 - [Troubleshooting 🛠️](#troubleshooting-️)
+- [Architecture](#architecture)
 - [Contributing 👨‍💻](#contributing-)
 - [Contributors 🤝](#contributors-)
 - [Maintainers](#maintainers)
 - [License 📜](#license-)
 - [Support 🙏](#support-)
-
----
-
-## 🧭 Quick Navigation
-
-Jump straight to the most commonly needed setup and deployment sections:
-
-- [Local Development](#local-development-monorepo)
-- [Environment Variables](#environment-variables)
-- [Deployment (Vercel)](#deploying-on-vercel)
-- [Troubleshooting](#troubleshooting-️)
 
 ---
 


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Open or link a related issue when there is one (`Closes #123`, `Fixes #45`, or write **None** under Related issue below).
- **Description:** Fill in **What this PR does** so a reviewer can understand the change without your local context.
- **Screenshots:** Add screenshots or a short recording when they help (UI changes, confusing flows, or non-code proof). If not needed, say so in the checklist.

## Screenshot (when helpful)

N/A — documentation-only change with no UI changes.

## What this PR does

- Consolidates README navigation into a single Table of Contents.
- Removes the redundant Quick Navigation section.
- Adds the Deployment (Vercel) and Architecture links to the main Table of Contents so important navigation remains accessible.
- Keeps the change focused on documentation without modifying application code.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [x] Documentation update

## Related issue

Fixes #4310

## More screenshots (optional)

N/A — no visual application changes.

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.