### PR TITLE
fix: remove duplicate useMemo declaration of uniqueStories in StoriesComponent

### DIFF
--- a/frontend/src/components/stories/stories.component.tsx
+++ b/frontend/src/components/stories/stories.component.tsx
@@ -1570,8 +1570,6 @@ const handleExportMarkdown = () => {
 
   const uniqueStories = useMemo(() => getUniqueStories(stories), [stories]);
 
-  const uniqueStories = useMemo(() => getUniqueStories(stories), [stories]);
-
   const filteredStories = useMemo(() => {
     if (!debouncedSearchQuery.trim()) return uniqueStories;
     const query = debouncedSearchQuery.toLowerCase();


### PR DESCRIPTION
### Description
Removes the second identical `const uniqueStories = useMemo(...)` declaration.
Having two block-scoped declarations of the same variable in the same scope
causes a TypeScript compile error and prevents the module from loading.
The first declaration is kept as-is — it already serves both `filteredStories`
and `currentStories` correctly.

### Related Issues
Closes #5351 