### PR TITLE
fix: increase typing debounce from 300ms to 2000ms in useCollaboration

### DIFF
--- a/frontend/src/hooks/useCollaboration.ts
+++ b/frontend/src/hooks/useCollaboration.ts
@@ -148,6 +148,8 @@ export function useCollaboration({
     [roomId]
   );
 
+  const TYPING_STOP_DELAY_MS = 2000; // standard debounce: stop after 2s of inactivity
+
   const emitTyping = useCallback(() => {
     if (!socketRef.current || !roomId) return;
     socketRef.current.emit("collab:typing", { roomId });
@@ -155,7 +157,7 @@ export function useCollaboration({
     if (typingTimerRef.current) clearTimeout(typingTimerRef.current);
     typingTimerRef.current = setTimeout(() => {
       socketRef.current?.emit("collab:stop_typing", { roomId });
-    }, 300);
+    }, TYPING_STOP_DELAY_MS);
   }, [roomId]);
 
   const stopTyping = useCallback(() => {


### PR DESCRIPTION
### Description
Increases the `stop_typing` debounce timeout from 300ms to 2000ms.
At 300ms, the timer fires between nearly every keystroke at normal
typing speed, causing the typing indicator to flash on and off for
other participants. 2000ms matches the industry standard used by
Slack, Discord, and WhatsApp.

### Related Issues
Closes #5235 