### PR TITLE
fix: guard removeSessionBookmark against no-op writes and spurious events

### DIFF
--- a/frontend/src/utils/session-bookmarks.ts
+++ b/frontend/src/utils/session-bookmarks.ts
@@ -37,6 +37,8 @@ export const removeSessionBookmark = (uuid: string): void => {
   }
   try {
     const bookmarks = getSessionBookmarks();
+    const existed = bookmarks.some((b) => b.uuid === uuid);
+    if (!existed) return; // nothing to remove — skip write and event
     const updated = bookmarks.filter((b) => b.uuid !== uuid);
     sessionStorage.setItem(SESSION_KEY, JSON.stringify(updated));
     window.dispatchEvent(new Event("session_bookmarks_changed"));


### PR DESCRIPTION
### Description
Adds an early return in `removeSessionBookmark` when the given UUID is not
found in the current bookmarks. Mirrors the existing guard in `addSessionBookmark`
and prevents unnecessary sessionStorage writes and component re-renders when
the item to remove doesn't exist.

### Related Issues
Closes #5227 