### PR TITLE
feat: add error reporting workflow from error page

### DIFF
--- a/frontend/src/components/ErrorPage.tsx
+++ b/frontend/src/components/ErrorPage.tsx
@@ -1,8 +1,11 @@
 import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { AUTH_KEY } from "../constants/storage-key";
 
 const ErrorPage = () => {
+  const navigate = useNavigate();
   const [isReloading, setIsReloading] = useState(false);
+  
 
   const handleReload = () => {
     setIsReloading(true);
@@ -138,6 +141,39 @@ const ErrorPage = () => {
                 Reset Cache & Reload
               </>
             )}
+          </button>
+          <button
+            onClick={() => {
+  sessionStorage.setItem(
+    "error-report",
+    JSON.stringify({
+      message: "Application crashed",
+      url: window.location.href,
+      stack: "Captured from ErrorBoundary",
+      timestamp: new Date().toISOString(),
+    })
+  );
+
+  navigate("/report-bug");
+}}
+            className="w-full px-6 py-3 border border-red-300 dark:border-red-700 text-red-600 dark:text-red-400 font-semibold rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20 transition-all transform hover:-translate-y-0.5 flex items-center justify-center gap-2"
+            aria-label="Report this error"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M8 10h8m-8 4h5M9 3h6a2 2 0 012 2v14l-5-3-5 3V5a2 2 0 012-2z"
+              />
+            </svg>
+            Report Error
           </button>
         </div>
 

--- a/frontend/src/components/report-bug/ReportBug.tsx
+++ b/frontend/src/components/report-bug/ReportBug.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "react-hot-toast";
 import { useSubmitBugReportMutation } from "../../redux/apis/bugReport.api";
@@ -58,6 +58,29 @@ const ReportBug = () => {
     formState: { errors }
   } = useForm<ReportBugFormData>();
   const { ref: screenshotRef, ...screenshotRegister } = register("screenshot");
+  useEffect(() => {
+  const errorReport = sessionStorage.getItem("error-report");
+
+  if (!errorReport) return;
+
+  try {
+    const error = JSON.parse(errorReport);
+
+    reset({
+      title: "Application Error",
+      category: "Other",
+      severity: "High",
+      description: error.message || "",
+      steps: `URL: ${error.url || window.location.href}`,
+      expected: "Application should work without crashing.",
+      actual: error.stack || error.message || "",
+    });
+
+    sessionStorage.removeItem("error-report");
+  } catch (err) {
+    console.error("Failed to load error report", err);
+  }
+}, [reset]);
 
   const onSubmit = async (data: ReportBugFormData) => {
     try {


### PR DESCRIPTION
## Description

This PR improves the existing error reporting workflow by integrating the Error Page with the existing Bug Report module.

### Changes
- Added a **Report Error** button to the Error Page.
- Navigates users to the existing Bug Report page.
- Passes error context using `sessionStorage`.
- Automatically pre-fills the Bug Report form with available error information.

### Files Modified
- `frontend/src/components/ErrorPage.tsx`
- `frontend/src/components/report-bug/ReportBug.tsx`

Fixes #1987