### PR TITLE
fix : passed different chapter content to StoryComparisonDashboard storyA and storyB

### DIFF
--- a/frontend/src/components/story/StoryWorkspace.tsx
+++ b/frontend/src/components/story/StoryWorkspace.tsx
@@ -446,14 +446,14 @@ const StoryWorkspace = () => {
 />
 <StoryComparisonDashboard
   storyA={
-    currentStory.chapters
-      ?.map((chapter) => chapter.content)
-      .join("\n\n") || ""
+    currentStory.chapters?.length
+      ? currentStory.chapters[currentStory.chapters.length - 1].content
+      : ""
   }
   storyB={
-    currentStory.chapters
-      ?.map((chapter) => chapter.content)
-      .join("\n\n") || ""
+    currentStory.chapters?.length && currentStory.chapters.length > 1
+      ? currentStory.chapters[currentStory.chapters.length - 2].content
+      : "(previous chapter will appear here)"
   }
 />
 


### PR DESCRIPTION
Closes #5323.

Summary of What Has Been Done:
The StoryComparisonDashboard in StoryWorkspace.tsx was receiving identical content for both storyA and storyB (the same full chapters list mapped and joined), causing the comparison to always show 0% difference. Fixed by passing the last chapter content to storyA and the second-to-last chapter content to storyB, enabling real comparison between consecutive chapters.

Changes Made:
- frontend/src/components/story/StoryWorkspace.tsx: Modified StoryComparisonDashboard usage to pass the last chapter as storyA and the previous chapter as storyB, with appropriate fallbacks

Impact it Made:
The story comparison dashboard now shows real differences between the current chapter and the previous chapter, giving writers meaningful feedback on how their story is evolving.

Note: Please assign this PR to the `tmdeveloper007` account.