### PR TITLE
fix(user): resolve merge-conflict artifacts in password pre-save hook

### DIFF
--- a/backend/src/app/modules/user/user.model.ts
+++ b/backend/src/app/modules/user/user.model.ts
@@ -104,7 +104,7 @@ export const UserSchema: Schema<IUser> = new Schema<IUser, UserModel>(
 
 UserSchema.pre("save", async function (next) {
   const user = this;
-main
+
   if (!user.isModified("password")) {
     return next();
   }
@@ -112,12 +112,12 @@ main
     this.passwordChangedAt = new Date(Date.now() - 1000);
   }
 
-main
+
     user.password = await bcrypt.hash(
       user.password,
       Number(config.bcrypt_salt_rounds)
     );
-  }
+  
 
   next();
 });


### PR DESCRIPTION
## Description

fixes #5708 
Fixes a broken `UserSchema.pre("save", ...)` hook in `backend/src/app/modules/user/user.model.ts` — the password-hashing hook that runs before every user document is persisted to MongoDB. The hook had two stray `main` tokens left over from an unresolved merge conflict, and an extra closing brace that prematurely ended the function body, leaving `next()` and the final `});` as orphaned, unparseable statements.

This wasn't just a stray comment or dead code — because the brace count was wrong, the file fails to parse entirely, which blocks `tsc --noEmit` for the **entire backend**. `main` currently cannot build cleanly because of this single file.

## Changes Made

- `backend/src/app/modules/user/user.model.ts` — removed the two stray `main` tokens and the extra closing brace inside the `pre("save", ...)` hook. Logic is otherwise unchanged: still skips hashing if the password wasn't modified, still updates `passwordChangedAt` for existing (non-new) users, still hashes with `bcrypt` using the configured salt rounds, and calls `next()` exactly once at the end.

## How to test

1. `cd backend && npm install`
2. `npx tsc --noEmit` — `user.model.ts` should no longer appear in the error output.
3. Register a new user via `POST /api/v1/auth/register` (or whichever endpoint creates a `User`) and confirm the stored `password` field is a bcrypt hash, not plaintext.
4. Update an existing user's password and confirm `passwordChangedAt` gets set.
5. Update an existing user's profile *without* touching the password and confirm the password isn't re-hashed (hash stays the same) — this is what `isModified("password")` guards against.

## Checklist

- [x] PR title follows Conventional Commits (`fix: resolve merge-conflict artifacts in password pre-save hook`)
- [x] Tested locally (`npm run dev` after setting up `.env` files)
- [ ] Added/updated tests