### PR TITLE
feature : added slugify utility for URL-safe string transformation

### DIFF
--- a/backend/src/app/utils/__tests__/slugify.test.ts
+++ b/backend/src/app/utils/__tests__/slugify.test.ts
@@ -1,0 +1,77 @@
+import { slugify } from "../slugify";
+
+describe("slugify", () => {
+  it("converts spaces to hyphens", () => {
+    expect(slugify("Hello World")).toBe("hello-world");
+  });
+
+  it("converts multiple spaces to single hyphens", () => {
+    expect(slugify("Hello   World")).toBe("hello-world");
+  });
+
+  it("converts tabs and newlines to hyphens", () => {
+    expect(slugify("Hello\tWorld")).toBe("hello-world");
+    expect(slugify("Hello\nWorld")).toBe("hello-world");
+  });
+
+  it("strips non-alphanumeric characters", () => {
+    expect(slugify("Hello@World!")).toBe("helloworld");
+    expect(slugify("What's Up?")).toBe("whats-up");
+    expect(slugify("Hello#World$Test")).toBe("helloworldtest");
+  });
+
+  it("preserves hyphens in the input", () => {
+    expect(slugify("hello-world-story")).toBe("hello-world-story");
+  });
+
+  it("collapses multiple consecutive hyphens into one", () => {
+    expect(slugify("hello---world")).toBe("hello-world");
+    expect(slugify("a--b--c")).toBe("a-b-c");
+  });
+
+  it("trims leading and trailing hyphens", () => {
+    expect(slugify("  hello world  ")).toBe("hello-world");
+    expect(slugify("--hello--")).toBe("hello");
+  });
+
+  it("preserves numbers", () => {
+    expect(slugify("Story 123")).toBe("story-123");
+    expect(slugify("Chapter 1: The Beginning")).toBe("chapter-1-the-beginning");
+  });
+
+  it("lower-cases the result", () => {
+    expect(slugify("HELLO WORLD")).toBe("hello-world");
+    expect(slugify("HeLLo WoRLd")).toBe("hello-world");
+  });
+
+  it("handles single character input", () => {
+    expect(slugify("A")).toBe("a");
+  });
+
+  it("handles empty string", () => {
+    expect(slugify("")).toBe("");
+  });
+
+  it("handles whitespace-only string", () => {
+    expect(slugify("   ")).toBe("");
+    expect(slugify("\t\n")).toBe("");
+  });
+
+  it("handles null input", () => {
+    expect(slugify(null as unknown as string)).toBe("");
+  });
+
+  it("handles undefined input", () => {
+    expect(slugify(undefined as unknown as string)).toBe("");
+  });
+
+  it("handles strings with only special characters", () => {
+    expect(slugify("@#$%")).toBe("");
+    expect(slugify("---")).toBe("");
+  });
+
+  it("produces consistent output for mixed input", () => {
+    expect(slugify("The Quick-Brown Fox!")).toBe("the-quick-brown-fox");
+    expect(slugify("  Hello   World@2024! ")).toBe("hello-world2024");
+  });
+});

--- a/backend/src/app/utils/slugify.ts
+++ b/backend/src/app/utils/slugify.ts
@@ -1,0 +1,21 @@
+/**
+ * Converts a string to a URL-safe slug.
+ * - Lowercases the string
+ * - Replaces spaces with hyphens
+ * - Strips non-alphanumeric characters (keeps hyphens)
+ * - Collapses multiple consecutive hyphens into one
+ * - Trims leading and trailing hyphens
+ */
+export const slugify = (text: string): string => {
+  if (!text || typeof text !== "string") {
+    return "";
+  }
+
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, "-")           // spaces to hyphens
+    .replace(/[^a-z0-9-]/g, "")     // strip non-alphanumeric (keep hyphens)
+    .replace(/-+/g, "-")            // collapse multiple hyphens
+    .replace(/^-+|-+$/g, "");       // trim leading/trailing hyphens
+};


### PR DESCRIPTION
Closes #5517.

Summary of What Has Been Done:
Added a new slugify utility at backend/src/app/utils/slugify.ts that converts strings to URL-safe slugs. The function lowercases input, replaces spaces with hyphens, strips non-alphanumeric characters, collapses consecutive hyphens, and trims leading/trailing hyphens. Includes 16 Jest unit tests.

Changes Made:
- Created backend/src/app/utils/slugify.ts with slugify function
- Created backend/src/app/utils/__tests__/slugify.test.ts with 16 test cases

Impact it Made:
- Provides a reusable utility for generating URL slugs across the backend
- All 16 Jest tests pass locally
- Is a new isolated file, no impact on existing code

Note: Please assign this PR to the `tmdeveloper007` account.