### PR TITLE
fix : added missing closing brace to truncateText utility

### DIFF
--- a/frontend/src/utils/truncateText.ts
+++ b/frontend/src/utils/truncateText.ts
@@ -33,3 +33,4 @@ export const truncateText = (
   }
 
   return truncated + suffix;
+}


### PR DESCRIPTION
Closes #5560.

Summary of What Has Been Done:
Fixed a TypeScript syntax error in frontend/src/utils/truncateText.ts by adding the missing closing brace that was terminating the arrow function.

Changes Made:
- frontend/src/utils/truncateText.ts: Added missing closing brace (}) after the return statement to properly close the export arrow function.

Impact it Made:
- Fixes TypeScript compilation error that would cause CI typecheck jobs to fail
- The truncateText utility can now be properly imported and used across the codebase

Note: Please assign this PR to the `tmdeveloper007` account.