### PR TITLE
fix: add warning log to empty catch in chat middleware

### DIFF
--- a/backend/src/app/modules/chat/chat.middleware.ts
+++ b/backend/src/app/modules/chat/chat.middleware.ts
@@ -37,7 +37,7 @@ export const flexibleChatRateLimiter = async (
         return next();
       }
     } catch {
-      // Invalid token -> guest limiter
+      console.warn('[ChatMiddleware] Token verification failed, applying guest rate limit');
     }
   }
 


### PR DESCRIPTION
Adds a warning log to the empty catch block in chat middleware when token verification fails, so the fallback to guest rate limiting is observable during debugging.