### PR TITLE
fix: add error logging to empty catch in ErrorPage

### DIFF
--- a/frontend/src/components/ErrorPage.tsx
+++ b/frontend/src/components/ErrorPage.tsx
@@ -29,7 +29,8 @@ const ErrorPage = () => {
       setTimeout(() => {
         window.location.reload();
       }, 300);
-    } catch {
+    } catch (error) {
+      console.error("Failed to reset cache", error);
       window.location.reload();
     }
   };


### PR DESCRIPTION
Adds error logging when cache reset fails in ErrorPage.