### PR TITLE
fix: validate continuation field before storing branch node in ContinueStoryModal

### DIFF
--- a/frontend/src/components/stories/ContinueStoryModal.tsx
+++ b/frontend/src/components/stories/ContinueStoryModal.tsx
@@ -91,7 +91,11 @@ const ContinueStoryModal = ({ story, onClose, onApply }: ContinueStoryModalProps
         }).unwrap();
       }
 
-      const continuation = result.data.continuation;
+      const continuation = result?.data?.continuation;
+      if (!continuation || typeof continuation !== "string") {
+        throw new Error("Invalid response: missing continuation field");
+      }
+
       const newBranch: BranchNode = {
         id: `branch-${Date.now()}`,
         parentId: activeBranchId,


### PR DESCRIPTION
### Description
Adds `result?.data?.continuation` optional chaining and a string type
guard before creating the `BranchNode`. If the field is missing or not
a string, throws a descriptive error caught by the existing `catch` block
— which shows "Failed to generate continuation" toast and leaves
`branches` state unmodified. Prevents `undefined` from being stored
in branch nodes and causing downstream `.trim()` TypeErrors.

### Related Issues
Closes #5662 