### PR TITLE
fix: reduce three decorative blur divs to one — remove fixed-position and duplicate instances

### DIFF
--- a/frontend/src/components/stories/stories.component.tsx
+++ b/frontend/src/components/stories/stories.component.tsx
@@ -2825,11 +2825,8 @@ onKeyDown={(e) => {
         isLogin={login}
         setStories={setStories}
       />
-      <div className="absolute top-[-200px] left-[250px] w-[800px] h-[350px] bg-blue-500/20 rounded-full blur-3xl -z-10"></div>
-
-      <div className="fixed top-[-200px] left-[250px] w-[800px] h-[350px] bg-blue-500/20 rounded-full blur-3xl -z-10"></div>
-
-      <div className="absolute top-[-200px] left-[250px] w-[800px] h-[350px] bg-blue-500/20 rounded-full blur-3xl -z-10"></div>
+      {/* Single decorative blur — absolute so it scrolls with content and doesn't bleed over modals */}
+      <div className="absolute top-[-200px] left-[250px] w-[800px] h-[350px] bg-blue-500/20 rounded-full blur-3xl -z-10 pointer-events-none"></div>
 
       {showLimitModal && (
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">


### PR DESCRIPTION
### Description
Replaces three near-identical decorative blur divs with a single `absolute`
positioned one. Removes the `fixed` variant (bleeds over modals, persists
on GPU during scroll) and the third duplicate (doubles blur opacity).
Adds `pointer-events-none` to ensure the decorative element never captures
clicks intended for content below it.

### Related Issues
Closes #5443 