### PR TITLE
fix: store revisions in state instead of recreating them inline on every render

### DIFF
--- a/frontend/src/components/story/StoryWorkspace.tsx
+++ b/frontend/src/components/story/StoryWorkspace.tsx
@@ -68,6 +68,12 @@ const StoryWorkspace = () => {
   "Classic" | "Novel" | "Minimal" | "Dark"
 >("Classic");
 
+  const [revisions, setRevisions] = useState(() => {
+    const storyContent =
+      currentStory?.chapters?.map((c) => c.content).join("\n\n") || "";
+    return storyContent ? [createRevision(storyContent)] : [];
+  });
+
   const handleCopyStory = async () => {
   if (!currentStory) {
     toast.error("No story available to copy.");
@@ -501,15 +507,10 @@ const StoryWorkspace = () => {
 />
 
 <StoryRevisionHistory
-  revisions={[
-    createRevision(
-      currentStory.chapters
-        ?.map((chapter) => chapter.content)
-        .join("\n\n") || ""
-    ),
-  ]}
+  revisions={revisions}
   onRestore={(content) => {
-    console.log("Restore revision:", content);
+    // TODO: dispatch action to restore story content from revision
+    console.warn("Restore revision not yet wired to Redux store:", content);
   }}
 />
 


### PR DESCRIPTION
### Description
Moves revision creation out of JSX into `useState` initialization, so the
revision list persists across renders rather than being recreated as a
single-entry array on every render. Adds a `TODO` to wire `onRestore` to
the Redux store once the restore action is implemented.

### Related Issues
Closes #5309