### PR TITLE
fix: memoize toggle and close with useCallback in useNotifications

### DIFF
--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -42,14 +42,14 @@ export const useNotifications = () => {
 
   const unreadCount = notifications.filter((item) => !item.isRead).length;
 
-  const toggle = () => {
+  const toggle = useCallback(() => {
     setIsOpen((prev) => !prev);
     if (!data && isAuthed) {
       void refetch();
     }
-  };
+  }, [data, isAuthed, refetch]);
 
-  const close = () => setIsOpen(false);
+  const close = useCallback(() => setIsOpen(false), []);
 
   const markAsRead = async (notificationId: string) => {
     await markNotificationRead(notificationId).unwrap();


### PR DESCRIPTION
### Description
Wraps `toggle` and `close` in `useCallback` to stabilize their references
across renders driven by real-time notification state updates. This allows
child components wrapped in `React.memo` to correctly skip re-renders when
only notification list data changes but the bell's open/close state has not.

### Related Issues
Closes #5274 