### PR TITLE
fix: disable Continue Story button when no story exists — eliminates silent no-op UX failure

### DIFF
--- a/frontend/src/components/story/ContinueStoryButton.tsx
+++ b/frontend/src/components/story/ContinueStoryButton.tsx
@@ -73,8 +73,13 @@ const ContinueStoryButton = () => {
       </label>
       <button
         onClick={handleContinue}
-        disabled={loading}
-        className="w-full sm:w-auto bg-purple-600 hover:bg-purple-700 transition-all px-6 py-3 rounded-xl text-white font-semibold"
+        disabled={loading || !currentStory}
+        title={!currentStory ? "Generate a story first before continuing" : undefined}
+        className={`w-full sm:w-auto transition-all px-6 py-3 rounded-xl text-white font-semibold
+          ${loading || !currentStory
+            ? "bg-purple-600/40 cursor-not-allowed opacity-50"
+            : "bg-purple-600 hover:bg-purple-700 cursor-pointer"
+          }`}
       >
         {loading ? "Generating Chapter..." : buttonText}
       </button>


### PR DESCRIPTION
### Description
Adds `!currentStory` to the `disabled` condition on the continue button.
When disabled due to missing story, applies `opacity-50` and
`cursor-not-allowed` styling and a `title` tooltip explaining why.
This gives users an immediate, clear signal that they need to generate
a story first — eliminating the silent no-op click behaviour.

### Related Issues
Closes #5535 