### PR TITLE
fix: remove duplicate useState declarations for guestRequestCount and showLimitModal in StoriesComponent

### DIFF
--- a/frontend/src/components/stories/stories.component.tsx
+++ b/frontend/src/components/stories/stories.component.tsx
@@ -673,11 +673,6 @@ const handleLoadFromRoster = (
 };
 const dropdownRef = useRef<HTMLDivElement>(null);
 const inputRef = useRef<HTMLTextAreaElement>(null);
-const [guestRequestCount, setGuestRequestCount] = useState<number>(() =>
-  parseInt(localStorage.getItem("guestRequestCount") || "0", 10),
-);
-const [showLimitModal, setShowLimitModal] = useState<boolean>(false);
-
 useEffect(() => {
   window.scrollTo({ top: 0, behavior: "smooth" });
 }, []);


### PR DESCRIPTION
### Description
Removes the first (orphaned) `useState` declarations for `guestRequestCount`
and `showLimitModal`. Both appeared in a stray code block copy-pasted from
the inner component body. Having duplicate `useState` calls causes TypeScript
compile errors and corrupts React's hook order index for all hooks below
the duplicate in the component tree.

### Related Issues
Closes #5368 