### PR TITLE
fix: validate accessToken before persisting it in storeUserInfo

### DIFF
--- a/frontend/src/services/auth.service.ts
+++ b/frontend/src/services/auth.service.ts
@@ -92,6 +92,14 @@ export const getValidDecodedToken = () => {
 };
 
 export const storeUserInfo = ({ accessToken }: AccessToken) => {
+  try {
+    const decodedData = decodedToken(accessToken);
+    validateTokenPayload(decodedData as Record<string, unknown>);
+  } catch (error) {
+    console.error("Refusing to store invalid access token:", error);
+    throw new Error("Received an invalid access token. Please try logging in again.");
+  }
+
   const result = setToLocalStorage(AUTH_KEY, accessToken);
   emitAuthChange();
   return result;


### PR DESCRIPTION
### Description
Adds token decoding and payload validation inside `storeUserInfo` before
writing to `localStorage`. If the token is invalid, an error is thrown and
`emitAuthChange` is never called, preventing the app from entering a false
logged-in state that resolves to an instant logout on next page load.

### Related Issues
Closes #5178 