### PR TITLE
fix: remove blanket eslint-disable from ContinueStoryButton, fix error: any to typed error: unknown

### DIFF
--- a/frontend/src/components/story/ContinueStoryButton.tsx
+++ b/frontend/src/components/story/ContinueStoryButton.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import toast from "react-hot-toast";
@@ -38,9 +37,12 @@ const ContinueStoryButton = () => {
 
       dispatch(addChapter(nextChapter));
       toast.success("New chapter generated successfully!");
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error(error);
-      const errorMsg = error?.message || "Failed to continue story. Please try again.";
+      const errorMsg =
+        error instanceof Error
+          ? error.message
+          : "Failed to continue story. Please try again.";
       toast.error(errorMsg);
     } finally {
       setLoading(false);


### PR DESCRIPTION
### Description
Removes `/* eslint-disable */` from the top of the file. Fixes the
`catch (error: any)` that likely caused the suppression by changing it
to `catch (error: unknown)` with an `instanceof Error` type guard.
This restores full ESLint/TypeScript coverage to the file and correctly
narrows the error type before accessing `.message`.

### Related Issues
Closes #5540 