### PR TITLE
fix: revoke blob URL after EPUB download in StoryViewer to eliminate memory leak

### DIFF
--- a/frontend/src/components/story/StoryViewer.tsx
+++ b/frontend/src/components/story/StoryViewer.tsx
@@ -289,12 +289,14 @@ ${ncxNavPoints}  </navMap>
 
       // Trigger ZIP blob download
       const blob = await zip.generateAsync({ type: "blob" });
+      const objectUrl = URL.createObjectURL(blob);
       const link = document.createElement("a");
-      link.href = URL.createObjectURL(blob);
+      link.href = objectUrl;
       link.download = `${safeName}.epub`;
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
+      URL.revokeObjectURL(objectUrl); // Release blob from memory immediately after download
 
       toast.success("EPUB downloaded successfully!");
     } catch (err) {


### PR DESCRIPTION
### Description
Stores the result of `URL.createObjectURL(blob)` in a variable and
calls `URL.revokeObjectURL(objectUrl)` immediately after `link.click()`.
Without this, each export permanently holds the EPUB blob in memory
for the browser session. This is a well-known JS memory leak pattern.

### Related Issues
Closes #5485 