### PR TITLE
fix: replace || with ?? for user ID field resolution in validateTokenPayload

### DIFF
--- a/frontend/src/utils/auth-validator.ts
+++ b/frontend/src/utils/auth-validator.ts
@@ -2,8 +2,8 @@ export const validateTokenPayload = (decodedData: Record<string, unknown>): void
   if (!decodedData || typeof decodedData !== "object" || Array.isArray(decodedData)) {
     throw new Error("Token payload is not a valid object.");
   }
-  const userId = decodedData.userId || decodedData._id || decodedData.sub;
-  if (!userId || typeof userId !== "string" || userId.trim() === "") {
+  const userId = decodedData.userId ?? decodedData._id ?? decodedData.sub;
+  if (userId === undefined || userId === null || typeof userId !== "string" || userId.trim() === "") {
     throw new Error("Token is missing a valid user identifier ('userId', '_id', or 'sub').");
   }
   if (typeof decodedData.email !== "string" || decodedData.email.trim() === "") {


### PR DESCRIPTION
### Description
Replaces the `||` operator with `??` (nullish coalescing) when resolving the
canonical user ID from `userId`, `_id`, or `sub`. This ensures falsy but
non-null values (e.g., `0`, `false`) are not silently skipped, and instead
surface as a type validation error downstream — preventing silent wrong-user
identity resolution.

### Related Issues
Closes #5176 