### PR TITLE
fix: pass full story path to AI when extending a branch in ContinueStoryModal

### DIFF
--- a/frontend/src/components/stories/ContinueStoryModal.tsx
+++ b/frontend/src/components/stories/ContinueStoryModal.tsx
@@ -110,7 +110,9 @@ const ContinueStoryModal = ({ story, onClose, onApply }: ContinueStoryModalProps
 
   const handleExtendBranch = (branch: BranchNode) => {
     setActiveBranchId(branch.id);
-    setPrompt(branch.continuation);
+    // Use the full story path (original + all parent continuations) as context
+    // so the AI has complete narrative context when generating the next branch
+    setPrompt(getFullContent(branch.id));
   };
 
   const handleApply = () => {


### PR DESCRIPTION
### Description
Changes `handleExtendBranch` to call `setPrompt(getFullContent(branch.id))`
instead of `setPrompt(branch.continuation)`. `getFullContent` traverses
the branch parent chain and assembles `story.content + all parent
continuations + this branch continuation` — giving the AI complete
narrative context. The same function was already used correctly in
`handleApply`; this fix applies the same logic to `handleGenerate`.

### Related Issues
Closes #5658 