### PR TITLE
fix(story): Resolve Cyclic Reference Rendering Crash in Story Graph Serializer (#5467)

### DIFF
--- a/backend/src/app/modules/story/__tests__/serializer.test.ts
+++ b/backend/src/app/modules/story/__tests__/serializer.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { serializeStoryGraph, IStoryNode } from "../story.serializer";
+
+describe("Story Graph Serializer Cyclic Reference Tests (#5467)", () => {
+  it("serializes linear non-cyclic story graph correctly", () => {
+    const rootNode: IStoryNode = {
+      id: "chap_1",
+      title: "Chapter 1: The Beginning",
+      content: "Once upon a time...",
+      children: [
+        {
+          id: "chap_2",
+          title: "Chapter 2: The Journey",
+          content: "Traveling through the forest...",
+          children: [],
+        },
+      ],
+    };
+
+    const result = serializeStoryGraph(rootNode);
+
+    expect(result.id).toBe("chap_1");
+    expect(result.children).toHaveLength(1);
+    expect(result.children[0].id).toBe("chap_2");
+    expect(result.children[0].isLoop).toBeUndefined();
+  });
+
+  it("handles cyclic narrative loops (Chapter 4 -> Chapter 2) without RangeError stack overflow", () => {
+    const chap2: IStoryNode = {
+      id: "chap_2",
+      title: "Chapter 2: The Crossroads",
+      content: "You find two paths...",
+      children: [],
+    };
+
+    const chap3: IStoryNode = {
+      id: "chap_3",
+      title: "Chapter 3: The Portal",
+      content: "Entering the glowing portal...",
+      children: [],
+    };
+
+    const chap4: IStoryNode = {
+      id: "chap_4",
+      title: "Chapter 4: Time Loop",
+      content: "The portal sends you back to the crossroads!",
+      children: [chap2], // CYCLIC EDGE: Chap 4 loops back to Chap 2
+    };
+
+    chap2.children = [chap3];
+    chap3.children = [chap4];
+
+    const chap1: IStoryNode = {
+      id: "chap_1",
+      title: "Chapter 1: Start",
+      content: "Beginning...",
+      children: [chap2],
+    };
+
+    expect(() => {
+      const result = serializeStoryGraph(chap1);
+      
+      // Verify depth 1: Chap 1 -> Chap 2
+      expect(result.children[0].id).toBe("chap_2");
+      // Verify depth 2: Chap 2 -> Chap 3
+      expect(result.children[0].children[0].id).toBe("chap_3");
+      // Verify depth 3: Chap 3 -> Chap 4
+      expect(result.children[0].children[0].children[0].id).toBe("chap_4");
+      // Verify depth 4: Chap 4 -> Chap 2 (LOOP EDGE DETECTED)
+      const loopEdge = result.children[0].children[0].children[0].children[0];
+      expect(loopEdge.id).toBe("chap_2");
+      expect(loopEdge.isLoop).toBe(true);
+      expect(loopEdge.targetNodeId).toBe("chap_2");
+      expect(loopEdge.children).toHaveLength(0);
+    }).not.toThrow();
+  });
+
+  it("throws an error for null or invalid story node", () => {
+    expect(() => serializeStoryGraph(null as any)).toThrow(/Invalid story node/);
+  });
+});

--- a/backend/src/app/modules/story/__tests__/serializer.test.ts
+++ b/backend/src/app/modules/story/__tests__/serializer.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect } from "@jest/globals";
 import { serializeStoryGraph, IStoryNode } from "../story.serializer";
 
 describe("Story Graph Serializer Cyclic Reference Tests (#5467)", () => {

--- a/backend/src/app/modules/story/story.serializer.ts
+++ b/backend/src/app/modules/story/story.serializer.ts
@@ -1,0 +1,67 @@
+export interface IStoryNode {
+  id: string;
+  title: string;
+  content: string;
+  choices?: { text: string; nextNodeId: string }[];
+  children?: IStoryNode[];
+}
+
+export interface SerializedStoryNode {
+  id: string;
+  title: string;
+  content: string;
+  isLoop?: boolean;
+  targetNodeId?: string;
+  choices?: { text: string; nextNodeId: string }[];
+  children: SerializedStoryNode[];
+}
+
+/**
+ * Story Graph Serializer
+ * Recursively serializes interactive branching story nodes into graph JSON objects.
+ * Prevents stack overflow RangeError crashes when cyclic narrative loops exist (e.g. Chapter 4 -> Chapter 2)
+ * by tracking visited node IDs using Set<string>.
+ */
+export function serializeStoryGraph(
+  node: IStoryNode,
+  visited: Set<string> = new Set()
+): SerializedStoryNode {
+  if (!node || !node.id) {
+    throw new Error('Invalid story node specified');
+  }
+
+  // 1. Detect cyclic reference edges to prevent RangeError stack overflow crashes
+  if (visited.has(node.id)) {
+    return {
+      id: node.id,
+      title: node.title || 'Loop Edge',
+      content: node.content || '',
+      isLoop: true,
+      targetNodeId: node.id,
+      choices: [],
+      children: [],
+    };
+  }
+
+  // 2. Track visited node ID in set
+  const nextVisited = new Set(visited);
+  nextVisited.add(node.id);
+
+  // 3. Serialize children nodes safely
+  const children: SerializedStoryNode[] = [];
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      children.push(serializeStoryGraph(child, nextVisited));
+    }
+  }
+
+  return {
+    id: node.id,
+    title: node.title || '',
+    content: node.content || '',
+    choices: node.choices || [],
+    children,
+  };
+}
+
+export default serializeStoryGraph;

--- a/backend/src/app/modules/story_branching/story.serializer.ts
+++ b/backend/src/app/modules/story_branching/story.serializer.ts
@@ -1,0 +1,2 @@
+export { serializeStoryGraph, default } from '../story/story.serializer';
+export type { IStoryNode, SerializedStoryNode } from '../story/story.serializer';


### PR DESCRIPTION
## Screenshot (when helpful)
N/A - Backend graph serializer logic and unit test suite.

## What this PR does
Fixes backend `RangeError: Maximum call stack size exceeded` crashes during story graph JSON serialization when looping narrative choices exist (e.g. Chapter 4 branching back to Chapter 2). Introduces a `Set<string>` visited node tracking mechanism in `story.serializer.ts` to detect cycle edges and serialize loop references safely (`{ targetNodeId, isLoop: true }`).

## Type of change
- [x] Bug fix
- [ ] New feature

## Related issue
Closes #5467

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.