### PR TITLE
feat : added validatePromptLength to genreBlend utility

### DIFF
--- a/frontend/src/utils/__tests__/genreBlend.test.ts
+++ b/frontend/src/utils/__tests__/genreBlend.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import {
+  blendGenres,
+  validateGenres,
+  regenerateBlend,
+  validatePromptLength,
+  DEFAULT_MAX_PROMPT_LENGTH,
+} from "../genreBlend";
+
+describe("blendGenres", () => {
+  it("returns selectedGenres and blendedPrompt unchanged", () => {
+    const request = { genres: ["fantasy", "sci-fi"], prompt: "write a story" };
+    const result = blendGenres(request);
+    expect(result.selectedGenres).toEqual(["fantasy", "sci-fi"]);
+    expect(result.blendedPrompt).toBe("write a story");
+  });
+
+  it("handles an empty genres array", () => {
+    const request = { genres: [], prompt: "write a story" };
+    const result = blendGenres(request);
+    expect(result.selectedGenres).toEqual([]);
+    expect(result.blendedPrompt).toBe("write a story");
+  });
+
+  it("preserves prompt whitespace and casing", () => {
+    const request = { genres: ["horror"], prompt: "  A   Dark   Tale  " };
+    const result = blendGenres(request);
+    expect(result.blendedPrompt).toBe("  A   Dark   Tale  ");
+  });
+
+  it("returns correct shape with single genre", () => {
+    const request = { genres: ["romance"], prompt: "a love story" };
+    const result = blendGenres(request);
+    expect(result).toHaveProperty("selectedGenres");
+    expect(result).toHaveProperty("blendedPrompt");
+    expect(Array.isArray(result.selectedGenres)).toBe(true);
+    expect(typeof result.blendedPrompt).toBe("string");
+  });
+});
+
+describe("validateGenres", () => {
+  it("returns true for array with exactly 2 genres", () => {
+    expect(validateGenres(["fantasy", "sci-fi"])).toBe(true);
+  });
+
+  it("returns true for array with more than 2 genres", () => {
+    expect(validateGenres(["fantasy", "sci-fi", "horror", "romance"])).toBe(true);
+  });
+
+  it("returns false for empty array", () => {
+    expect(validateGenres([])).toBe(false);
+  });
+
+  it("returns false for array with only 1 genre", () => {
+    expect(validateGenres(["fantasy"])).toBe(false);
+  });
+
+  it("throws when given null input", () => {
+    expect(() => validateGenres(null as unknown as string[])).toThrow();
+  });
+
+  it("throws when given undefined input", () => {
+    expect(() => validateGenres(undefined as unknown as string[])).toThrow();
+  });
+});
+
+describe("regenerateBlend", () => {
+  it("returns the same shape as blendGenres", () => {
+    const request = { genres: ["mystery", "thriller"], prompt: "solve the case" };
+    const result = regenerateBlend(request);
+    expect(result).toHaveProperty("selectedGenres");
+    expect(result).toHaveProperty("blendedPrompt");
+  });
+
+  it("delegates to blendGenres for empty genres", () => {
+    const request = { genres: [] as string[], prompt: "" };
+    const result = regenerateBlend(request);
+    expect(result.selectedGenres).toEqual([]);
+    expect(result.blendedPrompt).toBe("");
+  });
+
+  it("preserves genres and prompt through regeneration", () => {
+    const request = { genres: ["comedy", "drama"], prompt: "a funny drama" };
+    const result = regenerateBlend(request);
+    expect(result.selectedGenres).toEqual(request.genres);
+    expect(result.blendedPrompt).toBe(request.prompt);
+  });
+});
+
+describe("validatePromptLength", () => {
+  it("returns true for prompt within default max length", () => {
+    expect(validatePromptLength("a short prompt")).toBe(true);
+  });
+
+  it("returns true for prompt exactly at default max length", () => {
+    const prompt = "a".repeat(DEFAULT_MAX_PROMPT_LENGTH);
+    expect(validatePromptLength(prompt)).toBe(true);
+  });
+
+  it("returns false for prompt exceeding default max length", () => {
+    const prompt = "a".repeat(DEFAULT_MAX_PROMPT_LENGTH + 1);
+    expect(validatePromptLength(prompt)).toBe(false);
+  });
+
+  it("returns true for prompt within custom max length", () => {
+    expect(validatePromptLength("short", 10)).toBe(true);
+  });
+
+  it("returns false for prompt exceeding custom max length", () => {
+    expect(validatePromptLength("this is too long", 5)).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(validatePromptLength("")).toBe(false);
+  });
+
+  it("returns false for null input", () => {
+    expect(validatePromptLength(null as unknown as string)).toBe(false);
+  });
+
+  it("returns false for undefined input", () => {
+    expect(validatePromptLength(undefined as unknown as string)).toBe(false);
+  });
+
+  it("handles prompt with multibyte characters correctly", () => {
+    // Each multibyte char counts as one character in JS string.length
+    const prompt = "\u4e2d\u6587".repeat(500); // 1000 characters
+    expect(validatePromptLength(prompt, 2000)).toBe(true);
+    expect(validatePromptLength(prompt, 500)).toBe(false);
+  });
+});

--- a/frontend/src/utils/genreBlend.ts
+++ b/frontend/src/utils/genreBlend.ts
@@ -28,3 +28,15 @@ export const regenerateBlend = (
 ): GenreBlendResult => {
   return blendGenres(request);
 };
+
+export const DEFAULT_MAX_PROMPT_LENGTH = 2000;
+
+export const validatePromptLength = (
+  prompt: string,
+  maxLength: number = DEFAULT_MAX_PROMPT_LENGTH
+): boolean => {
+  if (!prompt || typeof prompt !== "string") {
+    return false;
+  }
+  return prompt.length <= maxLength;
+};


### PR DESCRIPTION
Closes #5334.

Summary of What Has Been Done:
Added a new validatePromptLength function to frontend/src/utils/genreBlend.ts with a configurable max length (default 2000 characters). This prevents oversized prompts from reaching downstream services. The function returns false for null, undefined, or empty prompts, and false when the prompt exceeds the max length.

Changes Made:
- frontend/src/utils/genreBlend.ts: Added validatePromptLength function and DEFAULT_MAX_PROMPT_LENGTH export
- frontend/src/utils/__tests__/genreBlend.test.ts: Added 22 tests covering all functions including the new validatePromptLength

Impact it Made:
- 22 test cases passing (verified with vitest)
- TypeScript type-check and ESLint lint both pass
- Enables callers to enforce prompt size limits at the utility layer

Note: Please assign this PR to the `tmdeveloper007` account.