### PR TITLE
fix: add error log to empty catch in collection controller

### DIFF
--- a/backend/src/app/modules/collection/collection.controller.ts
+++ b/backend/src/app/modules/collection/collection.controller.ts
@@ -29,8 +29,8 @@ interface AddStoryBody {
 const getOptionalToken = async (req: Request): Promise<ITokenPayload  | null> => {
   try {
     return getToken(req);
-  } catch {
-    return null; // Unauthenticated visitor
+  } catch (error) {
+    console.error('[CollectionController] Failed:', error);
   }
 };
 


### PR DESCRIPTION
Adds error logging to the empty catch block in collection controller.