### PR TITLE
feat: add dedicated bug-pattern checks for Swift (Issue #5218)

### DIFF
--- a/backend/src/app/modules/code_analysis/code_analysis.controller.ts
+++ b/backend/src/app/modules/code_analysis/code_analysis.controller.ts
@@ -1,0 +1,20 @@
+import { Request, Response } from "express";
+import httpStatus from "http-status";
+import catchAsync from "../../../shared/catch_async";
+import sendResponse from "../../../shared/send_response";
+import { CodeAnalysisService } from "./code_analysis.service";
+
+const analyzeSwift = catchAsync(async (req: Request, res: Response) => {
+  const result = await CodeAnalysisService.analyzeSwiftCode(req.body);
+
+  sendResponse(res, {
+    statusCode: httpStatus.OK,
+    success: true,
+    message: "Swift code analyzed successfully",
+    data: result,
+  });
+});
+
+export const CodeAnalysisController = {
+  analyzeSwift,
+};

--- a/backend/src/app/modules/code_analysis/code_analysis.interface.ts
+++ b/backend/src/app/modules/code_analysis/code_analysis.interface.ts
@@ -1,0 +1,21 @@
+export interface ICodeAnalysisRequest {
+  code: string;
+}
+
+export interface ICodeAnalysisIssue {
+  type: string;
+  line: number;
+  description: string;
+  suggestion: string;
+  severity: "error" | "warning" | "info";
+  codeSnippet: string;
+}
+
+export interface ICodeAnalysisResponse {
+  issues: ICodeAnalysisIssue[];
+  summary: string;
+  clean: boolean;
+  errorCount: number;
+  warningCount: number;
+  infoCount: number;
+}

--- a/backend/src/app/modules/code_analysis/code_analysis.router.ts
+++ b/backend/src/app/modules/code_analysis/code_analysis.router.ts
@@ -1,0 +1,18 @@
+import express from "express";
+import validateRequest from "../../middleware/validate.request";
+import { CodeAnalysisValidator } from "./code_analysis.validation";
+import { CodeAnalysisController } from "./code_analysis.controller";
+
+const router = express.Router();
+
+/**
+ * POST /api/v1/code-analysis/swift
+ * Analyze Swift code for common anti-patterns
+ */
+router.post(
+  "/swift",
+  validateRequest(CodeAnalysisValidator.analyzeSwift),
+  CodeAnalysisController.analyzeSwift
+);
+
+export const CodeAnalysisRouter = router;

--- a/backend/src/app/modules/code_analysis/code_analysis.service.ts
+++ b/backend/src/app/modules/code_analysis/code_analysis.service.ts
@@ -1,0 +1,63 @@
+import { ICodeAnalysisRequest, ICodeAnalysisResponse, ICodeAnalysisIssue } from "./code_analysis.interface";
+
+export const analyzeSwiftCode = async (payload: ICodeAnalysisRequest): Promise<ICodeAnalysisResponse> => {
+  const issues: ICodeAnalysisIssue[] = [];
+  const lines = payload.code.split('\n');
+
+  lines.forEach((line, index) => {
+    const lineNumber = index + 1;
+    
+    // 1. Force Unwrapping (!)
+    if (/\b\w+!\b/.test(line) && !line.includes("!=")) {
+      issues.push({
+        type: "ForceUnwrap",
+        line: lineNumber,
+        description: "Force unwrapping an optional can cause runtime crashes if the value is nil.",
+        suggestion: "Use optional binding (if let or guard let) to safely unwrap the value.",
+        severity: "error",
+        codeSnippet: line.trim()
+      });
+    }
+
+    // 2. Retain Cycles in Closures (checking for self. without weak self)
+    if (line.includes("self.") && !payload.code.includes("[weak self]") && !payload.code.includes("[unowned self]")) {
+      issues.push({
+        type: "PotentialRetainCycle",
+        line: lineNumber,
+        description: "Using 'self.' inside a closure without a capture list might cause a retain cycle.",
+        suggestion: "Consider using '[weak self]' or '[unowned self]' in the closure capture list.",
+        severity: "warning",
+        codeSnippet: line.trim()
+      });
+    }
+
+    // 3. Print statements in production
+    if (/print\(.*\)/.test(line) || /debugPrint\(.*\)/.test(line)) {
+      issues.push({
+        type: "PrintInProduction",
+        line: lineNumber,
+        description: "Print statements should generally be removed or replaced with a proper logging framework in production.",
+        suggestion: "Remove the print statement or use a logger (e.g., OSLog).",
+        severity: "info",
+        codeSnippet: line.trim()
+      });
+    }
+  });
+
+  const errorCount = issues.filter(i => i.severity === "error").length;
+  const warningCount = issues.filter(i => i.severity === "warning").length;
+  const infoCount = issues.filter(i => i.severity === "info").length;
+
+  return {
+    issues,
+    summary: `Found ${issues.length} issue(s): ${errorCount} error(s), ${warningCount} warning(s), ${infoCount} info.`,
+    clean: issues.length === 0,
+    errorCount,
+    warningCount,
+    infoCount
+  };
+};
+
+export const CodeAnalysisService = {
+  analyzeSwiftCode
+};

--- a/backend/src/app/modules/code_analysis/code_analysis.validation.ts
+++ b/backend/src/app/modules/code_analysis/code_analysis.validation.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const CodeAnalysisValidator = {
+  analyzeSwift: z.object({
+    body: z.object({
+      code: z.string().min(1, "Code snippet cannot be empty"),
+    }),
+  }),
+};

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -26,6 +26,7 @@ import PromptAnalysisRouter from "../app/modules/prompt_analysis/prompt_analysis
 import { StoryConsistencyRouter } from "../app/modules/story_consistency/story_consistency.router";
 import { UsageRouter } from "../app/modules/usage/usage.router";
 import characterRouter from "./character.routes";
+import { CodeAnalysisRouter } from "../app/modules/code_analysis/code_analysis.router";
 
 
 const router = express.Router();
@@ -106,6 +107,10 @@ const modules = [
   {
     path: "/usage",
     router: UsageRouter,
+  },
+  {
+    path: "/code-analysis",
+    router: CodeAnalysisRouter,
   },
 ];
 


### PR DESCRIPTION
## Screenshot (when helpful)

N/A - This PR introduces a backend API feature with no UI changes.

## What this PR does

This PR adds a dedicated Swift code analysis module to the backend to detect common anti-patterns and bugs in Swift snippets. 

**Key additions:**
- Exposes a new endpoint: `POST /api/v1/code-analysis/swift`.
- Implements regex-based detection for 3 common Swift issues:
  - **Force unwrapping:** Flags unsafe `!` usage.
  - **Retain cycles:** Flags missing `[weak self]` in closures.
  - **Production debugging:** Flags `print()` and `debugPrint()` statements.
- Registers the `CodeAnalysisRouter` in `backend/src/routes/index.ts`.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Fixes #5218

## More screenshots (optional)

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
