### PR TITLE
fix: validate enhancedPrompt field before calling onPromptChange — prevents undefined from silently clearing textarea

### DIFF
--- a/frontend/src/components/stories/PromptEnhancer.tsx
+++ b/frontend/src/components/stories/PromptEnhancer.tsx
@@ -32,7 +32,13 @@ const PromptEnhancer = ({ prompt, onPromptChange }: PromptEnhancerProps) => {
 
     try {
       const result = await enhancePrompt({ prompt: prompt.trim(), provider: selectedModel }).unwrap();
-      onPromptChange(result.data.enhancedPrompt);
+
+      const enhancedPrompt = result?.data?.enhancedPrompt;
+      if (!enhancedPrompt || typeof enhancedPrompt !== "string") {
+        throw new Error("Invalid response: missing enhancedPrompt field");
+      }
+
+      onPromptChange(enhancedPrompt);
       setIsEnhanced(true);
       toast.success("Prompt enhanced!");
     } catch (error) {


### PR DESCRIPTION
### Description
Uses optional chaining `result?.data?.enhancedPrompt` and validates
the result is a non-empty string before passing it to `onPromptChange`.
If the field is missing or not a string, throws a descriptive error
that propagates to the existing catch block, showing the "Enhancement
failed" toast and correctly resetting state — instead of silently
clearing the parent textarea.

### Related Issues
Closes #5623 