### PR TITLE
fix: remove duplicate location.state useEffect in StoriesComponent — prevents genre data loss and double navigation

### DIFF
--- a/frontend/src/components/stories/stories.component.tsx
+++ b/frontend/src/components/stories/stories.component.tsx
@@ -1036,13 +1036,6 @@ useEffect(() => {
   }, [selectedStory, selectedStory?.content, isLogin, selectTopics, createPost]);
 
 useEffect(() => {
-  if (location.state && location.state.prompt) {
-    setTextareaValue(location.state.prompt);
-    navigate(location.pathname, { replace: true, state: {} });
-  }
-}, [location, navigate]);
-
-useEffect(() => {
   setValue("prompt", textareaValue);
 }, [textareaValue, setValue]);
 


### PR DESCRIPTION
### Description
Removes the second `useEffect` that processed `location.state.prompt` and
called `navigate` to clear state. The first effect already handles both
`prompt` and `genre` from `location.state` and calls `navigate` once.
Having both effects caused the genre to be silently dropped on navigation
and `navigate` to be called twice in the same render.

### Related Issues
Closes #5355 