### PR TITLE
fix: prevent chatbot icon and scroll-to-top button overlap

### DIFF
--- a/frontend/src/components/ScrollToTopButton.tsx
+++ b/frontend/src/components/ScrollToTopButton.tsx
@@ -34,7 +34,7 @@ const ScrollToTopButton = () => {
       aria-label="Scroll to top"
       title="Scroll to top"
       className={`
-        fixed bottom-24 right-7
+        fixed bottom-28 right-7
         w-12 h-12 rounded-full
         border border-white/20 cursor-pointer
         bg-gradient-to-br from-blue-600 to-indigo-600


### PR DESCRIPTION
## Before you open this PR

**Issue:** Open or link a related issue when there is one (Closes #123, Fixes #45, or write None under Related issue below).  
**Description:** Fill in What this PR does so a reviewer can understand the change without your local context.  
**Screenshots:** Add screenshots or a short recording when they help (UI changes, confusing flows, or non-code proof). If not needed, say so in the checklist.

---

## Screenshot (when helpful)

N/A — small UI positioning change. The modification only adjusts the spacing between two existing floating buttons without changing their appearance or functionality.

---

## What this PR does

- Fixes the overlap between the floating chatbot button and the Scroll-to-Top button.
- Adjusts the Scroll-to-Top button position from `bottom-24` to `bottom-28` to provide adequate spacing.
- Preserves the existing design, animations, responsiveness, and functionality of both components.
- Keeps the change focused on the UI positioning without modifying any unrelated code.

---

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

---

## Related issue

Fixes #4757

---

## More screenshots (optional)

N/A — no additional screenshots required.

---

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.