### PR TITLE
fix: add optimistic concurrency with storyVersion for TOCTOU race 

### DIFF
--- a/backend/src/app/modules/collab/collab.interface.ts
+++ b/backend/src/app/modules/collab/collab.interface.ts
@@ -18,6 +18,7 @@ export interface ICollabRoom {
   collabState?: Buffer;
   isAiGenerating: boolean;
   isPublic: boolean;
+  storyVersion: number;
 }
 
 export interface IParticipant {

--- a/backend/src/app/modules/collab/collab.model.ts
+++ b/backend/src/app/modules/collab/collab.model.ts
@@ -37,6 +37,7 @@ const CollabRoomSchema = new Schema<ICollabRoom>(
     collabState: { type: Buffer },
     isAiGenerating: { type: Boolean, required: true, default: false },
     isPublic: { type: Boolean, required: true, default: true },
+    storyVersion: { type: Number, required: true, default: 0 },
   },
   {
     timestamps: true,

--- a/backend/src/socket/collab.socket.ts
+++ b/backend/src/socket/collab.socket.ts
@@ -193,6 +193,7 @@ export const setupCollabSocket = (io: Server) => {
         };
 
         room.story.push(chunk);
+        room.storyVersion += 1;
         await room.save();
 
         collabNamespace
@@ -260,33 +261,44 @@ export const setupCollabSocket = (io: Server) => {
           return;
         }
 
-        const room = await CollabRoom.findOne({ roomId });
-        if (!room) return;
-
         const userId = socket.data.userId;
         if (!userId) {
           socket.emit("collab:error", { message: "Unauthorized" });
           return;
         }
 
-        const participant = room.participants.find((p) => p.userId === userId);
-        if (!participant) {
-          socket.emit("collab:error", {
-            message: "You are not a participant of this room",
-          });
-          return;
-        }
-
-        // Check if AI is already generating
-        if (room.isAiGenerating) {
+        // Atomic optimistic lock: only proceed if isAiGenerating is false
+        const locked = await CollabRoom.findOneAndUpdate(
+          { roomId, isAiGenerating: false },
+          { isAiGenerating: true },
+          { new: false }
+        );
+        if (!locked) {
           socket.emit("collab:error", {
             message: "AI is already generating. Please wait for it to finish.",
           });
           return;
         }
 
+        // Verify user is a participant
+        const participant = locked.participants.find((p) => p.userId === userId);
+        if (!participant) {
+          await CollabRoom.findOneAndUpdate(
+            { roomId },
+            { isAiGenerating: false }
+          );
+          socket.emit("collab:error", {
+            message: "You are not a participant of this room",
+          });
+          return;
+        }
+
         const user = await User.findById(userId);
         if (!user) {
+          await CollabRoom.findOneAndUpdate(
+            { roomId },
+            { isAiGenerating: false }
+          );
           socket.emit("collab:error", { message: "User not found!" });
           return;
         }
@@ -301,22 +313,23 @@ export const setupCollabSocket = (io: Server) => {
               ? error.message
               : "Monthly request limit exceeded!";
           socket.emit("collab:error", { message: errorMsg });
+          await CollabRoom.findOneAndUpdate(
+            { roomId },
+            { isAiGenerating: false }
+          );
           activeAiGenerations.delete(roomId);
           return;
         }
 
         const guard = createUserQuotaGuard(user.email);
+        const initialStoryLength = locked.story.length;
+        const currentVersion = locked.storyVersion;
 
         try {
           await runWithQuotaCleanup(guard, async () => {
-            // Set AI generating flag to true and remember current story length
-            room.isAiGenerating = true;
-            const initialStoryLength = room.story.length;
-            await room.save();
-
             collabNamespace.to(roomId).emit("collab:ai_thinking", { roomId });
 
-            const storyContext = room.story
+            const storyContext = locked.story
               .map((chunk) => chunk.text)
               .filter(Boolean)
               .join("\n");
@@ -345,18 +358,43 @@ export const setupCollabSocket = (io: Server) => {
               timestamp: new Date(),
             };
 
-            const latestRoom = await CollabRoom.findOne({ roomId });
-            if (latestRoom) {
-              // Insert the AI chunk right after the last chunk that existed when we started the AI call
-              // This ensures the AI's continuation is in the correct context position even if users added text in between
-              latestRoom.story.splice(initialStoryLength, 0, aiChunk);
-              latestRoom.isAiGenerating = false;
-              await latestRoom.save();
+            // Optimistic concurrency: only update if storyVersion hasn't changed
+            const updated = await CollabRoom.findOneAndUpdate(
+              {
+                roomId,
+                storyVersion: currentVersion,
+                isAiGenerating: true,
+              },
+              {
+                $push: { story: { $each: [aiChunk], $position: initialStoryLength } },
+                $inc: { storyVersion: 1 },
+                isAiGenerating: false,
+              },
+              { new: true }
+            );
 
+            if (updated) {
               collabNamespace.to(roomId).emit("collab:story_updated", {
-                story: latestRoom.story,
+                story: updated.story,
                 newChunk: aiChunk,
               });
+            } else {
+              // Version conflict — someone else modified the story; try a safe append
+              const fallback = await CollabRoom.findOneAndUpdate(
+                { roomId, isAiGenerating: true },
+                {
+                  $push: { story: aiChunk },
+                  $inc: { storyVersion: 1 },
+                  isAiGenerating: false,
+                },
+                { new: true }
+              );
+              if (fallback) {
+                collabNamespace.to(roomId).emit("collab:story_updated", {
+                  story: fallback.story,
+                  newChunk: aiChunk,
+                });
+              }
             }
           });
         } catch (error) {
@@ -365,15 +403,11 @@ export const setupCollabSocket = (io: Server) => {
             message: "AI continuation failed. Please try again.",
           });
         } finally {
-          // Make sure we unset the flag even if there's an error
-          const roomToUpdate = await CollabRoom.findOne({ roomId });
-          if (roomToUpdate && roomToUpdate.isAiGenerating) {
-            roomToUpdate.isAiGenerating = false;
-            await roomToUpdate.save();
-          }
-
+          await CollabRoom.findOneAndUpdate(
+            { roomId, isAiGenerating: true },
+            { isAiGenerating: false }
+          );
           activeAiGenerations.delete(roomId);
-
           collabNamespace.to(roomId).emit("collab:user_stop_typing", {
             userId: "ai",
           });


### PR DESCRIPTION
## Fix: Add optimistic concurrency to collab story timeline

AI continuation text was inserted at a stale position before concurrent user edits, corrupting the collaborative story timeline.

### Changes
- Added `storyVersion: number` field to `ICollabRoom` and schema
- Replaced non-atomic `findOne` + `isAiGenerating` check with `findOneAndUpdate` (atomic lock)
- Added optimistic concurrency guard using `storyVersion` on final write
- Incremented `storyVersion` in both `add_text` and `ai_continue` handlers

Closes #5557