### PR TITLE
fix: return response.data directly from transformResponse to remove double data nesting

### DIFF
--- a/frontend/src/redux/apis/auth.api.ts
+++ b/frontend/src/redux/apis/auth.api.ts
@@ -12,7 +12,7 @@ const authApi = baseApi.injectEndpoints({
         data: data,
       }),
       transformResponse: (response: { data: AccessToken }) => {
-        return { data: response.data };
+        return response.data;
       },
       invalidatesTags: [tagTypes.user],
     }),
@@ -23,7 +23,7 @@ const authApi = baseApi.injectEndpoints({
         data: data,
       }),
       transformResponse: (response: { data: AccessToken }) => {
-        return { data: response.data };
+        return response.data;
       },
       invalidatesTags: [tagTypes.user],
     }),
@@ -34,7 +34,7 @@ const authApi = baseApi.injectEndpoints({
         data: data,
       }),
       transformResponse: (response: { data: AccessToken }) => {
-        return { data: response.data };
+        return response.data;
       },
       invalidatesTags: [tagTypes.user],
     }),
@@ -45,7 +45,7 @@ const authApi = baseApi.injectEndpoints({
         data: data,
       }),
       transformResponse: (response: { data: AccessToken }) => {
-        return { data: response.data };
+        return response.data;
       },
       invalidatesTags: [tagTypes.user],
     }),
@@ -56,7 +56,7 @@ const authApi = baseApi.injectEndpoints({
         data: data,
       }),
       transformResponse: (response: { data: AccessToken }) => {
-        return { data: response.data };
+        return response.data;
       },
       invalidatesTags: [tagTypes.user],
     }),
@@ -74,7 +74,7 @@ const authApi = baseApi.injectEndpoints({
         data: data,
       }),
       transformResponse: (response: { data: AccessToken }) => {
-        return { data: response.data };
+        return response.data;
       },
       invalidatesTags: [tagTypes.user],
     }),


### PR DESCRIPTION
### Description
Changes all auth mutation `transformResponse` functions to return `response.data`
(an `AccessToken`) directly instead of `{ data: response.data }`. This removes
the extra nesting layer so components access `result.data.accessToken` rather
than `result.data.data.accessToken`, eliminating a silent type mismatch footgun.

Affects: loginUser, googleLogin, githubLogin, registerUser,
         registerWithGoogle, resetPassword.

### Related Issues
Closes #5225 