### PR TITLE
fix: make isAuthed reactive in useNotifications by listening to auth change event

### DIFF
--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -15,7 +15,15 @@ import type { NotificationItem, INotification } from "../models/notification";
 export const useNotifications = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [realtimeNotifications, setRealtimeNotifications] = useState<INotification[]>([]);
-  const isAuthed = isLoggedIn();
+  const [mutationError, setMutationError] = useState<string | null>(null);
+  const [isAuthed, setIsAuthed] = useState(() => isLoggedIn());
+
+  // Keep isAuthed reactive to auth changes from this tab and other tabs
+  useEffect(() => {
+    const handleAuthChange = () => setIsAuthed(isLoggedIn());
+    window.addEventListener("story-spark-auth-change", handleAuthChange);
+    return () => window.removeEventListener("story-spark-auth-change", handleAuthChange);
+  }, []);
 
   const { data, isFetching, refetch } = useGetNotificationsQuery(undefined, {
     skip: !isAuthed,


### PR DESCRIPTION
### Description
Converts `isAuthed` from a direct `isLoggedIn()` call (computed on every render)
to React state initialised once and kept reactive via the `story-spark-auth-change`
custom event. This ensures the socket disconnects and notifications stop fetching
immediately when the user logs out — from any tab — without waiting for an
unrelated re-render.

### Related Issues
Closes #5276 