### PR TITLE
fix : added typeof window guard in useAccessibility hook

### DIFF
--- a/frontend/src/hooks/useAccessibility.js
+++ b/frontend/src/hooks/useAccessibility.js
@@ -5,11 +5,13 @@ export const useAccessibility = () => {
   const [reducedMotion, setReducedMotion] = useState(false);
 
   useEffect(() => {
+    if (typeof window === 'undefined') return;
     const saved = localStorage.getItem('accessibility-contrast');
     if (saved) setHighContrast(JSON.parse(saved));
   }, []);
 
   const toggle = (setter, key) => {
+    if (typeof window === 'undefined') return;
     setter(v => {
       localStorage.setItem(key, !v);
       return !v;


### PR DESCRIPTION
Closes #5433.

Summary of What Has Been Done:
Added typeof window !== 'undefined' guards in the useAccessibility hook to prevent localStorage access during server-side rendering (Next.js, Vite SSR). The fix guards both the useEffect that reads the saved accessibility preference and the toggle function that writes it back.

Changes Made:
- frontend/src/hooks/useAccessibility.js: Added typeof window guard in useEffect before reading localStorage; added typeof window guard in toggle function before writing localStorage.

Impact it Made:
- Prevents runtime crashes in SSR environments when the hook is used in server-rendered component trees.
- Follows the same SSR-safe pattern used elsewhere in the codebase.

Note: Please assign this PR to the `tmdeveloper007` account.