### PR TITLE
fix : removed duplicate truncateText function declaration in truncateText.ts

### DIFF
--- a/frontend/src/utils/truncateText.ts
+++ b/frontend/src/utils/truncateText.ts
@@ -1,4 +1,3 @@
-
 /**
  * Truncates a string to a maximum length, adding an ellipsis suffix.
  * Attempts to break at a word boundary when possible.
@@ -35,32 +34,3 @@ export const truncateText = (
 
   return truncated + suffix;
 };
-
-export const truncateText = (
-    text: string,
-    maxLength: number,
-    suffix: string = '...'
-): string => {
-    if(!text || text.length <= maxLength){
-        return text
-    }
-
-
-    if(maxLength <= suffix.length){
-        return suffix.substring(0,maxLength)
-    }
-
-    const allowedLength = maxLength - suffix.length
-    let resultText = text.substring(0,allowedLength)
-
-    if(text[allowedLength] !== " " && text[allowedLength -1] !== " "){
-        const lastSpaceIndex = resultText.lastIndexOf(" ")
-        if(lastSpaceIndex !== -1){
-            resultText = resultText.substring(0,lastSpaceIndex)
-        }
-    }
-
-
-    return resultText.trimEnd() + suffix
-}
-


### PR DESCRIPTION
Closes #5397.

Summary of What Has Been Done:
Removed the second (older) `export const truncateText` function declaration from frontend/src/utils/truncateText.ts. The file contained two declarations with different implementations. Kept the first declaration which has proper type checking, null guard, and word-boundary truncation logic.

Changes Made:
- frontend/src/utils/truncateText.ts: Removed the second duplicate truncateText function (lines 38-65 of the original file) that lacked type checking and had inconsistent behavior.

Impact it Made:
- Fixes TypeScript duplicate-identifier compilation errors
- Ensures the more robust truncateText implementation is used at runtime
- Clean diff with only dead code removed

Note: Please assign this PR to the `tmdeveloper007` account.