### PR TITLE
fix : removed duplicate truncateText function declaration in truncateText.ts

### DIFF
--- a/frontend/src/utils/truncateText.ts
+++ b/frontend/src/utils/truncateText.ts
@@ -34,33 +34,5 @@ export const truncateText = (
   }
 
   return truncated + suffix;
-};
-
-export const truncateText = (
-    text: string,
-    maxLength: number,
-    suffix: string = '...'
-): string => {
-    if(!text || text.length <= maxLength){
-        return text
-    }
-
-
-    if(maxLength <= suffix.length){
-        return suffix.substring(0,maxLength)
-    }
-
-    const allowedLength = maxLength - suffix.length
-    let resultText = text.substring(0,allowedLength)
-
-    if(text[allowedLength] !== " " && text[allowedLength -1] !== " "){
-        const lastSpaceIndex = resultText.lastIndexOf(" ")
-        if(lastSpaceIndex !== -1){
-            resultText = resultText.substring(0,lastSpaceIndex)
-        }
-    }
-
-
-    return resultText.trimEnd() + suffix
 }
 


### PR DESCRIPTION
Closes #5324.

Summary of What Has Been Done:
Removed the second duplicate declaration of the truncateText function from frontend/src/utils/truncateText.ts. The file had two implementations of the same function - the first using .slice() and .lastIndexOf() with proper null/type guards, and a second using .substring() and .trimEnd() with different word-boundary logic. The second declaration was shadowing the first and causing ambiguity. Only the first (correct) implementation is retained.

Changes Made:
- frontend/src/utils/truncateText.ts: Removed the duplicate truncateText function declaration (28 lines removed)

Impact it Made:
Removes code duplication and ensures only one consistent implementation is used. The remaining implementation properly guards against null/undefined inputs and handles word-boundary truncation cleanly.

Note: Please assign this PR to the `tmdeveloper007` account.