### PR TITLE
fix: revoke object URL after download in downloadBlob helper — fixes systemic blob memory leak across all file exports

### DIFF
--- a/frontend/src/components/stories/stories.helpers.ts
+++ b/frontend/src/components/stories/stories.helpers.ts
@@ -86,4 +86,5 @@ export const downloadBlob = (blob: Blob, fileName: string) => {
   document.body.appendChild(link);
   link.click();
   link.remove();
+  URL.revokeObjectURL(url); // Release blob reference immediately after download triggers
 };


### PR DESCRIPTION
### Description
Adds `URL.revokeObjectURL(url)` after `link.click()` in the shared
`downloadBlob` helper. Since this function is the single download
utility for all export formats in the app, this one-line fix eliminates
the entire class of blob memory leak for every download operation.

### Related Issues
Closes #5578 