### PR TITLE
fix: invert notification merge order so real-time state overrides stale REST data

### DIFF
--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -29,7 +29,9 @@ export const useNotifications = () => {
     const baseNotifications = data ?? [];
     const merged = new Map<string, NotificationItem>();
 
-    for (const notification of [...realtimeNotifications, ...baseNotifications]) {
+    // REST data is added first — real-time data is added last and wins
+    // for duplicate IDs, since real-time state is always more up-to-date.
+    for (const notification of [...baseNotifications, ...realtimeNotifications]) {
       merged.set(notification._id, notification);
     }
 


### PR DESCRIPTION
### Description
Swaps the iteration order in the `useMemo` merge from
`[...realtimeNotifications, ...baseNotifications]` to
`[...baseNotifications, ...realtimeNotifications]`.

Since `Map.set` overwrites on duplicate keys, real-time notifications
now take precedence over REST data for the same ID — preserving
optimistic updates and ensuring the most current state is always shown.

### Related Issues
Closes #5271 