### PR TITLE
fix(story-rating): use authenticated user id when creating ratings

### DIFF
--- a/backend/src/app/modules/story_rating/story_rating.controller.ts
+++ b/backend/src/app/modules/story_rating/story_rating.controller.ts
@@ -5,7 +5,7 @@ import httpStatus from "http-status";
 import { StoryRatingService } from "./story_rating.service";
 
 const createOrUpdateRating = catchAsync(async (req: Request, res: Response) => {
-  const userId = req.user?.userId;
+  const userId = req.user?._id;
   const { storyId, rating, review } = req.body;
 
   const result = await StoryRatingService.rateStory(
@@ -53,7 +53,7 @@ const getAverageRating = catchAsync(async (req: Request, res: Response) => {
 });
 
 const deleteRating = catchAsync(async (req: Request, res: Response) => {
-  const userId = req.user?.userId;
+  const userId = req.user?._id;
   const { ratingId } = req.params;
 
   const result = await StoryRatingService.deleteRating(userId, ratingId);


### PR DESCRIPTION
## Screenshot (when helpful)

N/A – This is a backend bug fix with no UI changes.

---

## What this PR does

This PR fixes an issue where the story rating controller attempted to access the authenticated user's ID using `req.user.userId`, even though the authentication middleware attaches a Mongoose user document that exposes the identifier as `_id` (and `id`).

The controller now uses the correct authenticated user identifier, allowing story rating operations to correctly associate ratings with the authenticated user and preventing runtime failures caused by an undefined user ID.

---

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

---

## Related issue

Closes #5191 

---

## More screenshots (optional)

N/A

---

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.