### PR TITLE
fix: restore useCallback wrapper on playSoundtrack — prevents TypeError crash after story generation

### DIFF
--- a/frontend/src/components/stories/stories.component.tsx
+++ b/frontend/src/components/stories/stories.component.tsx
@@ -741,12 +741,9 @@ useEffect(() => {
   const audioRef = useRef<HTMLAudioElement | null>(null);
 
 
-  const playSoundtrack = (genre: string) => {
-
+  const playSoundtrack = useCallback((genre: string) => {
     const soundtrack = soundtrackMap[genre];
-
     if (!soundtrack) return;
-
     if (audioRef.current) {
       audioRef.current.pause();
       audioRef.current.currentTime = 0;
@@ -755,7 +752,7 @@ useEffect(() => {
         /* ignore autoplay restrictions */
       });
     }
-  }, []);
+  }, []); // audioRef is a stable ref — no deps needed
 
   const [isCopied, setIsCopied] = useState<boolean>(false);
   const [showWorldMap, setShowWorldMap] = useState<boolean>(false);


### PR DESCRIPTION
### Description
Restores the `useCallback(` opening that was accidentally removed while
leaving the `}, [])` closing in place. Without the wrapper, JavaScript's
comma operator assigns `[]` to `playSoundtrack` instead of the function,
causing a `TypeError` every time `playSoundtrack(selectedGenre)` is called
after a successful story generation.

### Related Issues
Closes #5359 