### PR TITLE
fix: downgrade chapter title headings from h1 to h2 in StoryViewer for SEO and WCAG compliance

### DIFF
--- a/frontend/src/components/story/StoryViewer.tsx
+++ b/frontend/src/components/story/StoryViewer.tsx
@@ -423,11 +423,16 @@ ${ncxNavPoints}  </navMap>
       </div>
 
       <div className="max-w-4xl mx-auto">
+        {/* Single h1 for the story title — SEO and accessibility primary landmark */}
+        {chapters[0] && (
+          <h1 className="sr-only">{chapters[0].title}</h1>
+        )}
         {chapters.map((chapter) => (
           <div key={chapter.id} className="mb-16">
-            <h1 className="text-4xl font-extrabold tracking-tight text-white mb-6">
+            {/* h2: chapter titles are sub-sections, not page titles */}
+            <h2 className="text-4xl font-extrabold tracking-tight text-white mb-6">
               {chapter.title}
-            </h1>
+            </h2>
             <ReadingTimeBadge text={chapter.content} />
             <p className="text-lg text-zinc-300 whitespace-pre-line leading-9">
               {chapter.content}


### PR DESCRIPTION
### Description
Changes all chapter title `<h1>` elements to `<h2>` in the chapter
map. Adds a single visually-hidden `<h1>` using the first chapter's
title as the page's primary landmark. This satisfies both search engine
expectations (one primary topic signal per page) and WCAG 1.3.1
(meaningful heading hierarchy for screen readers).

### Related Issues
Closes #5487 