### PR TITLE
fix: correct closing brace position in onSubmit — restore post-generation cleanup for logged-in users

### DIFF
--- a/frontend/src/components/stories/stories.component.tsx
+++ b/frontend/src/components/stories/stories.component.tsx
@@ -1101,7 +1101,9 @@ const onSubmit: SubmitHandler<Inputs> = useCallback(async (data) => {
           const newCount = guestRequestCount + 1;
           setGuestRequestCount(newCount);
           localStorage.setItem("guestRequestCount", String(newCount));
-        // Clear draft after successful generation
+        } // ← correctly closes the if (!login) block here
+
+        // Post-generation cleanup — runs for ALL users
         localStorage.removeItem(DRAFT_KEY);
         setDraftStatus("");
         reset();
@@ -1110,8 +1112,7 @@ const onSubmit: SubmitHandler<Inputs> = useCallback(async (data) => {
         if (selectedGenre) {
           playSoundtrack(selectedGenre);
         }
-        window.scrollTo({ top: 0, behavior: 'smooth' });
-      }
+        window.scrollTo({ top: 0, behavior: "smooth" });
     } catch (error: unknown) {
       const message = getErrorMessage(error);
       if (message !== "Story generation was cancelled.") {


### PR DESCRIPTION
### Description
Moves the closing brace of the `if (!login)` block to immediately after
`localStorage.setItem("guestRequestCount", ...)`. All subsequent cleanup
(`removeItem`, `setDraftStatus`, `reset`, `setCharacters`, `setCurrentStep`,
`playSoundtrack`, `scrollTo`) now runs unconditionally for all users,
as originally intended.

### Related Issues
Closes #5362