### PR TITLE
fix : prevent stale closure in useVoicePreview stopPreview callback

### DIFF
--- a/frontend/src/hooks/useVoicePreview.ts
+++ b/frontend/src/hooks/useVoicePreview.ts
@@ -20,17 +20,19 @@ export interface UseVoicePreviewResult {
  */
 export const useVoicePreview = (): UseVoicePreviewResult => {
   const previewUtteranceRef = useRef<SpeechSynthesisUtterance | null>(null);
+  const isPlayingRef = useRef(false);
   const [previewingVoiceId, setPreviewingVoiceId] = useState<string | null>(null);
   const [isPreviewPlaying, setIsPreviewPlaying] = useState(false);
 
   const stopPreview = useCallback(() => {
-    if (isPreviewPlaying && previewUtteranceRef.current) {
+    if (isPlayingRef.current && previewUtteranceRef.current) {
       window.speechSynthesis.cancel();
       previewUtteranceRef.current = null;
     }
+    isPlayingRef.current = false;
     setIsPreviewPlaying(false);
     setPreviewingVoiceId(null);
-  }, [isPreviewPlaying]);
+  }, []);
 
   const playPreview = useCallback(
     (voice: SpeechVoiceOption) => {
@@ -50,18 +52,21 @@ export const useVoicePreview = (): UseVoicePreviewResult => {
       }
 
       utterance.onstart = () => {
+        isPlayingRef.current = true;
         setPreviewingVoiceId(voice.id);
         setIsPreviewPlaying(true);
       };
 
       utterance.onend = () => {
         previewUtteranceRef.current = null;
+        isPlayingRef.current = false;
         setIsPreviewPlaying(false);
         setPreviewingVoiceId(null);
       };
 
       utterance.onerror = () => {
         previewUtteranceRef.current = null;
+        isPlayingRef.current = false;
         setIsPreviewPlaying(false);
         setPreviewingVoiceId(null);
       };


### PR DESCRIPTION
Closes #5296.

Summary of What Has Been Done:
Fixed a stale-closure bug in the useVoicePreview hook. The stopPreview callback checked isPreviewPlaying from its useCallback closure (captured at creation time), not at call-time. This meant when playPreview called stopPreview() before starting a new preview, the stale closure had isPreviewPlaying=false, so speechSynthesis.cancel() was never called.

Fix: introduced isPlayingRef (useRef) to track actual playing state. stopPreview now has zero dependencies and checks the ref directly, ensuring correct behavior regardless of call timing.

Changes Made:
- frontend/src/hooks/useVoicePreview.ts: Added isPlayingRef, removed isPreviewPlaying dependency from stopPreview useCallback, updated utterance.onstart/onend/onerror to sync the ref

Impact it Made:
- Correct state management when rapidly starting and stopping voice previews
- No more stale closure causing incorrect isPreviewPlaying state

Note: Please assign this PR to the `tmdeveloper007` account.