### PR TITLE
fix: hide Restore Version button on current version card in VersionHistoryPanel

### DIFF
--- a/frontend/src/components/story/VersionHistoryPanel.tsx
+++ b/frontend/src/components/story/VersionHistoryPanel.tsx
@@ -90,16 +90,19 @@ const VersionHistoryPanel = () => {
               )}
 
               <div className="flex flex-col gap-2 mt-3">
-                <button
-                  onClick={() =>
-                    dispatch(
-                      restoreVersion(version.id)
-                    )
-                  }
-                  className="w-full bg-blue-600 hover:bg-blue-700 text-white text-sm py-2 rounded-lg transition"
-                >
-                  Restore Version
-                </button>
+                {/* Hide restore on the current version — would discard unsaved edits */}
+                {!isCurrent && (
+                  <button
+                    onClick={() =>
+                      dispatch(
+                        restoreVersion(version.id)
+                      )
+                    }
+                    className="w-full bg-blue-600 hover:bg-blue-700 text-white text-sm py-2 rounded-lg transition"
+                  >
+                    Restore Version
+                  </button>
+                )}
 
                 <button
                   onClick={() =>


### PR DESCRIPTION
### Description
Wraps the "Restore Version" button in `{!isCurrent && (...)}` so it
only renders on non-current versions. This eliminates the contradictory
UI (badge + restore button coexisting) and prevents `restoreVersion`
from being dispatched on the already-loaded version, which would
silently discard any unsaved edits made since the snapshot.

### Related Issues
Closes #5529