### PR TITLE
fix: filter empty paragraphs in EPUB export to match PDF behavior and pass EPUBCheck validation

### DIFF
--- a/frontend/src/components/story/StoryViewer.tsx
+++ b/frontend/src/components/story/StoryViewer.tsx
@@ -225,7 +225,9 @@ p {
 
         const paragraphsHtml = (chapter.content || "")
           .split(/\n+/)
-          .map((para) => `<p>${para.trim()}</p>`)
+          .map((para) => para.trim())
+          .filter((para) => para.length > 0)   // mirror PDF: skip empty paragraphs
+          .map((para) => `<p>${para}</p>`)
           .join("\n");
 
         const htmlContent = `<?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
### Description
Adds `.filter((para) => para.length > 0)` to the EPUB paragraph
pipeline in `handleExportEPUB`, mirroring the `if (!clean) return`
guard already present in `handleExportPDF`. Empty content lines no
longer produce `<p></p>` elements, preventing blank-line rendering
artefacts in e-readers and EPUBCheck conformance warnings.

### Related Issues
Closes #5489 