### PR TITLE
fix: disable model selector after enhancement

### DIFF
--- a/frontend/src/components/stories/PromptEnhancer.tsx
+++ b/frontend/src/components/stories/PromptEnhancer.tsx
@@ -58,7 +58,7 @@ const PromptEnhancer = ({ prompt, onPromptChange }: PromptEnhancerProps) => {
         aria-label="Select AI writing model"
         value={selectedModel}
         onChange={(e) => setSelectedModel(e.target.value)}
-        disabled={isEnhancing}
+        disabled={isEnhanced || isEnhancing}
         className="rounded-full border border-slate-200 dark:border-white/10 bg-slate-50 dark:bg-white/5 text-slate-800 dark:text-slate-200 px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-cyan-500/50 cursor-pointer transition-all duration-300"
       >
         <option value="gemini" className="bg-white dark:bg-slate-900 text-slate-800 dark:text-slate-200">Google Gemini (Default)</option>
@@ -72,10 +72,9 @@ const PromptEnhancer = ({ prompt, onPromptChange }: PromptEnhancerProps) => {
         onClick={handleEnhance}
         disabled={isEnhancing || !prompt.trim()}
         className={`flex items-center gap-2 rounded-full border px-4 py-2 text-sm transition-all duration-300
-          ${
-            isEnhancing || !prompt.trim()
-              ? "cursor-not-allowed border-white/10 bg-white/5 text-slate-500"
-              : "border-cyan-300/40 bg-cyan-300/10 text-cyan-100 hover:bg-cyan-300/20"
+          ${isEnhancing || !prompt.trim()
+            ? "cursor-not-allowed border-white/10 bg-white/5 text-slate-500"
+            : "border-cyan-300/40 bg-cyan-300/10 text-cyan-100 hover:bg-cyan-300/20"
           }`}
       >
         <AnimatePresence mode="wait">


### PR DESCRIPTION
## Summary
This PR fixes the issue where the model selector remained active after a prompt was successfully enhanced.

## Changes Made
- Disabled the model selector when `isEnhanced` is `true`.
- Kept the selector disabled while enhancement is in progress (`isEnhancing`).
- Ensured the selector becomes enabled again after reverting the enhancement.

## Files Modified
- frontend/src/components/stories/PromptEnhancer.tsx

## Testing
- ✅ Model selector is enabled before enhancement.
- ✅ Model selector is disabled after enhancement.
- ✅ Model selector is enabled again after clicking "Revert to original".

Fixes #5625