### PR TITLE
fix: validate JSON.parse result is array in getSessionBookmarks to prevent TypeError on corrupted storage

### DIFF
--- a/frontend/src/utils/session-bookmarks.ts
+++ b/frontend/src/utils/session-bookmarks.ts
@@ -8,9 +8,17 @@ export const getSessionBookmarks = (): IStories[] => {
   }
   try {
     const data = sessionStorage.getItem(SESSION_KEY);
-    return data ? JSON.parse(data) : [];
+    if (!data) return [];
+    const parsed = JSON.parse(data);
+    if (!Array.isArray(parsed)) {
+      console.warn("Session bookmarks data is corrupted (not an array). Resetting.");
+      sessionStorage.removeItem(SESSION_KEY);
+      return [];
+    }
+    return parsed as IStories[];
   } catch (error) {
     console.error("Failed to read session bookmarks", error);
+    sessionStorage.removeItem(SESSION_KEY); // clear corrupted data
     return [];
   }
 };


### PR DESCRIPTION
### Description
Adds an `Array.isArray(parsed)` check after `JSON.parse` in `getSessionBookmarks`.
If the parsed value is not an array, the corrupted entry is cleared from
sessionStorage and `[]` is returned as a safe fallback. Also clears corrupted
data in the catch block to prevent repeated failures.

### Related Issues
Closes #5229 