### PR TITLE
fix: surface ApiError.message for unhandled 4xx status codes in getErrorMessage

### DIFF
--- a/frontend/src/components/stories/stories.helpers.ts
+++ b/frontend/src/components/stories/stories.helpers.ts
@@ -16,6 +16,11 @@ export function getErrorMessage(error: unknown): string {
     if (error.status >= 500) {
       return "A server error occurred. Please try again later.";
     }
+    // For all other ApiError status codes (4xx), surface the server's message
+    // so users get actionable context (e.g. "Token expired", "Plan limit reached")
+    if (error.message) {
+      return error.message;
+    }
   }
   if (error instanceof TypeError) {
     return "Could not reach the server. Please check your connection and try again.";


### PR DESCRIPTION
### Description
Adds a final `if (error.message) return error.message` inside the
`instanceof ApiError` block, after all specific status code checks.
This ensures 401, 403, 404, 422, and any other unhandled codes return
the server's specific message instead of the generic fallback.
The generic "An unexpected error occurred" is now truly a last resort —
only for errors with no message at all.

### Related Issues
Closes #5582 