### PR TITLE
Fix speech synthesis comma

### DIFF
--- a/frontend/src/hooks/useSpeechSynthesis.ts
+++ b/frontend/src/hooks/useSpeechSynthesis.ts
@@ -112,7 +112,7 @@ const getLanguageLabel = (lang: string): string => {
   }
 };
 
-,const buildWordRanges = (inputText: string): WordRange[] => {
+const buildWordRanges = (inputText: string): WordRange[] => {
   if (!inputText.trim()) {
     return [];
   }

--- a/frontend/src/hooks/useSpeechSynthesis.ts
+++ b/frontend/src/hooks/useSpeechSynthesis.ts
@@ -179,7 +179,7 @@ export const useSpeechSynthesis = (
     setIsSpeaking(false);
     setIsPaused(false);
     setCurrentWordIndex(0);
-  }, []);
+  };
 
   useEffect(() => {
     if (!hasSpeechSupport()) {


### PR DESCRIPTION
## Before you open this PR

**Issue:** Open or link a related issue when there is one (`Closes #123`, `Fixes #45`, or write `None` under Related issue below).

**Description:** Fill in **What this PR does** so a reviewer can understand the change without your local context.

**Screenshots:** Add screenshots or a short recording when they help (UI changes, confusing flows, or non-code proof). If not needed, say so in the checklist.

### Screenshot (when helpful)

N/A — This PR contains only syntax fixes in a TypeScript hook and does not introduce any UI changes.

## What this PR does

Fixes the syntax errors in `frontend/src/hooks/useSpeechSynthesis.ts` that were preventing the TypeScript compiler from successfully parsing and compiling the frontend codebase.

The issue was caused by invalid syntax in the file, including:

* An unintended leading comma before the `const buildWordRanges` declaration at line 120.
* A dangling `useCallback` dependency array (`}, []);`) that should have been a standard function closure (`};`) around line 182.

These changes restore valid TypeScript syntax and allow the frontend codebase to be parsed and compiled successfully.

The fix was verified using:

```bash
pnpm --dir frontend exec tsc -b --noEmit
```

## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

## Related issue

Fixes #4556 

## More screenshots (optional)

N/A — No UI or visual changes were made.

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted N/A with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.
