### PR TITLE
fix: implement genre-specific themes in getGenreTheme — was returning same purple for all genres

### DIFF
--- a/frontend/src/components/stories/stories.helpers.ts
+++ b/frontend/src/components/stories/stories.helpers.ts
@@ -24,6 +24,31 @@ export function getErrorMessage(error: unknown): string {
 }
 
 export const getGenreTheme = (tag: string) => {
+  const genre = (tag || "").toLowerCase();
+
+  if (genre.includes("horror") || genre.includes("thriller")) {
+    return { gradient: "135deg, #1a0a0a, #3b0f0f", accent: "#ef4444", icon: "💀" };
+  }
+  if (genre.includes("romance") || genre.includes("romantic")) {
+    return { gradient: "135deg, #2d0a1e, #4a0d2e", accent: "#f472b6", icon: "💕" };
+  }
+  if (genre.includes("sci-fi") || genre.includes("science fiction") || genre.includes("scifi")) {
+    return { gradient: "135deg, #03082e, #0a1628", accent: "#38bdf8", icon: "🚀" };
+  }
+  if (genre.includes("fantasy") || genre.includes("magic")) {
+    return { gradient: "135deg, #0f0a2e, #1e0a3b", accent: "#a78bfa", icon: "🧙" };
+  }
+  if (genre.includes("mystery") || genre.includes("detective")) {
+    return { gradient: "135deg, #0a0a0a, #1a1a2e", accent: "#94a3b8", icon: "🔍" };
+  }
+  if (genre.includes("adventure") || genre.includes("action")) {
+    return { gradient: "135deg, #0a1a0a, #0f2d10", accent: "#4ade80", icon: "⚔️" };
+  }
+  if (genre.includes("comedy") || genre.includes("humor") || genre.includes("funny")) {
+    return { gradient: "135deg, #1a1400, #2d2200", accent: "#fbbf24", icon: "😄" };
+  }
+
+  // Default — generic purple for uncategorised genres
   return { gradient: "45deg, #1e1b4b, #311042", accent: "#a855f7", icon: "✨" };
 };
 


### PR DESCRIPTION
### Description
Implements genre-specific `gradient`, `accent`, and `icon` values for
Horror/Thriller, Romance, Sci-Fi, Fantasy, Mystery, Adventure, and Comedy.
Falls back to the original purple theme for unrecognised genres. Uses
case-insensitive substring matching to handle tag variations
(e.g. "sci-fi", "science fiction", "scifi").

### Related Issues
Closes #5580 