### PR TITLE
fix(backend): patch in-memory draft auto-saver DOS & leak

### DIFF
--- a/backend/src/routes/stories.ts
+++ b/backend/src/routes/stories.ts
@@ -39,15 +39,22 @@ const branchingStorySchema = z.object({
 });
 
 const autosaveDraftSchema = z.object({
-  draftId: z.string().min(1, "draftId is required"),
-  title: z.string().default(""),
-  content: z.string().default(""),
+  draftId: z.string().min(1, "draftId is required").max(100, "draftId is too long"),
+  title: z.string().max(200, "title is too long").default(""),
+  content: z.string().max(50000, "content is too long").default(""),
 });
 
 const autosaveDraftStore = new Map<string, { draftId: string; title: string; content: string; savedAt: string }>();
 
 router.put(
   "/save",
+  storyLimiter,
+  auth(
+    ENUM_USER_ROLE.USER,
+    ENUM_USER_ROLE.WRITER,
+    ENUM_USER_ROLE.ADMIN,
+    ENUM_USER_ROLE.SUPER_ADMIN
+  ),
   catchAsync(async (req, res) => {
     const parsed = autosaveDraftSchema.safeParse(req.body);
 
@@ -61,6 +68,12 @@ router.put(
 
     const { draftId, title, content } = parsed.data;
     const savedAt = new Date().toISOString();
+
+    // Bound the in-memory map to prevent memory leak / OOM
+    if (autosaveDraftStore.size > 5000) {
+      // Very basic LRU/cleanup: clear it or delete oldest (for simplicity, clear half or just clear)
+      autosaveDraftStore.clear(); 
+    }
 
     autosaveDraftStore.set(draftId, { draftId, title, content, savedAt });
 


### PR DESCRIPTION
**Description:**
Closes #5445 
**What this PR does:**
This PR under gssoc'26 mitigates a critical memory leak and Denial of Service (DoS) vulnerability in the backend's in-memory draft autosave system (`PUT /api/v1/stories/save`). 

**Why it's needed:**
Previously, the `PUT /save` endpoint:
1. Did not enforce authentication, allowing anyone to hit it anonymously.
2. Lacked rate limiting.
3. Accepted unbounded payload strings for `title` and `content`.
4. Stored all incoming payloads indefinitely in an unbounded global JavaScript `Map` (`autosaveDraftStore`).

This combination allowed a trivial Application-Level DoS where an attacker could flood the endpoint with massive payloads under unique `draftId`s, rapidly filling the Node.js V8 heap and crashing the server with an Out-Of-Memory (OOM) error.

**Changes made:**
- **Authentication & Throttling:** Added the `auth()` and `storyLimiter` middlewares to the route.
- **Payload Constraints:** Enforced `.max()` limits in the Zod schema (`draftId`: 100, `title`: 200, `content`: 50,000).
- **Map Bounding:** Added basic bounds checking to the `autosaveDraftStore`. The map will proactively `.clear()` itself if it exceeds 5000 active entries, guaranteeing the process heap remains safe.

**Checklist:**
- [x] I have read the contribution guidelines.
- [x] I have tested the changes locally.
- [x] My code follows the project's style guidelines.

@ronisarkarexe Please check it