### PR TITLE
fix(posts): respect limit query parameter in getPostsByTag

### DIFF
--- a/backend/src/app/modules/post/post.controller.ts
+++ b/backend/src/app/modules/post/post.controller.ts
@@ -111,7 +111,7 @@ const getPostsByTag = catchAsync(async (req: Request, res: Response) => {
   const tag = routeParam(req.params.tag);
   const excludeId = req.query.excludeId as string | undefined;
   const limit = req.query.limit ? Math.min(Number(req.query.limit), 50) : 10;
-  const result = await PostService.getPostsByTag(tag, excludeId);
+  const result = await PostService.getPostsByTag(tag, excludeId, limit);
   sendResponse(res, {
     statusCode: httpStatus.OK,
     success: true,


### PR DESCRIPTION
## Screenshot (when helpful)

N/A – This is a backend API bug fix with no UI changes.

---

## What this PR does

This PR fixes an issue where the `GET /posts/tag/:tag` endpoint ignored the validated `limit` query parameter.

The controller already parsed and validated the `limit` value, but it was not forwarded to `PostService.getPostsByTag()`. As a result, the service always used its default limit, regardless of the client's request.

This change forwards the validated `limit` parameter to the service while preserving the existing default value and maximum limit validation.

---

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

---

## Related issue

Closes #5192 

---

## More screenshots (optional)

N/A

---

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.