### PR TITLE
fix: move mid-file import statements to top of stories.component.tsx

### DIFF
--- a/frontend/src/components/stories/stories.component.tsx
+++ b/frontend/src/components/stories/stories.component.tsx
@@ -1,4 +1,11 @@
-import React, { useCallback, useState, useEffect, useRef } from "react";
+import React, { useCallback, useState, useEffect, useRef, useMemo } from "react";
+import AudioPlayer, { type AudioPlayerHandle, type NarrationPlaybackState } from "../AudioPlayer";
+import ImageFallback from "../ImageFallback";
+import GeneratedStoryTimeline from "./GeneratedStoryTimeline";
+import {
+  useGenerateAlternateEndingsMutation,
+  useGenerateFreeAlternateEndingsMutation,
+} from "../../redux/apis/ai.model.api";
 import jsPDF from "jspdf";
 import StoriesViewComponent, { IStories } from "./stories.view.component";
 import { Link, useLocation, useNavigate } from "react-router-dom";
@@ -412,14 +419,6 @@ const TonePicker: React.FC<TonePickerProps> = React.memo(({ selected, onChange }
     </div>
   );
 });
-import AudioPlayer, { type AudioPlayerHandle, type NarrationPlaybackState } from "../AudioPlayer";
-import { useLocation } from "react-router-dom";
-import {
-  useGenerateAlternateEndingsMutation,
-  useGenerateFreeAlternateEndingsMutation,
-} from "../../redux/apis/ai.model.api";
-import ImageFallback from "../ImageFallback";
-import GeneratedStoryTimeline from "./GeneratedStoryTimeline";
 export interface IStories {
   uuid: string;
   title: string;


### PR DESCRIPTION
### Description
Moves five import statements that were illegally placed in the middle of the
component body to the top of the file. Removes the duplicate `useLocation`
import (already imported at top). Fixes the SyntaxError that prevented the
entire module from compiling.

### Related Issues
Closes #5345 