### PR TITLE
fix(frontend): remove duplicate yjs dependency entries from package.json

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,9 +59,6 @@
     "socket.io-client": "^4.8.3",
     "tailwindcss": "^4.0.6",
     "y-indexeddb": "^9.0.12",
-    "yjs": "^13.6.31",
-    "y-quill": "^1.0.0",
-    "y-indexeddb": "^9.0.12",
     "y-protocols": "^1.0.6",
     "y-quill": "^1.0.0",
     "yjs": "^13.6.31"


### PR DESCRIPTION
## Screenshot (when helpful)

N/A. This is a dependency manifest change with no UI surface. Command output is included below.

## What this PR does

`frontend/package.json` listed `y-indexeddb`, `y-quill` and `yjs` twice in `dependencies`. JSON parsing is last-one-wins, so three of those entries were dead weight: editing the first copy of a version range had no effect, and `npm pkg fix` silently rewrote the file to drop them even when `--dry-run` was passed.

This PR removes the three redundant lines and restores the alphabetical ordering used by the rest of the block (`y-indexeddb`, `y-protocols`, `y-quill`, `yjs`).

No version ranges change, so dependency resolution is identical and `pnpm-lock.yaml` needs no update.

### Verification

Duplicate scan is clean after the change:

```
no duplicate keys
```

Resolved ranges are byte-for-byte what they were before:

```
y-indexeddb ^9.0.12 | y-protocols ^1.0.6 | y-quill ^1.0.0 | yjs ^13.6.31
total deps: 45
```

`pnpm install` succeeds (exit 0), and `npm pkg fix` no longer mutates the file, so contributors will stop picking up spurious diffs.

The resulting file is byte-identical to its state before PR #5169 introduced the duplication. Git confirms it resolves to the same blob that PR referenced as its base:

```
git hash-object frontend/package.json
d678b741d723c9911dc74e3a6b7b92a01e14e535
```

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #5263

## More screenshots (optional)

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
