### PR TITLE
fix: return "Neutral" as dominantEmotion in analyzeStoryEmotion when total keyword score is zero

### DIFF
--- a/frontend/src/components/stories/stories.utils.ts
+++ b/frontend/src/components/stories/stories.utils.ts
@@ -238,10 +238,11 @@ export const analyzeStoryEmotion = (content: string) => {
     ])
   );
 
+  // Only determine a dominant emotion if at least one keyword was matched
   const dominantEmotion =
-    Object.entries(scores).sort(
-      (a, b) => b[1] - a[1]
-    )[0][0];
+    total > 0
+      ? Object.entries(scores).sort((a, b) => b[1] - a[1])[0][0]
+      : "Neutral";
 
   return {
     scores: percentages,


### PR DESCRIPTION
### Description
Guards the `dominantEmotion` calculation with `total > 0`. When no
keywords are matched (all scores are 0), returns `"Neutral"` instead
of the arbitrary sort winner `"Happy"`. This correctly distinguishes
between "content with no detected emotion" and "genuinely happy content"
and prevents false emotion labels in the UI.

### Related Issues
Closes #5616 