### PR TITLE
Fix : form card misaligned on live server

### DIFF
--- a/auth.css
+++ b/auth.css
@@ -651,8 +651,8 @@ input:-webkit-autofill:focus {
 .auth-container{
     width:min(1180px, 100%);
     min-height:min(760px, calc(100svh - 48px));
-    display:grid;
-    grid-template-columns:minmax(0, 1fr) minmax(380px, 0.92fr);
+    display:flex;
+    justify-content:center;
     align-items:stretch;
 }
 
@@ -760,6 +760,7 @@ input:-webkit-autofill:focus {
         transition: none !important;
         scroll-behavior: auto !important;
     }
+}
 
 /* Ensure submit and Google buttons fill the card width */
 .ds-btn-submit,


### PR DESCRIPTION
## Screenshot (when helpful)

N/A — this is a CSS layout fix with no new UI elements. Behavior can be verified by comparing the auth page's alignment before and after on a live server (form card centered instead of shifted left with dead space on the right).

## What this PR does

<Fixes two CSS bugs in auth.css that caused the login/signup form card to render misaligned (shifted left with empty space on the right) when viewed on a live server, even though it looked fine in some local previews.

1 Duplicate .auth-container rule with grid override: A second .auth-container definition further down the file set display: grid with a two-column grid-template-columns. Since .left-pane is hidden (display: none !important), the form card was the only grid item and auto-placed into the first column, leaving the second column empty and pushing the card off-center. Changed this rule to display: flex with justify-content: center so the card centers correctly regardless of the hidden pane.
2 Unclosed @media (prefers-reduced-motion: reduce) block: The media query was missing its closing brace, which trapped the width-safety rules for .ds-btn-submit, .ds-btn-google, and .auth-container input inside it. As a result, those rules only applied for users with reduced-motion enabled at the OS level, not for everyone. Added the missing } so those fixes apply globally as intended.




## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [✓ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

None



## More screenshots (optional)

N/A



## Checklist

- [✓ ] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [ ✓] I have filled in the related issue number when there is one.
- [✓ ] I have tested my changes.
- [ ✓] I have done a self-review of the code.
