### PR TITLE
Fix CSRF protection for story bookmark and preference routes (#5667)

### DIFF
--- a/backend/src/app/middleware/__tests__/csrf.middleware.test.ts
+++ b/backend/src/app/middleware/__tests__/csrf.middleware.test.ts
@@ -1,0 +1,59 @@
+import type { NextFunction, Request, Response } from "express";
+import csrfMiddleware, { generateCsrfToken } from "../csrf.middleware";
+
+describe("csrf middleware", () => {
+  const buildMocks = (headerValue?: string, userId = "user-123") => {
+    const req = {
+      headers: headerValue === undefined ? {} : { "x-csrf-token": headerValue },
+      user: { _id: userId },
+    } as unknown as Request;
+
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    } as unknown as Response;
+
+    const next = jest.fn() as NextFunction;
+
+    return { req, res, next };
+  };
+
+  it("allows requests with a valid token", () => {
+    const { req, res, next } = buildMocks(generateCsrfToken("user-123"));
+
+    csrfMiddleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("blocks requests with a missing token", () => {
+    const { req, res, next } = buildMocks();
+
+    csrfMiddleware(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        message: "Invalid or missing CSRF token",
+      })
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("blocks requests with an invalid token", () => {
+    const { req, res, next } = buildMocks("bad-token");
+
+    csrfMiddleware(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        message: "Invalid or missing CSRF token",
+      })
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/app/middleware/csrf.middleware.ts
+++ b/backend/src/app/middleware/csrf.middleware.ts
@@ -1,0 +1,77 @@
+import { createHmac, timingSafeEqual } from "crypto";
+import { NextFunction, Request, Response } from "express";
+import httpStatus from "http-status";
+
+const CSRF_HEADER = "x-csrf-token";
+
+const normalizeHeader = (value: string | string[] | undefined): string => {
+  if (Array.isArray(value)) {
+    return value[0]?.trim() ?? "";
+  }
+
+  return value?.trim() ?? "";
+};
+
+const getProvidedToken = (req: Request): string => {
+  const headerValue =
+    (req.header ? req.header(CSRF_HEADER) : undefined) ??
+    (req.header ? req.header("X-CSRF-Token") : undefined) ??
+    (req.get ? req.get(CSRF_HEADER) : undefined) ??
+    (req.get ? req.get("X-CSRF-Token") : undefined);
+
+  if (headerValue) {
+    return normalizeHeader(headerValue);
+  }
+
+  const headers = req.headers as Record<string, string | string[] | undefined>;
+  return normalizeHeader(
+    headers[CSRF_HEADER] ?? headers["x-csrf-token"] ?? headers["X-CSRF-Token"]
+  );
+};
+
+export const generateCsrfToken = (userId: string): string => {
+  const secret = process.env.JWT_SECRET || "test-secret";
+  const hmac = createHmac("sha256", secret);
+  hmac.update(userId);
+  return hmac.digest("hex");
+};
+
+const csrfMiddleware = (req: Request, res: Response, next: NextFunction) => {
+  const providedToken = getProvidedToken(req);
+  const userId = (req.user as { _id?: string } | undefined)?._id;
+
+  if (!userId) {
+    res.status(httpStatus.FORBIDDEN).json({
+      success: false,
+      message: "Invalid or missing CSRF token",
+    });
+    return;
+  }
+
+  if (!providedToken) {
+    res.status(httpStatus.FORBIDDEN).json({
+      success: false,
+      message: "Invalid or missing CSRF token",
+    });
+    return;
+  }
+
+  const expectedToken = generateCsrfToken(userId);
+  const providedBuffer = Buffer.from(providedToken);
+  const expectedBuffer = Buffer.from(expectedToken);
+
+  if (
+    providedBuffer.length !== expectedBuffer.length ||
+    !timingSafeEqual(providedBuffer, expectedBuffer)
+  ) {
+    res.status(httpStatus.FORBIDDEN).json({
+      success: false,
+      message: "Invalid or missing CSRF token",
+    });
+    return;
+  }
+
+  next();
+};
+
+export default csrfMiddleware;

--- a/backend/src/app/modules/bookmark/bookmark.router.ts
+++ b/backend/src/app/modules/bookmark/bookmark.router.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import { ENUM_USER_ROLE } from "../../../enums/user";
 import auth from "../../middleware/auth.middleware";
+import csrfMiddleware from "../../middleware/csrf.middleware";
 import { BookmarkController } from "./bookmark.controller";
 
 const router = express.Router();
@@ -14,6 +15,7 @@ router.post(
     ENUM_USER_ROLE.ADMIN,
     ENUM_USER_ROLE.SUPER_ADMIN
   ),
+  csrfMiddleware,
   BookmarkController.toggleBookmark
 );
 
@@ -50,6 +52,7 @@ router.delete(
     ENUM_USER_ROLE.ADMIN,
     ENUM_USER_ROLE.SUPER_ADMIN
   ),
+  csrfMiddleware,
   BookmarkController.deleteBookmark
 );
 

--- a/backend/src/app/modules/post/post.router.ts
+++ b/backend/src/app/modules/post/post.router.ts
@@ -3,6 +3,7 @@ import { PostController } from "./post.controller";
 import { PostMetaController } from "./post.meta.controller";
 import auth from "../../middleware/auth.middleware";
 import checkRequestLimit from "../../middleware/check.request.limit";
+import csrfMiddleware from "../../middleware/csrf.middleware";
 import validateRequest from "../../middleware/validate.request";
 import { PostValidator } from "./post.validation";
 import { ENUM_USER_ROLE } from "../../../enums/user";
@@ -89,6 +90,7 @@ router.patch(
     ENUM_USER_ROLE.ADMIN,
     ENUM_USER_ROLE.SUPER_ADMIN
   ),
+  csrfMiddleware,
   PostController.toggleBookmark
 );
 

--- a/backend/src/app/modules/reaction/reaction.router.ts
+++ b/backend/src/app/modules/reaction/reaction.router.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import { ENUM_USER_ROLE } from "../../../enums/user";
 import auth from "../../middleware/auth.middleware";
+import csrfMiddleware from "../../middleware/csrf.middleware";
 import { ReactionController } from "./reaction.controller";
 
 const router = express.Router();
@@ -13,6 +14,7 @@ router.post(
     ENUM_USER_ROLE.SUPER_ADMIN,
     ENUM_USER_ROLE.USER
   ),
+  csrfMiddleware,
   ReactionController.toggleReaction
 );
 

--- a/backend/src/app/modules/user/user.router.ts
+++ b/backend/src/app/modules/user/user.router.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import { UserController } from "./user.controller";
 import auth from "../../middleware/auth.middleware";
+import csrfMiddleware from "../../middleware/csrf.middleware";
 import { ENUM_USER_ROLE } from "../../../enums/user";
 import validateRequest from "../../middleware/validate.request";
 import { UserValidator } from "./user.validation";
@@ -44,6 +45,7 @@ router.patch(
     ENUM_USER_ROLE.ADMIN,
     ENUM_USER_ROLE.SUPER_ADMIN
   ),
+  csrfMiddleware,
   validateRequest(UserValidator.updateUser),
   UserController.updateUser
 );


### PR DESCRIPTION
## Summary
This PR implements CSRF protection for story bookmark and preference modification routes.

### Changes Made
- Added a new CSRF middleware to validate `X-CSRF-Token` for state-changing requests.
- Applied CSRF protection to bookmark, reaction/voting, post, and user preference routes.
- Added regression tests covering:
  - Valid CSRF token
  - Missing CSRF token
  - Invalid CSRF token
- Returns **HTTP 403 Forbidden** when the CSRF token is missing or invalid.

Fixes #5667