### PR TITLE
fix: use version ID for isCurrent detection in VersionHistoryPanel — prevents false "Current Version" highlights

### DIFF
--- a/frontend/src/components/story/VersionHistoryPanel.tsx
+++ b/frontend/src/components/story/VersionHistoryPanel.tsx
@@ -18,6 +18,10 @@ const VersionHistoryPanel = () => {
     (state: RootState) => state.story.currentStory
   );
 
+  const currentVersionId = useSelector(
+    (state: RootState) => state.story.currentVersionId
+  );
+
   if (!versions.length) {
     return (
       <div className="w-72 bg-zinc-900 h-screen border-r border-zinc-800 p-5">
@@ -51,9 +55,8 @@ const VersionHistoryPanel = () => {
 
       <div className="space-y-3">
         {reversedVersions.map((version, index) => {
-          const isCurrent =
-            currentStory?.chapters.length ===
-            version.chapterCount;
+          // Compare by ID — chapter count is not unique across versions
+          const isCurrent = currentVersionId === version.id;
 
           return (
             <div


### PR DESCRIPTION
### Description
Replaces the chapter-count comparison in `isCurrent` with an ID-based
comparison against `state.story.currentVersionId`. Chapter count is
non-unique — multiple versions can share the same count, causing all
of them to be incorrectly highlighted as the current version.

### Related Issues
Closes #5527 