### PR TITLE
fix: cap related stories at 4 in RelatedStoriesComponent — prevents full library dump in related content section

### DIFF
--- a/frontend/src/components/stories/RelatedStories.tsx
+++ b/frontend/src/components/stories/RelatedStories.tsx
@@ -9,7 +9,10 @@ export interface IRelatedStoriesComponentProps {
 
 export const RelatedStoriesComponent: React.FC<IRelatedStoriesComponentProps> = ({ posts, currentPostId }) => {
   const navigate = useNavigate();
-  const filteredPosts = posts.filter((post) => post._id !== currentPostId);
+  const MAX_RELATED = 4;
+  const filteredPosts = posts
+    .filter((post) => post._id !== currentPostId)
+    .slice(0, MAX_RELATED);
 
   return (
     <div className="mt-8">


### PR DESCRIPTION
### Description
Adds `.slice(0, MAX_RELATED)` after the `currentPostId` filter.
`MAX_RELATED = 4` follows standard "related content" UX patterns
(Medium, Substack). Prevents the component from rendering every story
in the database as the library scales.

### Related Issues
Closes #5675