### PR TITLE
fix : added missing VocabularyAnalyzer import in StoryWorkspace.tsx

### DIFF
--- a/frontend/src/components/story/StoryWorkspace.tsx
+++ b/frontend/src/components/story/StoryWorkspace.tsx
@@ -49,7 +49,7 @@ import StoryNamingAssistant from "../naming-assistant/StoryNamingAssistant";
 import StoryPublishingReadiness from "../publishing-readiness/StoryPublishingReadiness";
 import StoryTagGenerator from "../story-tags/StoryTagGenerator";
 import StoryReadingInfo from "../reading-info/StoryReadingInfo";
-
+import VocabularyAnalyzer from "../vocabulary/VocabularyAnalyzer";
 
 import {
   getSafeFileName,


### PR DESCRIPTION
Closes #5321.

Summary of What Has Been Done:
Added the missing import statement for VocabularyAnalyzer from the vocabulary component directory in StoryWorkspace.tsx. The component was already being used in the JSX but the import was missing, causing a runtime ReferenceError whenever the workspace renders.

Changes Made:
- frontend/src/components/story/StoryWorkspace.tsx: Added import VocabularyAnalyzer from "../vocabulary/VocabularyAnalyzer"

Impact it Made:
Fixes the runtime ReferenceError that prevented StoryWorkspace from rendering. The VocabularyAnalyzer panel is now properly imported and functional.

Note: Please assign this PR to the `tmdeveloper007` account.