### PR TITLE
test : added unit tests for scroll-to-chapter utility

### DIFF
--- a/frontend/src/utils/__tests__/scroll-to-chapter.test.ts
+++ b/frontend/src/utils/__tests__/scroll-to-chapter.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { scrollToChapter } from "../scroll-to-chapter";
+
+const mockScrollIntoView = vi.fn();
+const mockGetElementById = vi.fn();
+
+vi.stubGlobal("document", {
+  getElementById: mockGetElementById,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetElementById.mockReturnValue({
+    scrollIntoView: mockScrollIntoView,
+  });
+});
+
+describe("scrollToChapter", () => {
+  it("calls scrollIntoView on the chapter element with correct id", () => {
+    scrollToChapter(42);
+    expect(mockGetElementById).toHaveBeenCalledWith("chapter-42");
+    expect(mockScrollIntoView).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block: "start",
+    });
+  });
+
+  it("does nothing when the chapter element is not found", () => {
+    mockGetElementById.mockReturnValue(null);
+    scrollToChapter(99);
+    expect(mockGetElementById).toHaveBeenCalledWith("chapter-99");
+    expect(mockScrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it("constructs correct element id for different chapter numbers", () => {
+    scrollToChapter(1);
+    expect(mockGetElementById).toHaveBeenCalledWith("chapter-1");
+
+    mockGetElementById.mockClear();
+    scrollToChapter(100);
+    expect(mockGetElementById).toHaveBeenCalledWith("chapter-100");
+  });
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,12 +1,11 @@
 import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
   test: {
     globals: true,
-    environment: 'jsdom',
-    globals: true,
+    environment: "jsdom",
     setupFiles: [],
   },
 });
-


### PR DESCRIPTION
Closes #5294.

Summary of What Has Been Done:
Added vitest unit tests for the scrollToChapter utility function in frontend/src/utils/__tests__/scroll-to-chapter.test.ts. Also fixed a pre-existing bug in frontend/vitest.config.ts where the react() plugin was used without being imported.

Changes Made:
- frontend/src/utils/__tests__/scroll-to-chapter.test.ts: 3 test cases covering element lookup, scroll options, and no-op behavior
- frontend/vitest.config.ts: Added missing import for @vitejs/plugin-react

Impact it Made:
- Test coverage for an untested scroll utility function
- Fixed vitest config so tests can run without startup errors

Note: Please assign this PR to the `tmdeveloper007` account.