### PR TITLE
fix: add toast feedback to handleCompare validation guards in ComparisonMode

### DIFF
--- a/frontend/src/components/story-comparison/ComparisonMode.tsx
+++ b/frontend/src/components/story-comparison/ComparisonMode.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import toast from "react-hot-toast";
 import VariationSelector from "./VariationSelector";
 import DiffViewer from "./DiffViewer";
 
@@ -32,7 +33,12 @@ const ComparisonMode: React.FC<ComparisonModeProps> = ({
   const [showComparison, setShowComparison] = useState(false);
 
   const handleCompare = () => {
-    if (!selectedVersion1 || !selectedVersion2 || selectedVersion1._id === selectedVersion2._id) {
+    if (!selectedVersion1 || !selectedVersion2) {
+      toast.error("Please select two versions to compare.");
+      return;
+    }
+    if (selectedVersion1._id === selectedVersion2._id) {
+      toast.error("Please select two different versions — you selected the same version twice.");
       return;
     }
 


### PR DESCRIPTION
### Description
Splits the combined guard condition into two separate checks, each
with a descriptive `toast.error()` message. Imports `react-hot-toast`
which is already used throughout the app. This ensures users always
know why the Compare button isn't proceeding, eliminating the silent
failure UX.

### Related Issues
Closes #5742 