### PR TITLE
refactor(ai): remove duplicate sanitizeJsonText implementation

### DIFF
--- a/backend/src/app/modules/ai_model/ai_model.utils.ts
+++ b/backend/src/app/modules/ai_model/ai_model.utils.ts
@@ -33,15 +33,6 @@ const genAI = new GoogleGenerativeAI(geminiApiKey);
 const MISSING_GEMINI_API_KEY_MESSAGE =
   "Gemini API key is not configured. Set GEMINI_API_KEY before using Gemini generation features.";
 
-const sanitizeJsonText = (rawText: string): string => {
-  const trimmed = rawText.trim();
-  if (!trimmed.startsWith("```")) return trimmed;
-  return trimmed
-    .replace(/^```(?:json)?\s*/i, "")
-    .replace(/\s*```$/, "")
-    .trim();
-};
-
 const model = genAI.getGenerativeModel({
   model: "gemini-2.5-flash",
 });
@@ -147,18 +138,6 @@ const throwIfAborted = (signal?: AbortSignal): void => {
   if (signal?.aborted) {
     throw new GenerationAbortedError();
   }
-};
-
-const sanitizeJsonText = (rawText: string): string => {
-  const trimmed = rawText.trim();
-  if (!trimmed.startsWith("```")) {
-    return trimmed;
-  }
-
-  return trimmed
-    .replace(/^```(?:json)?\s*/i, "")
-    .replace(/\s*```$/, "")
-    .trim();
 };
 
 const buildCharactersInstruction = (characters?: ICharacter[]): string => {
@@ -815,6 +794,7 @@ Rules:
       `AI storyboard generation failed: ${errorMsg}`,
     );
   }
+}
 
 export async function chatWithGemini(
   message: string,

--- a/backend/src/utils/promptSecurity.ts
+++ b/backend/src/utils/promptSecurity.ts
@@ -136,3 +136,15 @@ export const validateOutput = (aiResponse: string): string => {
 
   return aiResponse;
 };
+
+/**
+ * Strips markdown code block formatting (```json ... ```) from JSON string.
+ */
+export const sanitizeJsonText = (rawText: string): string => {
+  const trimmed = rawText.trim();
+  if (!trimmed.startsWith("```")) return trimmed;
+  return trimmed
+    .replace(/^```(?:json)?\s*/i, "")
+    .replace(/\s*```$/, "")
+    .trim();
+};


### PR DESCRIPTION
## Screenshot (when helpful)

N/A – This is a backend refactoring with no UI changes.

---

## What this PR does

This PR removes duplicate implementations of `sanitizeJsonText` from `ai_model.utils.ts` and consolidates the logic into the shared utility in `backend/src/utils/promptSecurity.ts`.

The AI module now relies on a single canonical implementation, reducing code duplication and making future maintenance easier while preserving existing behavior.

Additionally, a syntax issue preventing successful TypeScript compilation was resolved during the refactor.

---

## Type of change

- [x] Bug fix
- [x] Code refactor
- [ ] New feature
- [ ] Documentation update

---

## Related issue

Closes #5187 

---

## More screenshots (optional)

N/A

---

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.