### PR TITLE
fix(character): remove duplicated controller code from unresolved merge

### DIFF
--- a/backend/src/controllers/character.controller.ts
+++ b/backend/src/controllers/character.controller.ts
@@ -1,140 +1,9 @@
 import { NextFunction, Request, Response } from 'express';
-import { Character } from '../models/Character.model';
-
-export const createCharacter = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const { name, age, personality, appearance, background, traits, notes } = req.body;
-    
-    if (!name || typeof name !== "string") {
-      return res.status(400).json({
-        success: false,
-        message: "Name is required"
-      });
-    }
-
-    if (!appearance || typeof appearance !== "string") {
-      return res.status(400).json({
-        success: false,
-        message: "Appearance is required"
-      });
-    }
-
-    if (personality && !Array.isArray(personality)) {
-      return res.status(400).json({
-        success: false,
-        message: "Personality must be an array"
-      });
-    }
-
-    const userId = req.user?.id;
-
-    if (!userId) {
-      return res.status(401).json({ success: false, message: 'Unauthorized' });
-    }
-
-    if (!name || typeof name !== 'string' || !name.trim()) {
-      return res.status(400).json({ success: false, message: 'Character name is required' });
-    }
-
-    const character = new Character({
-      userId,
-      name: name.trim(),
-      age,
-      personality,
-      appearance,
-      background,
-      traits,
-      notes,
-    });
-
-    await character.save();
-    res.status(201).json({ success: true, data: character });
-  } catch (error) {
-    next(error);
-  }
-};
-
-export const getCharacters = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const userId = req.user?.id;
-    if (!userId) {
-      return res.status(401).json({ success: false, message: 'Unauthorized' });
-    }
-
-    const characters = await Character.find({ userId }).sort({ createdAt: -1 });
-    res.status(200).json({ success: true, data: characters });
-  } catch (error) {
-    next(error);
-  }
-};
-
-export const getCharacterById = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const { id } = req.params;
-    const userId = req.user?.id;
-
-    if (!userId) {
-      return res.status(401).json({ success: false, message: 'Unauthorized' });
-    }
-
-    const character = await Character.findOne({ _id: id, userId });
-    if (!character) {
-      return res.status(404).json({ success: false, message: 'Character not found' });
-    }
-
-    res.status(200).json({ success: true, data: character });
-  } catch (error) {
-    next(error);
-  }
-};
-
-export const updateCharacter = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const { id } = req.params;
-    const userId = req.user?.id;
-
-    if (!userId) {
-      return res.status(401).json({ success: false, message: 'Unauthorized' });
-    }
-
-    const updates = req.body;
-    const character = await Character.findOneAndUpdate(
-      { _id: id, userId },
-      { $set: updates },
-      { new: true, runValidators: true }
-    );
-
-    if (!character) {
-      return res.status(404).json({ success: false, message: 'Character not found' });
-    }
-
-    res.status(200).json({ success: true, data: character });
-  } catch (error) {
-    next(error);
-  }
-};
-
-export const deleteCharacter = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const { id } = req.params;
-    const userId = req.user?.id;
-
-    if (!userId) {
-      return res.status(401).json({ success: false, message: 'Unauthorized' });
-    }
-
-    const character = await Character.findOneAndDelete({ _id: id, userId });
-    if (!character) {
-      return res.status(404).json({ success: false, message: 'Character not found' });
-    }
-
-    res.status(200).json({ success: true, message: 'Character deleted successfully' });
-  } catch (error) {
-    next(error);
 import { Character } from '../Character.model';
 import ApiError from '../errors/api_error';
 import httpStatus from 'http-status';
 import catchAsync from '../shared/catch_async';
+
 export const createCharacter = catchAsync(async (req: Request, res: Response, next: NextFunction) => {
   const { name, age, personality, appearance, background, traits, notes } = req.body;
   const userId = req.user?.id;
@@ -178,7 +47,6 @@ export const getCharacterById = catchAsync(async (req: Request, res: Response, n
   const character = await Character.findOne({ _id: id, userId });
   if (!character) {
     throw new ApiError(httpStatus.NOT_FOUND, 'Character not found');
-
   }
 
   res.status(200).json({ success: true, data: character });
@@ -197,6 +65,7 @@ export const updateCharacter = catchAsync(async (req: Request, res: Response, ne
   delete updates._id;
   delete updates.createdAt;
   delete updates.updatedAt;
+
   const character = await Character.findOneAndUpdate(
     { _id: id, userId },
     { $set: updates },


### PR DESCRIPTION
## Description

Fixes #5710 

Fixes `backend/src/controllers/character.controller.ts`, which contained the **entire file duplicated twice** from an unresolved merge conflict — every controller function (`createCharacter`, `getCharacters`, `getCharacterById`, `updateCharacter`, `deleteCharacter`) existed in two different styles back-to-back, glued together mid-function. This left an unclosed brace that broke `tsc --noEmit` for the whole backend.

## Root cause

- **First copy** (removed): manual `try/catch`, imports `Character` from `../models/Character.model` — this path returns 404, confirming it's dead code from an older version of the file.
- **Second copy** (kept): wrapped in `catchAsync`, throws `ApiError` instead of manually building response objects, imports `Character` from the correct `../Character.model`. This also matches the error-handling convention already used elsewhere in the codebase (`payment.controller.ts`, `story.routes.ts`).

## Changes Made

- `backend/src/controllers/character.controller.ts` — removed the entire first, superseded copy of the file. Kept the second, correct copy as-is.

## How to test

1. `cd backend && npm install`
2. `npx tsc --noEmit` — `character.controller.ts` should no longer appear in the error output.
3. Exercise the character CRUD endpoints (`POST`/`GET`/`PATCH`/`DELETE` on `/character`, whatever the mounted route prefix is) and confirm they still behave correctly — particularly that a missing/invalid character ID returns a proper `404` via `ApiError`, not a crash.

## Checklist

- [x] PR title follows Conventional Commits (`fix: remove duplicated controller code from unresolved merge`)
- [x] Tested locally (`npm run dev` after setting up `.env` files)
- [ ] Added/updated tests