### PR TITLE
fix: add transformResponse to forgotPassword for consistent auth API response shape

### DIFF
--- a/frontend/src/redux/apis/auth.api.ts
+++ b/frontend/src/redux/apis/auth.api.ts
@@ -66,6 +66,9 @@ const authApi = baseApi.injectEndpoints({
         method: "POST",
         data: data,
       }),
+      transformResponse: (response: { data: { message: string } }) => {
+        return { data: response.data };
+      },
     }),
     resetPassword: build.mutation({
       query: (data) => ({


### PR DESCRIPTION
### Description
Adds a `transformResponse` to the `forgotPassword` mutation matching the
pattern used by all other auth API mutations. This normalizes the response
shape so callers receive `{ data: { message } }` rather than the raw backend
response object, decoupling the component from the backend response structure.

### Related Issues
Closes #5223 