### PR TITLE
fix(config): remove duplicate frontend_url key and use correct dev port

### DIFF
--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -39,7 +39,7 @@ export const assertAIProviderConfigured = (): void => {
 
 export default {
   env: process.env.NODE_ENV,
-  frontend_url: process.env.FRONTEND_URL,
+  frontend_url: process.env.FRONTEND_URL || "http://localhost:4001",
   port: process.env.PORT || "5000",
   disable_logs: process.env.DISABLE_LOGS === "true" || process.env.VERCEL === "1",
   database_url: (() => {
@@ -77,7 +77,6 @@ export default {
   verify_email: process.env.VERIFY_EMAIL,
   verify_password: process.env.VERIFY_PASSWORD,
   google_client_id: process.env.GOOGLE_CLIENT_ID,
-  frontend_url: process.env.FRONTEND_URL || "http://localhost:3000",
   github: {
     token: process.env.GITHUB_TOKEN,
     repo: process.env.GITHUB_REPO || "ronisarkarexe/story-spark-ai",


### PR DESCRIPTION
## Screenshot (when helpful)

N/A. This is a backend configuration and compile fix with no UI surface. Verification output is included below.

## What this PR does

`backend/src/config/index.ts` declared `frontend_url` twice in the same exported object literal (line 42 and line 80). JavaScript resolves duplicate keys with last-one-wins, so the line 42 declaration added by PR #5085 was silently discarded, and the key is also a TS1117 grammar error under the backend `strict: true` tsconfig.

This PR collapses the two declarations into one, keeping it in the server settings group next to `env` and `port` so it matches where `FRONTEND_URL` sits in `backend/.env.example`.

The fallback is also corrected from `http://localhost:3000` to `http://localhost:4001`. Port 3000 is not used anywhere in this project, while the frontend dev server runs on 4001 (`frontend/vite.config.ts` sets `port: 4001`, the `start` script passes `--port 4001`, and `defaultCorsOrigins` in `backend/src/app.ts` lists `http://localhost:4001`). Since `config.frontend_url` builds the email change verification link in `backend/src/app/modules/user/user.service.ts:108`, the old fallback pointed users at a port that serves nothing.

Behaviour when `FRONTEND_URL` is set is unchanged.

### Verification

Before, compiling the file on its own:

```
src/config/index.ts(80,3): error TS1117: An object literal cannot have multiple properties with the same name.
```

After, the same command exits cleanly with no errors:

```bash
cd backend
./node_modules/.bin/tsc --noEmit --skipLibCheck --strict --target ES2020 --module commonjs --esModuleInterop src/config/index.ts
```

Runtime check of the resolved value:

```
FRONTEND_URL unset -> http://localhost:4001
FRONTEND_URL set   -> https://storysparkai.vercel.app
```

Full backend build (`tsc --noEmit -p tsconfig.json`) reports the same 180 pre-existing parse errors before and after this change, with none in `config/index.ts`. Those failures are tracked separately in #5165 and #5166 and are not touched here.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #5261

## More screenshots (optional)

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
