### PR TITLE
fix: declare isDangerLimit from DANGER_THRESHOLD constant in StoriesComponent

### DIFF
--- a/frontend/src/components/stories/stories.component.tsx
+++ b/frontend/src/components/stories/stories.component.tsx
@@ -1438,6 +1438,7 @@ const onSubmit: SubmitHandler<Inputs> = useCallback(async (data) => {
   };
 
   const isOverLimit = textareaValue.length >= MAX_PROMPT_LENGTH;
+  const isDangerLimit = textareaValue.length >= MAX_PROMPT_LENGTH * DANGER_THRESHOLD;
   const isNearLimit = textareaValue.length >= MAX_PROMPT_LENGTH * WARN_THRESHOLD;
   
   useKeyboardShortcuts({
@@ -1507,6 +1508,7 @@ const handleExportMarkdown = () => {
 
 
   const isOverLimit = textareaValue.length >= MAX_PROMPT_LENGTH;
+  const isDangerLimit = textareaValue.length >= MAX_PROMPT_LENGTH * DANGER_THRESHOLD;
   const isNearLimit = textareaValue.length >= MAX_PROMPT_LENGTH * WARN_THRESHOLD;
   const isGenerateDisabled = loading || isOverLimit || !textareaValue.trim();
 


### PR DESCRIPTION
### Description
Adds `const isDangerLimit = textareaValue.length >= MAX_PROMPT_LENGTH * DANGER_THRESHOLD`
to the component. `isDangerLimit` was already referenced in two places in the
JSX character counter colour logic but was never declared, causing a TypeScript
compile error and silently disabling the danger-zone red colour between 95%
and 100% of the character limit.

### Related Issues
Closes #5349 