### PR TITLE
test: add regression coverage for blog JSX structure

### DIFF
--- a/frontend/src/components/footer/__tests__/blog.test.tsx
+++ b/frontend/src/components/footer/__tests__/blog.test.tsx
@@ -1,0 +1,39 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import Blog from "../blog";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Blog", () => {
+  it("renders the blog page content without JSX structure errors", () => {
+    render(
+      <MemoryRouter>
+        <Blog />
+      </MemoryRouter>
+    );
+
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: /explore creative insights/i,
+      })
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: /latest topics/i,
+      })
+    ).toBeInTheDocument();
+
+    expect(screen.getAllByRole("link", { name: /read more/i })).toHaveLength(3);
+
+    expect(
+      screen.getByRole("link", { name: /back to home/i })
+    ).toHaveAttribute("href", "/");
+  });
+});


### PR DESCRIPTION
## Description

Adds focused regression coverage for the Blog component related to the JSX structure issue reported in #4475.

The Blog page currently renders with the corrected JSX structure, but it did not have a dedicated regression test protecting its key render structure. This PR adds coverage to help detect future JSX/rendering regressions in the Blog component.

## Changes

- Added a focused regression test for the Blog component.
- Verifies the `Explore Creative Insights` main heading renders correctly.
- Verifies the `Latest Topics` section renders correctly.
- Verifies all three `Read More` links are rendered.
- Verifies the `Back to Home` navigation points to `/`.
- Keeps the production Blog component unchanged.

## Testing

Targeted regression test:

`vitest run --config vite.config.ts src/components/footer/__tests__/blog.test.tsx`

Result:

```text
Test Files  1 passed (1)
Tests       1 passed (1)