### PR TITLE
fix: use trimmedSentence for segment text in buildSentenceSegments — fixes highlight bleed and string comparison in AudioPlayer

### DIFF
--- a/frontend/src/components/stories/stories.helpers.ts
+++ b/frontend/src/components/stories/stories.helpers.ts
@@ -58,7 +58,7 @@ export const buildSentenceSegments = (content: string): StorySentenceSegment[] =
 
     segments.push({
       id: `${index}-${startWordIndex}-${endWordIndex}`,
-      text: sentence,
+      text: trimmedSentence, // Use trimmed text — sentence includes trailing \s* from regex
       startWordIndex,
       endWordIndex,
     });


### PR DESCRIPTION
### Description
Changes `text: sentence` to `text: trimmedSentence` in the
`segments.push()` call inside `buildSentenceSegments`. The raw
`sentence` from the regex match includes trailing whitespace from
`\s*` — the trimmed version is already computed for the empty guard
and is the correct value to store as the segment's display text.

### Related Issues
Closes #5584 