### PR TITLE
fix: scope auth input styles to .auth-form-card to stop footer newsletter input overflow

### DIFF
--- a/frontend/src/components/login/auth.css
+++ b/frontend/src/components/login/auth.css
@@ -161,9 +161,9 @@ body {
     overflow: hidden;
 }
 
-input[type="text"],
-input[type="email"],
-input[type="password"] {
+.auth-form-card input[type="text"],
+.auth-form-card input[type="email"],
+.auth-form-card input[type="password"] {
     width: 100%;
     max-width: 100%;
     box-sizing: border-box;
@@ -231,9 +231,9 @@ input[type="password"] {
 }
 
 /* ── Design System: Form Input Custom Fields ── */
-input[type="text"],
-input[type="email"],
-input[type="password"] {
+.auth-form-card input[type="text"],
+.auth-form-card input[type="email"],
+.auth-form-card input[type="password"] {
     width: 100%;
     max-width: 100%;
     height: var(--ds-input-height);


### PR DESCRIPTION
…tter input overflow

## Before you open this PR

- **Issue:** Open or link a related issue when there is one (`Closes #123`, `Fixes #45`, or write **None** under Related issue below).
- **Description:** Fill in **What this PR does** so a reviewer can understand the change without your local context.
- **Screenshots:** Add screenshots or a short recording when they help (UI changes, confusing flows, or non-code proof). If not needed, say so in the checklist.

## Screenshot (when helpful)

N/A — CSS scoping fix, no visual change to intended behavior (fixes an unintended
visual bug). Root cause and fix verified directly against source.

<!-- Drag & drop or paste. For non-UI work, you can use tests output, logs, or API responses. Write “N/A” in the checklist if you skip this section. -->



## What this PR does

The global input[type="email"]/text/password rules in auth.css weren't scoped to
.auth-form-card, so a hardcoded 50px height + 14px border-radius + border leaked
into the footer's newsletter input (44px container), causing the overflow shown
in the issue screenshots. Scoped both rule blocks to .auth-form-card, matching a
pattern already used elsewhere in the same file for the same containment issue.
No other files changed.

<!-- Short summary: what problem does this solve, and how? -->




## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #5200

<!-- Example: Closes #123 or Fixes #45. Use “None” if there is no issue. -->



## More screenshots (optional)

<!-- Extra before/after images, flows, or recordings for reviewers. -->



## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
