### PR TITLE
fix: add empty chapters guard in ContinueStoryButton — prevents continueStory([]) from generating disconnected AI content

### DIFF
--- a/frontend/src/components/story/ContinueStoryButton.tsx
+++ b/frontend/src/components/story/ContinueStoryButton.tsx
@@ -31,6 +31,11 @@ const ContinueStoryButton = () => {
   const handleContinue = async () => {
     if (!currentStory) return;
 
+    if (!currentStory.chapters || currentStory.chapters.length === 0) {
+      toast.error("No chapters found. Generate the first chapter before continuing.");
+      return;
+    }
+
     try {
       setLoading(true);
 


### PR DESCRIPTION
### Description
Adds an explicit check for `currentStory.chapters.length === 0` before
calling `continueStory`. If the story has no chapters, a toast error
is shown ("Generate the first chapter before continuing") and the
function returns early. This prevents the AI from receiving zero
narrative context and silently appending a random unrelated chapter
to the story.

### Related Issues
Closes #5537 