### PR TITLE
fix: preserve version selections on back navigation in ComparisonMode — eliminates forced reselection of unchanged versions

### DIFF
--- a/frontend/src/components/story-comparison/ComparisonMode.tsx
+++ b/frontend/src/components/story-comparison/ComparisonMode.tsx
@@ -44,9 +44,9 @@ const ComparisonMode: React.FC<ComparisonModeProps> = ({
   };
 
   const handleBackToSelection = () => {
+    // Keep both selections so the user only needs to change the one they want —
+    // clearing both on every back forces redundant reselection for common workflows
     setShowComparison(false);
-    setSelectedVersion1(null);
-    setSelectedVersion2(null);
   };
 
   if (isLoadingVersions) {


### PR DESCRIPTION
### Description
Removes `setSelectedVersion1(null)` and `setSelectedVersion2(null)`
from `handleBackToSelection`. Both selections are preserved when
returning from DiffViewer to the selector. Users can update whichever
version they want to change in `VariationSelector`. This is standard
behaviour in comparison tools (GitHub, VS Code diff) where going
back preserves the current selection state.

### Related Issues
Closes #5744 