### PR TITLE
fix: use /\s+/ regex split in getShortenedText to match getWordCount tokenization

### DIFF
--- a/frontend/src/components/stories/stories.utils.ts
+++ b/frontend/src/components/stories/stories.utils.ts
@@ -5,7 +5,8 @@ export const getShortenedText = (
   wordLimit: number = 35
 ): string => {
   if (!content) return "";
-  const words: string[] = content.split(" ");
+  // Use /\s+/ to match getWordCount behaviour — handles tabs, newlines, multiple spaces
+  const words: string[] = content.trim().split(/\s+/);
   return words.length > wordLimit
     ? words.slice(0, wordLimit).join(" ") + "..."
     : content;


### PR DESCRIPTION
### Description
Replaces `content.split(" ")` with `content.trim().split(/\s+/)` in
`getShortenedText`. This aligns with `getWordCount`'s tokenization
strategy, correctly handles tabs/newlines as word boundaries, and
eliminates empty-string tokens produced by consecutive spaces.

### Related Issues
Closes #5614 