### PR TITLE
fix: call removeAllListeners in useCollaboration cleanup to prevent zombie socket handlersfix(useCollaboration): call removeAllListeners in cleanup to prevent …

### DIFF
--- a/frontend/src/hooks/useCollaboration.ts
+++ b/frontend/src/hooks/useCollaboration.ts
@@ -133,7 +133,7 @@ export function useCollaboration({
 
     return () => {
       if (typingTimerRef.current) clearTimeout(typingTimerRef.current);
-      socket.off("collab:joined", handleJoined);
+      socket.removeAllListeners(); // remove all handlers before disconnecting
       socket.disconnect();
       socketRef.current = null;
     };


### PR DESCRIPTION
### Description
Replaces the single `socket.off("collab:joined", handleJoined)` in the
`useEffect` cleanup with `socket.removeAllListeners()`. This ensures all
seven registered socket event handlers are detached before the socket
disconnects, preventing zombie handlers from firing state updates on
unmounted components and eliminating the associated memory leak.

### Related Issues
Closes #5233 