### PR TITLE
fix: add empty/whitespace guard to getInitials — prevents blank avatar badge on untitled stories

### DIFF
--- a/frontend/src/components/stories/stories.helpers.ts
+++ b/frontend/src/components/stories/stories.helpers.ts
@@ -27,7 +27,10 @@ export const getGenreTheme = (tag: string) => {
   return { gradient: "45deg, #1e1b4b, #311042", accent: "#a855f7", icon: "✨" };
 };
 
-export const getInitials = (title: string) => title.slice(0, 2).toUpperCase();
+export const getInitials = (title: string): string => {
+  const trimmed = (title || "").trim();
+  return trimmed.slice(0, 2).toUpperCase() || "?";
+};
 
 export type StorySentenceSegment = {
   id: string;


### PR DESCRIPTION
### Description
Trims `title` before slicing and adds `|| "?"` as a final fallback
so the avatar always renders at least one visible character. Handles
null/undefined defensively with `(title || "")`. This matches the
standard avatar fallback pattern used by GitHub, Linear, and Notion.

### Related Issues
Closes #5586