### PR TITLE
fix: remove blanket eslint-disable and fix any type safety violation in ContinueStoryButton

### DIFF
--- a/frontend/src/components/story/ContinueStoryButton.tsx
+++ b/frontend/src/components/story/ContinueStoryButton.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import toast from "react-hot-toast";
@@ -38,9 +37,12 @@ const ContinueStoryButton = () => {
 
       dispatch(addChapter(nextChapter));
       toast.success("New chapter generated successfully!");
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error(error);
-      const errorMsg = error?.message || "Failed to continue story. Please try again.";
+      const errorMsg =
+        error instanceof Error
+          ? error.message
+          : "Failed to continue story. Please try again.";
       toast.error(errorMsg);
     } finally {
       setLoading(false);


### PR DESCRIPTION
## What this PR does
Removes the blanket `/* eslint-disable */` at the top of `ContinueStoryButton.tsx`, which was suppressing every ESLint rule for the entire file. This was masking a real `@typescript-eslint/no-explicit-any` violation in the error handler.

Fixed by:
- Removing the file-level `/* eslint-disable */` comment.
- Replacing `catch (error: any)` with `catch (error: unknown)`.
- Adding an `error instanceof Error` type guard before accessing `error.message`, falling back to a generic message otherwise.

Re-ran ESLint on the file after the fix — no other violations were hiding behind the blanket disable.

## Type of change
Check all that apply (if more than one, explain in “What this PR does”).
- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue
Fixes #5540

## More screenshots (optional)
N/A

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.