### PR TITLE
fix(backend): resolve unresolved merge conflicts in server.ts and app.ts

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -19,10 +19,6 @@ import globalRateLimiter from "./app/middleware/global.rate-limiter";
 import { sanitizeAllMiddleware } from "./app/middleware/sanitize.middleware";
 import ApiError from "./errors/api_error";
 
-interface ApiError extends Error {
-  statusCode: number;
-  errorMessages: { path: string; message: string }[];
-}
 const app: Application = express();
 // Only trust the proxy in production, where we're actually behind a real
 // reverse proxy. In dev there's no real proxy in front of us, so trusting
@@ -70,18 +66,20 @@ app.use(
   })
 );
 
-
 // Rate limiter — placed after CORS so OPTIONS preflight requests are
 // never counted against the limit before CORS has a chance to respond.
 app.use(globalRateLimiter);
 
-// ─── 1. FIXED: ENFORCED HARDENED PAYLOAD LIMITS TO PREVENT DoS ───
-app.use(express.json({ limit: "2mb" }));
-app.use(express.urlencoded({ extended: true, limit: "2mb" }));
-app.use(cookieParser());
+// Payload limit set to 10mb to support large story content and character
+// network data without triggering 413 errors. Previously 2mb, which was
+// too restrictive for real story payloads — see PR discussion if this
+// needs revisiting against DoS-hardening concerns.
+app.use(express.json({ limit: "10mb" }));
+app.use(express.urlencoded({ extended: true, limit: "10mb" }));
+app.use(cookieParser() as unknown as RequestHandler);
 app.use(sanitizeAllMiddleware);
 
