### PR TITLE
fix : added runtime type validation for ReactionType in toggleReaction

### DIFF
--- a/backend/src/app/modules/reaction/reaction.service.ts
+++ b/backend/src/app/modules/reaction/reaction.service.ts
@@ -9,11 +9,20 @@ import { verifyPostAccess } from "../post/post.utils";
 
 type ReactionType = "like" | "love" | "laugh" | "angry" | "sad";
 
+const VALID_REACTION_TYPES: ReactionType[] = ["like", "love", "laugh", "angry", "sad"];
+
 const toggleReaction = async (
   postId: string,
   type: ReactionType = "like",
   token: ITokenPayload
 ) => {
+  if (!VALID_REACTION_TYPES.includes(type)) {
+    throw new ApiError(
+      httpStatus.BAD_REQUEST,
+      `Invalid reaction type '${type}'. Allowed types: ${VALID_REACTION_TYPES.join(", ")}`
+    );
+  }
+
   const { email } = token;
 
   if (!Types.ObjectId.isValid(postId)) {


### PR DESCRIPTION
Closes #5518.

Summary of What Has Been Done:
Added a runtime validation guard in the toggleReaction function at backend/src/app/modules/reaction/reaction.service.ts. The guard checks the reaction type against the allowed set ('like', 'love', 'laugh', 'angry', 'sad') and throws a BAD_REQUEST ApiError if an invalid type is provided. While TypeScript enforces this at compile time, the runtime guard prevents silent failures from untyped callers.

Changes Made:
- backend/src/app/modules/reaction/reaction.service.ts: Added VALID_REACTION_TYPES constant and includes() check before processing

Impact it Made:
- Prevents silent failures or database errors from invalid reaction types
- Provides clear error feedback (BAD_REQUEST with allowed types list) for invalid input
- Adds defensive layer complementing TypeScript compile-time check

Note: Please assign this PR to the `tmdeveloper007` account.