### PR TITLE
fix: add error log to empty catch in engagement controller

### DIFF
--- a/backend/src/app/modules/engagement/engagement.controller.ts
+++ b/backend/src/app/modules/engagement/engagement.controller.ts
@@ -7,8 +7,8 @@ export const EngagementController = {
       const { chapterText, title } = req.body;
       const data = await analyzeEngagement(chapterText, title);
       return res.status(200).json({ success: true, data });
-    } catch {
-      return res.status(500).json({
+  } catch (error) {
+    console.error('[EngagementController] Failed:', error);
         success: false,
         message: "Engagement analysis failed. Please try again.",
       });


### PR DESCRIPTION
Adds error logging to the empty catch block in engagement controller.