### PR TITLE
Implement character limit for user prompts

### DIFF
--- a/backend/src/utils/promptSecurity.ts
+++ b/backend/src/utils/promptSecurity.ts
@@ -9,6 +9,9 @@
  */
 import { assertContentSafe } from "./contentModeration";
 
+// Added strict character limit to prevent DoS/ReDoS
+const MAX_PROMPT_LENGTH = 10000; 
+
 const FORBIDDEN_PATTERNS: RegExp[] = [
   // Direct instruction override attempts
   /ignore\s+(?:.*?\s+)?(?:instructions?|prompts?|context|rules?|constraints?)/i,
@@ -75,6 +78,11 @@ const normalizeText = (input: string): string => {
 export const validateAndFormatPrompt = (userPrompt: string): string => {
   if (!userPrompt || typeof userPrompt !== "string") {
     throw new Error("Security Violation: Invalid prompt input.");
+  }
+
+  // Length check BEFORE expensive normalizations and regex matching
+  if (userPrompt.length > MAX_PROMPT_LENGTH) {
+    throw new Error(`Security Violation: Prompt exceeds maximum length of ${MAX_PROMPT_LENGTH} characters.`);
   }
 
   const canonicalPrompt = normalizeText(userPrompt);


### PR DESCRIPTION
Added a maximum character limit to user prompts to prevent potential DoS/ReDoS attacks.


## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [x] Bug fix
- [x] New feature
- [x] Code refactor
- [x] Documentation update

## Related issue
Closes #5736 
<!-- Example: Closes #123 or Fixes #45. Use “None” if there is no issue. -->


## Checklist

- [ ] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [ ] I have tested my changes.
- [x] I have done a self-review of the code.
