### PR TITLE
fix: replace h-screen with h-full in VersionHistoryPanel to prevent layout overflow and double scrollbars

### DIFF
--- a/frontend/src/components/story/VersionHistoryPanel.tsx
+++ b/frontend/src/components/story/VersionHistoryPanel.tsx
@@ -20,7 +20,7 @@ const VersionHistoryPanel = () => {
 
   if (!versions.length) {
     return (
-      <div className="w-72 bg-zinc-900 h-screen border-r border-zinc-800 p-5">
+      <div className="w-72 bg-zinc-900 h-full border-r border-zinc-800 p-5">
         <h2 className="text-2xl font-bold text-white mb-6">
           Version History
         </h2>
@@ -39,7 +39,7 @@ const VersionHistoryPanel = () => {
   const reversedVersions = [...versions].reverse();
 
   return (
-    <div className="w-72 bg-zinc-900 h-screen border-r border-zinc-800 p-5 overflow-y-auto">
+    <div className="w-72 bg-zinc-900 h-full border-r border-zinc-800 p-5 overflow-y-auto">
       <h2 className="text-2xl font-bold text-white mb-2">
         Version History
       </h2>


### PR DESCRIPTION
### Description
Replaces `h-screen` with `h-full` on both the empty-state and main
render path root divs. `h-screen` (100vh) causes the sidebar to
extend past its parent layout container when a navbar is present,
creating overflow and a second scrollbar. `h-full` correctly inherits
the parent's height and stays within the layout.

### Related Issues
Closes #5533