### PR TITLE
fix: add error log to empty catch in frontend middleware

### DIFF
--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -38,8 +38,8 @@ export default async function middleware(request: Request): Promise<Response | u
         signal: AbortSignal.timeout(4_000),
       });
       if (res.ok) story = await res.json();
-    } catch {
-      // backend unreachable — serve generic fallback
+    } catch (error) {
+      console.error('[Middleware] Auth verification failed:', error);
     }
   }
 


### PR DESCRIPTION
Adds error logging to the empty catch block in frontend middleware.ts.