### PR TITLE
feat: add pitch/volume controls and audio waveform visualizer to narration player

### DIFF
--- a/frontend/src/components/AudioVisualizer.tsx
+++ b/frontend/src/components/AudioVisualizer.tsx
@@ -1,0 +1,86 @@
+import React, { useEffect, useRef } from "react";
+
+interface AudioVisualizerProps {
+  isPlaying: boolean;
+  barCount?: number;
+}
+
+const AudioVisualizer: React.FC<AudioVisualizerProps> = ({
+  isPlaying,
+  barCount = 32,
+}) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const animationRef = useRef<number | null>(null);
+  const barHeightsRef = useRef<number[]>(
+    Array.from({ length: barCount }, () => Math.random() * 0.3 + 0.1)
+  );
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    const width = canvas.clientWidth;
+    const height = canvas.clientHeight;
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+    ctx.scale(dpr, dpr);
+
+    const draw = () => {
+      ctx.clearRect(0, 0, width, height);
+
+      const barWidth = width / barCount;
+      const gap = barWidth * 0.3;
+
+      for (let i = 0; i < barCount; i++) {
+        if (isPlaying) {
+          const target = Math.random() * 0.85 + 0.15;
+          barHeightsRef.current[i] +=
+            (target - barHeightsRef.current[i]) * 0.35;
+        } else {
+          barHeightsRef.current[i] +=
+            (0.08 - barHeightsRef.current[i]) * 0.15;
+        }
+
+        const barHeight = Math.max(2, barHeightsRef.current[i] * height);
+        const x = i * barWidth + gap / 2;
+        const y = (height - barHeight) / 2;
+
+        const gradient = ctx.createLinearGradient(0, y, 0, y + barHeight);
+        gradient.addColorStop(0, "#818cf8");
+        gradient.addColorStop(1, "#c084fc");
+
+        ctx.fillStyle = gradient;
+        ctx.beginPath();
+        const radius = Math.min(3, (barWidth - gap) / 2);
+        const w = barWidth - gap;
+        ctx.roundRect(x, y, w, barHeight, radius);
+        ctx.fill();
+      }
+
+      animationRef.current = requestAnimationFrame(draw);
+    };
+
+    draw();
+
+    return () => {
+      if (animationRef.current) {
+        cancelAnimationFrame(animationRef.current);
+      }
+    };
+  }, [isPlaying, barCount]);
+
+  return (
+    <div
+      role="img"
+      aria-label={isPlaying ? "Audio waveform, narration playing" : "Audio waveform, idle"}
+      className="w-full h-16 rounded-xl bg-slate-100 dark:bg-slate-800/60 overflow-hidden"
+    >
+      <canvas ref={canvasRef} className="w-full h-full" />
+    </div>
+  );
+};
+
+export default AudioVisualizer;


### PR DESCRIPTION
## Related Issue
closes #5647

## Summary
This PR adds part of the audio narration features requested in #5647: pitch/volume controls and a live waveform visualizer during narration. Word-level highlighting was already implemented in `stories.view.component.tsx` prior to this PR and did not need changes.

## Changes

### 1. Bug fix — `useSpeechSynthesis.ts`
- Fixed a missing `useCallback` closing bracket on the `stop` function that would have caused a syntax/runtime error.
- Removed a duplicate dependency array on the `speakText`/`play` callback (two arrays were present where only one is valid).

### 2. Pitch & Volume controls — `AudioPlayer.tsx`
- Added range sliders for pitch (0.5x–2x) and volume (0–1) alongside the existing playback speed selector.
- Wired to the existing `pitch`/`setPitch` and `volume`/`setVolume` values already exposed by `useSpeechSynthesis`.

### 3. Audio waveform visualizer — new `AudioVisualizer.tsx`
- New canvas-based animated waveform component that reacts to the player's `isPlaying` state.
- Since the Web Speech API does not expose a real audio stream, bars are procedurally animated (randomized target heights with smoothing) rather than driven by actual frequency data — this gives visual feedback during narration without needing external audio libraries.
- Rendered inside `AudioPlayer.tsx` above the playback controls.

## Not included in this PR
- ElevenLabs / OpenAI TTS streaming fallback — not implemented (out of scope for this PR, can be tracked as a follow-up).
- Word/sentence highlighting — already existed in `stories.view.component.tsx` before this PR; not touched here.

## Testing
- [ ] `npm run build` / `tsc --noEmit` passes
- [ ] Manually verified play/pause/stop/resume still work after the hook fix
- [ ] Verified pitch and volume sliders affect narration audibly
- [ ] Verified waveform animates while playing and settles when idle