### PR TITLE
fix: re-emit collab:join_room on socket reconnect to restore room membership after network drops

### DIFF
--- a/frontend/src/hooks/useCollaboration.ts
+++ b/frontend/src/hooks/useCollaboration.ts
@@ -77,7 +77,9 @@ export function useCollaboration({
 
     socketRef.current = socket;
 
-    socket.emit("collab:join_room", { roomId });
+    // emit join on initial connect AND on every reconnect
+    const joinRoom = () => socket.emit("collab:join_room", { roomId });
+    socket.on("connect", joinRoom);
 
     const handleJoined = (response: { room?: CollabRoom; message?: string }) => {
       if (response?.room) {


### PR DESCRIPTION
### Description
Replaces the one-time `socket.emit("collab:join_room")` call with a
`socket.on("connect", joinRoom)` handler. The `connect` event fires on
both initial connection and every automatic reconnection, ensuring the
client always re-joins the room after a network drop without requiring
a page refresh.

The `joinRoom` listener is automatically removed by `socket.removeAllListeners()`
in the existing cleanup (from the Bug 2 fix).

### Related Issues
Closes #5239 