### PR TITLE
fix: escape triple-quote delimiter in prompt formatter and fix brittle JSON extraction #5633

### DIFF
--- a/backend/src/utils/promptSecurity.ts
+++ b/backend/src/utils/promptSecurity.ts
@@ -88,7 +88,8 @@ export const validateAndFormatPrompt = (userPrompt: string): string => {
   assertContentSafe(normalizedPrompt);
 
   // Strict delimiters to isolate user input
-  return `"""\n${normalizedPrompt}\n"""`;
+  const escapedPrompt = normalizedPrompt.replace(/"""/g, '\\"\\"\\"');
+  return `"""\n${escapedPrompt}\n"""`;
 };
 
 export const validateOutput = (aiResponse: string): string => {
@@ -142,9 +143,13 @@ export const validateOutput = (aiResponse: string): string => {
  */
 export const sanitizeJsonText = (rawText: string): string => {
   const trimmed = rawText.trim();
-  if (!trimmed.startsWith("```")) return trimmed;
-  return trimmed
-    .replace(/^```(?:json)?\s*/i, "")
-    .replace(/\s*```$/, "")
-    .trim();
+
+  // Extract JSON from markdown code block anywhere in the text
+  const codeBlockMatch = trimmed.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
+  if (codeBlockMatch) {
+    return codeBlockMatch[1].trim();
+  }
+
+  // If no code block, return as-is
+  return trimmed;
 };


### PR DESCRIPTION
## What this PR does
Fixes two security and reliability bugs in `backend/src/utils/promptSecurity.ts`:

**1. Delimiter Bypass Vulnerability (Security Fix)**
`validateAndFormatPrompt` wraps user input in triple-quote `"""` delimiters 
but did not escape occurrences of `"""` within the user input itself. 
An attacker could inject `"""` followed by system-level instructions to 
break out of the user input block.

Fix: Added `.replace(/"""/g, '\\"\\"\\"')` to escape triple-quotes in 
user input before wrapping.

**2. Brittle JSON Extraction Fix**
`sanitizeJsonText` only handled markdown code blocks at the start of the 
string. If the LLM returned conversational filler before the JSON block 
(e.g. "Here is the data:\n```json"), the function failed to extract the JSON.

Fix: Replaced `startsWith` check with a regex that finds markdown code 
blocks anywhere in the text using `trimmed.match(/```(?:json)?\s*([\s\S]*?)\s*```/i)`.

## Type of change
- [x] Bug fix

## Related issue
Closes #5633

## Screenshot
N/A — backend security and utility fix with no UI changes

## Checklist
- [x] I have added screenshots or a recording when they help explain 
  this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.