### PR TITLE
fix: remove debouncedPrompt setValue effect — prevents form reversion to stale content during typing

### DIFF
--- a/frontend/src/components/stories/stories.component.tsx
+++ b/frontend/src/components/stories/stories.component.tsx
@@ -962,10 +962,6 @@ useEffect(() => {
 
 
   useEffect(() => {
-    setValue("prompt", debouncedPrompt);
-  }, [debouncedPrompt, setValue]);
-
-  useEffect(() => {
     setNarrationWordIndex(0);
     setNarrationState("idle");
   }, [selectedStory?.uuid]);


### PR DESCRIPTION
### Description
Removes the `useEffect(() => setValue("prompt", debouncedPrompt), [debouncedPrompt])`
effect. The debounced value is 300ms behind the live textarea, causing the
form to briefly revert to stale content mid-typing and triggering duplicate
validation. The `textareaValue` effect already correctly keeps the form in
sync. `debouncedPrompt` is preserved for the draft autosave effect where
debouncing is appropriate.

### Related Issues
Closes #5357 