### PR TITLE
fix: disable StoryComparisonDashboard until storyB is wired to a real alternate source

### DIFF
--- a/frontend/src/components/story/StoryWorkspace.tsx
+++ b/frontend/src/components/story/StoryWorkspace.tsx
@@ -444,18 +444,18 @@ const StoryWorkspace = () => {
     console.log("Restore draft:", draft);
   }}
 />
-<StoryComparisonDashboard
+{/* StoryComparisonDashboard requires a second story source (e.g. a saved
+    draft or previous version) for storyB. Passing the same content for both
+    sides makes the comparison meaningless. Wire storyB to a real alternate
+    source before rendering this component. */}
+{/* <StoryComparisonDashboard
   storyA={
     currentStory.chapters
       ?.map((chapter) => chapter.content)
       .join("\n\n") || ""
   }
-  storyB={
-    currentStory.chapters
-      ?.map((chapter) => chapter.content)
-      .join("\n\n") || ""
-  }
-/>
+  storyB={previousStoryDraft ?? ""}
+/> */}
 
 <StoryTimelineVisualization
   story={


### PR DESCRIPTION
### Description
Comments out `StoryComparisonDashboard` with an explanatory note because
both `storyA` and `storyB` were receiving the exact same content, making
the comparison always show 0% differences. The component should be restored
once `storyB` is connected to a genuine alternate story source such as a
previous revision or saved draft.

### Related Issues
Closes #5307 