### PR TITLE
fix: guard requestAiContinue against duplicate AI requests using isAiThinkingRef

### DIFF
--- a/frontend/src/hooks/useCollaboration.ts
+++ b/frontend/src/hooks/useCollaboration.ts
@@ -50,6 +50,7 @@ export function useCollaboration({
 }: UseCollaborationOptions): UseCollaborationReturn {
   const socketRef = useRef<Socket | null>(null);
   const typingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isAiThinkingRef = useRef(false);
 
   const [room, setRoom] = useState<CollabRoom | null>(null);
   const [loading, setLoading] = useState(true);
@@ -103,6 +104,7 @@ export function useCollaboration({
         if (data?.story) {
           setRoom((prev) => (prev ? { ...prev, story: data.story! } : null));
         }
+        isAiThinkingRef.current = false;
         setIsAiThinking(false);
       }
     );
@@ -122,7 +124,10 @@ export function useCollaboration({
       });
     });
 
-    socket.on("collab:ai_thinking", () => setIsAiThinking(true));
+    socket.on("collab:ai_thinking", () => {
+      isAiThinkingRef.current = true;
+      setIsAiThinking(true);
+    });
 
     socket.on("collab:error", (data: { message: string }) => {
       const msg = data?.message || "Collaboration error occurred.";
@@ -166,6 +171,7 @@ export function useCollaboration({
 
   const requestAiContinue = useCallback(() => {
     if (!socketRef.current || !roomId) return;
+    if (isAiThinkingRef.current) return; // prevent duplicate AI requests
     socketRef.current.emit("collab:ai_continue", { roomId });
   }, [roomId]);
 


### PR DESCRIPTION
### Description
Introduces `isAiThinkingRef` to mirror `isAiThinking` state for safe access
inside `useCallback`. `requestAiContinue` now returns early if
`isAiThinkingRef.current` is `true`, preventing multiple simultaneous
`collab:ai_continue` events from being emitted by the same or different
participants clicking the AI button while generation is in progress.

### Related Issues
Closes #5237 