### PR TITLE
fix: wire StoryCoverGenerator props to actual story data instead of hardcoded Fantasy/Adventure values

### DIFF
--- a/frontend/src/components/story/StoryWorkspace.tsx
+++ b/frontend/src/components/story/StoryWorkspace.tsx
@@ -278,11 +278,17 @@ const StoryWorkspace = () => {
     />
   </div>
 
-  <StoryCoverGenerator
+<StoryCoverGenerator
   title={currentStory.title}
-  genre="Fantasy"
-  theme="Adventure"
-  characters={["Hero", "Villain"]}
+  genre={currentStory.genre ?? "General"}
+  theme={currentStory.theme ?? currentStory.title}
+  characters={
+    currentStory.characters?.map((c) => c.name) ??
+    currentStory.chapters
+      ?.flatMap((ch) => ch.characters ?? [])
+      .slice(0, 3) ??
+    []
+  }
 />
 
 <StoryRewritePanel


### PR DESCRIPTION
### Description
Replaces hardcoded `genre="Fantasy"`, `theme="Adventure"`, and
`characters={["Hero", "Villain"]}` with values derived from `currentStory`
in the Redux store. Cover generation now reflects the actual story's
genre, theme, and characters instead of always producing a generic
Fantasy Adventure cover.

### Related Issues
Closes #5311 