-// Legacy Route Rewrite Rewrite Rules
+// Legacy Route Rewrite Rules
 app.use((req, res, next) => {
   if (
     req.method === "GET" &&
@@ -89,33 +87,19 @@ app.use((req, res, next) => {
   ) {
     req.url = req.url.replace(/^\/api\/story\//, "/api/v1/story/");
   }
-// Payload limit set to 10mb to support large story content and
-// character network data without triggering 413 errors.
-// Previously used Express default (100kb) which was too restrictive.
-app.use(express.json({ limit: "10mb" }));
-app.use(express.urlencoded({ extended: true, limit: "10mb" }));
-app.use(cookieParser() as unknown as RequestHandler);
-
+  next();
+});
 
 app.use("/api/v1", Routers);
 
-// ─── 2. FIXED: REFUSED TO SHORT-CIRCUIT, DELEGATING 404 TO NEXT() ───
-app.use((req: Request, res: Response, next: NextFunction) => {
-  // Constructing a standardized operational error structure
-  const error = new Error("API Not Found") as ApiError;
-  error.statusCode = httpStatus.NOT_FOUND;
 app.use((req: Request, _res: Response, next: NextFunction) => {
-  const error = new ApiError(httpStatus.NOT_FOUND, "API Not Found");
-  error.errorMessages = [
-    {
-      path: req.originalUrl,
-      message: "The requested API endpoint route does not exist.",
-    },
-  ];
-  next(error);
+  next(
+    new ApiError(
+      httpStatus.NOT_FOUND,
+      `The requested API endpoint route does not exist: ${req.originalUrl}`
+    )
+  );
 });
-
 app.use(globalErrorHandler);
 
 export default app;
-export { defaultCorsOrigins };

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -10,10 +10,9 @@ import { Secret } from "jsonwebtoken";
 import logger from "./utils/logger.util";
 import { setNotificationSocket } from "./socket/notification.socket";
 import { setupCollabSocket } from "./socket/collab.socket";
-import { setupCollabSocket } from "./socket/collab.socket";
-import { setNotificationSocket } from "./socket/notification.socket";
 import { YjsGateway } from "./app/modules/collab/yjs.gateway";
 import { socketRateLimiter } from "./socket/socket-rate-limiter";
+import { startOrderReconciliationJob } from "./jobs/reconcilePendingOrders.job";
 
 // Override DNS resolvers only when explicitly configured, default to the platform environment
 if (config.dns_servers?.length) {
@@ -68,7 +67,7 @@ async function reconnectMongo() {
 
 async function connectDB() {
   if (mongoose.connection.readyState === 1) return;
-  // config.database_url is guaranteed non-empty by config/index.ts – if it throws at
+  // config.database_url is guaranteed non-empty by config/index.ts – it throws at
   // module load time if DATABASE_URL is missing, so no runtime guard is needed here
   if (!mongoose.connection.listeners('error').length) {
     mongoose.connection.on('error', (err) => {
@@ -93,6 +92,8 @@ async function connectDB() {
 }
 
 async function main() {
+  let httpServer: http.Server | undefined;
+
   // ==========================================
   // CENTRALIZED GRACEFUL SHUTDOWN HANDLERS FOR #2784
   // ==========================================
@@ -102,18 +103,15 @@ async function main() {
 
     try {
       if (httpServer) {
-        await new Promise<void>((resolve) => {
-          httpServer.close(() => resolve());
+        await new Promise<void>((resolve, reject) => {
+          httpServer!.close((err) => {
+            if (err) reject(err);
+            else resolve();
+          });
         });
         logger.info('🔌 HTTP server closed.');
       }
       if (mongoose && mongoose.connection && mongoose.connection.readyState !== 0) {
-        await new Promise<void>((resolve, reject) => {
-        httpServer.close((err) => {
-        if (err) reject(err);
-        else resolve();
-  });
-});
         await mongoose.connection.close();
         logger.info('🔌 MongoDB connection safely closed.');
       }
@@ -126,19 +124,12 @@ async function main() {
 
   // Catch unhandled Promise failures across asynchronous operations
   process.on('unhandledRejection', (reason: unknown) => {
-    handleGracefulShutdown('Unhandled Rejection', reason);
+    void handleGracefulShutdown('Unhandled Rejection', reason);
   });
 
   // Intercept unexpected application crashes before they tear down the system
-  process.on("unhandledRejection", (reason) => {
-  void handleGracefulShutdown("Unhandled Rejection", reason);
-  });
-
-  process.on("uncaughtException", (error) => {
-  void handleGracefulShutdown("Uncaught Exception", error);
-  });
   process.on('uncaughtException', (error: Error) => {
-    handleGracefulShutdown('Uncaught Exception', error);
+    void handleGracefulShutdown('Uncaught Exception', error);
   });
 
   try {
@@ -147,80 +138,30 @@ async function main() {
     logger.error("Critical error during application startup:", startupError);
     process.exit(1);
   }
+
   try {
-    const httpServer = http.createServer(app);
-  const defaultCorsOrigins = 
-    process.env.NODE_ENV === "development"
-      ? ["http://localhost:4001", "http://localhost:4002"]
-      : [];
-  // Recovers orders left in "paid_pending_entitlement" by a crash between
-  // the Order write and the User write in verifyPayment. See issue #4876.
-  startOrderReconciliationJob();
+    httpServer = http.createServer(app);
 
-  const httpServer = http.createServer(app);
-  // defaultCorsOrigins is imported from app.ts for consistency
+    // Recovers orders left in "paid_pending_entitlement" by a crash between
+    // the Order write and the User write in verifyPayment. See issue #4876.
+    startOrderReconciliationJob();
 
-  const socketCorsOrigins =
-    config.cors_origins && config.cors_origins.length > 0
-      ? config.cors_origins
-      : defaultCorsOrigins;
-  // Instantiate Socket.IO on top of the HTTP server (previously imported
-  // but never constructed — realtime features were silently dead).
-  const io = new Server(httpServer, {
-    cors: {
-      origin: socketCorsOrigins,
-      credentials: true,
-    },
-  });
+    const socketCorsOrigins =
+      config.cors_origins && config.cors_origins.length > 0
+        ? config.cors_origins
+        : defaultCorsOrigins;
 
-
-  // Initialize Socket.IO server with rate limiting
-  const io = new Server(httpServer, {
-    cors: {
-      origin: socketCorsOrigins,
-      credentials: true,
-      methods: ["GET", "POST"],
-    },
-  });
-
-  // Apply rate limiting to all Socket.IO connections
-  io.use(socketRateLimiter);
-
-  // Setup Socket.IO namespaces
-  setupCollabSocket(io);
-  setNotificationSocket(io);
-  new YjsGateway(io);
-
-  const io = new Server(httpServer, {
-    cors: {
-      origin: socketCorsOrigins,
-      methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-      credentials: true,
-    },
-  });
-
-  setNotificationSocket(io);
-  setupCollabSocket(io);
-
-
-  logger.info("🔌 Socket.IO server initialized with rate limiting");
-
+    // Single Socket.IO instance: full CORS methods + credentials, rate
+    // limiting, JWT auth handshake, and per-user room joining.
     const io = new Server(httpServer, {
-        cors: {
-          origin: socketCorsOrigins,
-          credentials: true,
-        },
+      cors: {
+        origin: socketCorsOrigins,
+        methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+        credentials: true,
+      },
     });
 
-    const [{ setNotificationSocket }, { setupCollabSocket }, { YjsGateway }] = await Promise.all([
-      import("./socket/notification.socket"),
-      import("./socket/collab.socket"),
-      import("./app/modules/collab/yjs.gateway"),
-    ]);
-
-    setNotificationSocket(io);
-    setupCollabSocket(io);
-    new YjsGateway(io);
+    io.use(socketRateLimiter);
 
     io.use((socket, next) => {
       try {
@@ -251,6 +192,12 @@ async function main() {
         socket.join(`user:${userId}`);
       }
     });
+
+    setNotificationSocket(io);
+    setupCollabSocket(io);
+    new YjsGateway(io);
+
+    logger.info("🔌 Socket.IO server initialized with rate limiting");
 
     httpServer.listen(config.port, () => {
       logger.info(`Story-Spark-AI app listening on port ${config.port}`);


### PR DESCRIPTION
## Description

fixes #5706

Fixes unresolved merge conflicts left in `backend/src/server.ts` and `backend/src/app.ts` that prevented the backend from passing `tsc --noEmit` on a clean `main` checkout. Both files had duplicate declarations and orphaned code fragments stacked on top of each other from a previous merge that was never fully resolved.

## Changes Made

**`backend/src/server.ts`**
- Removed duplicate `httpServer`/`io` declarations (was declared 2x and 4x respectively in the same scope) — kept the last `io` setup as authoritative, since it was the only one with rate limiting, JWT auth middleware, and per-user room joining, and the only one that actually reached `httpServer.listen(...)`.
- Removed duplicate imports of `setupCollabSocket` and `setNotificationSocket`.
- Removed the duplicate `process.on('unhandledRejection', ...)` and `process.on('uncaughtException', ...)` registrations — each now registers exactly once.
- Fixed `handleGracefulShutdown` closing `httpServer` twice; it now closes once, followed by the Mongo connection.

**`backend/src/app.ts`**
- Removed the local `interface ApiError` that conflicted with the real imported `ApiError` class from `./errors/api_error`.
- Closed the "Legacy Route Rewrite Rules" middleware's function body, which had been left open, silently swallowing the payload-limit setup, `cookieParser()`, and the `Routers` mount inside it.
- Resolved the conflicting `2mb` vs `10mb` payload limits — kept `10mb`, since it has a concrete justification (fixing real 413 errors on story/character-network payloads); flagging this for maintainer review below.
- Removed the duplicate `cookieParser()` registration.
- Replaced the two stacked 404 handlers (one incomplete, one referencing a nonexistent `errorMessages` property on `ApiError`) with a single handler using `ApiError`'s real constructor. Confirmed via `global.error.handler.ts` that `errorMessages` is derived from `err.message` there, so nothing downstream depended on setting it directly.

## Needs maintainer input

The `2mb` vs `10mb` payload limit conflict was a judgment call, not a mechanical merge — one was commented as intentional DoS hardening, the other as a fix for a real reported 413 bug. I kept `10mb` since it has a concrete justification, but if the `2mb` limit was tied to a specific security requirement, that trade-off should get an explicit sign-off rather than resting on my resolution of the merge conflict.

## How to test

1. `cd backend && npm install`
2. `npx tsc --noEmit` — should show 0 errors in `server.ts` and `app.ts` (any remaining errors should be in other, unrelated files).
3. `npm run dev` — server should boot, log `Story-Spark-AI app listening on port ...`, and Socket.IO connections should authenticate via JWT as before.
4. Hit a nonexistent route (e.g. `GET /api/v1/does-not-exist`) — should return a `404` with a proper `message` field, not hang or crash.

## Checklist

- [x] PR title follows Conventional Commits (`fix: resolve unresolved merge conflicts in server.ts and app.ts`)
- [x] Tested locally (`npm run dev` after setting up `.env` files)
- [ ] Added/updated tests