### PR TITLE
fix: render AudioPlayer in StoryViewer control panel — restores missing audio narration feature

### DIFF
--- a/frontend/src/components/story/StoryViewer.tsx
+++ b/frontend/src/components/story/StoryViewer.tsx
@@ -405,6 +405,16 @@ ${ncxNavPoints}  </navMap>
           </div>
         </div>
 
+        {/* Audio Narration Player */}
+        {chapters.length > 0 && (
+          <div className="mb-4">
+            <AudioPlayer
+              text={chapters.map((ch) => ch.content).join("\n\n")}
+              title={chapters[0]?.title ?? "Story"}
+            />
+          </div>
+        )}
+
         {/* Action Export Buttons */}
         <div className="flex gap-4">
           <button


### PR DESCRIPTION
### Description
Adds the `AudioPlayer` component to the `StoryViewer` control panel.
It was imported but never rendered, silently omitting audio narration
from the story reading view. The player receives all chapter content
joined as a single string and the first chapter's title.

### Related Issues
Closes #5483