### PR TITLE
fix: remove duplicate import of StoriesViewComponent and IStories — definitions already exist inline

### DIFF
--- a/frontend/src/components/stories/stories.component.tsx
+++ b/frontend/src/components/stories/stories.component.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState, useEffect, useRef } from "react";
 import jsPDF from "jspdf";
-import StoriesViewComponent, { IStories } from "./stories.view.component";
+// StoriesViewComponent and IStories are defined locally in this file
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { getUserInfo, isLoggedIn } from "../../services/auth.service";
 import { getRequestLimit, getWordCount, prompts, STORY_TEMPLATES } from "./stories.utils";


### PR DESCRIPTION
### Description
Removes the top-level import of `StoriesViewComponent` and `IStories` from
`./stories.view.component` since both identifiers are already fully defined
inline in `stories.component.tsx`. Having both an import and a local
declaration in the same scope caused TypeScript to throw Duplicate identifier
errors, preventing the entire module from compiling.

### Related Issues
Closes #5347 