### PR TITLE
fix: add ref counter to socket lifecycle, remove connect/disconnect from useNotifications

### DIFF
--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -5,7 +5,7 @@ import {
   useMarkNotificationReadMutation,
   useMarkAllNotificationsReadMutation,
 } from "../redux/apis/notification.api";
-import { connectSocket, disconnectSocket } from "../socket/socket.oi";
+import { getSocketIo } from "../socket/socket.oi";
 import type { NotificationItem, INotification } from "../models/notification";
 
 /**
@@ -71,13 +71,10 @@ export const useNotifications = () => {
 
   // Set up Socket.IO listeners
   useEffect(() => {
-    if (!isAuthed) {
-      disconnectSocket();
-      return;
-    }
+    if (!isAuthed) return;
 
     try {
-      const socket = connectSocket();
+      const socket = getSocketIo();
       if (!socket) {
         return;
       }

--- a/frontend/src/socket/socket.oi.ts
+++ b/frontend/src/socket/socket.oi.ts
@@ -5,6 +5,7 @@ import { resolveSocketUrl } from "../helpers/socket-url";
 
 let socketIoInstance: Socket | null = null;
 let tokenCheckInterval: any = null;
+let refCount = 0;
 
 const startTokenCheck = (socket: Socket) => {
   if (tokenCheckInterval) clearInterval(tokenCheckInterval);
@@ -32,6 +33,8 @@ export const getSocketIo = (): Socket | null => {
 };
 
 export const connectSocket = (): Socket | null => {
+  refCount++;
+
   const token = getToken();
   if (!token) {
     console.warn("[Story Spark] User not authenticated. Cannot connect to Socket.IO.");
@@ -87,6 +90,9 @@ export const connectSocket = (): Socket | null => {
 };
 
 export const disconnectSocket = (): void => {
+  refCount = Math.max(0, refCount - 1);
+  if (refCount > 0) return;
+
   stopTokenCheck();
   if (socketIoInstance) {
     socketIoInstance.disconnect();


### PR DESCRIPTION
## Fix: Add reference counting to socket singleton

Two components managed the same singleton socket, competing to connect/disconnect and causing missed notifications.

### Changes
- Added `refCount` variable to `socket.oi.ts` — only last consumer's disconnect actually closes the socket
- Removed `connectSocket()`/`disconnectSocket()` from `useNotifications.ts`
- `SocketProvider` is the sole owner of connection lifecycle

Closes #5555