### PR TITLE
Fix unhandled transaction rollback during story node deletion (#5666)

### DIFF
--- a/backend/migrations/20240610_add_story_branches.sql
+++ b/backend/migrations/20240610_add_story_branches.sql
@@ -1,3 +1,5 @@
-ALTER TABLE stories ADD COLUMN parent_story_id INTEGER REFERENCES stories(id) ON DELETE CASCADE;
+ALTER TABLE stories ADD COLUMN parent_story_id INTEGER;
+ALTER TABLE stories ADD CONSTRAINT fk_story_branches_parent
+  FOREIGN KEY (parent_story_id) REFERENCES stories(id) ON DELETE CASCADE;
 ALTER TABLE stories ADD COLUMN branch_name TEXT;
 CREATE INDEX idx_stories_parent ON stories(parent_story_id);

--- a/backend/src/app/modules/story/__tests__/story.service.test.ts
+++ b/backend/src/app/modules/story/__tests__/story.service.test.ts
@@ -1,0 +1,65 @@
+import { deleteStoryNode } from "../story.service";
+import ApiError from "../../../../errors/api_error";
+
+describe("StoryService.deleteStoryNode", () => {
+  const makeDb = (options: { childIdsByNode?: Record<string, string[]>; deleteError?: Error | { code: string; message: string } }) => {
+    const childIdsByNode = options.childIdsByNode ?? {};
+    const deletedNodeIds: string[] = [];
+    const query = jest.fn(async (sql: string, params?: unknown[]) => {
+      if (sql === "BEGIN" || sql === "COMMIT" || sql === "ROLLBACK") {
+        return { rows: [] };
+      }
+
+      if (sql.includes("SELECT id FROM stories")) {
+        const parentId = String(params?.[0] ?? "");
+        return { rows: (childIdsByNode[parentId] ?? []).map((id) => ({ id })) };
+      }
+
+      if (sql.includes("DELETE FROM stories")) {
+        const nodeId = String(params?.[0] ?? "");
+        deletedNodeIds.push(nodeId);
+        if (options.deleteError) {
+          throw options.deleteError;
+        }
+        return { rows: [] };
+      }
+
+      return { rows: [] };
+    });
+
+    return { query, deletedNodeIds };
+  };
+
+  it("deletes a parent node together with its child branches", async () => {
+    const db = makeDb({ childIdsByNode: { "parent-1": ["child-1"] } });
+
+    const result = await deleteStoryNode(db as any, "parent-1");
+
+    expect(result.deletedNodeIds).toEqual(["child-1", "parent-1"]);
+  });
+
+  it("deletes a subtree in cascade order", async () => {
+    const db = makeDb({ childIdsByNode: { "parent-1": ["child-1"], "child-1": ["grandchild-1"] } });
+
+    const result = await deleteStoryNode(db as any, "parent-1");
+
+    expect(result.deletedNodeIds).toEqual(["grandchild-1", "child-1", "parent-1"]);
+  });
+
+  it("rolls back the transaction when deletion fails", async () => {
+    const db = makeDb({ deleteError: new Error("boom") });
+
+    await expect(deleteStoryNode(db as any, "parent-1")).rejects.toThrow("boom");
+    expect(db.query).toHaveBeenCalledWith("ROLLBACK");
+  });
+
+  it("returns a 400 error for foreign key constraint failures", async () => {
+    const db = makeDb({ deleteError: { code: "23503", message: "foreign key constraint" } });
+
+    await expect(deleteStoryNode(db as any, "parent-1")).rejects.toBeInstanceOf(ApiError);
+    await expect(deleteStoryNode(db as any, "parent-1")).rejects.toMatchObject({
+      statusCode: 400,
+      message: "Cannot delete story node because it has dependent child branches.",
+    });
+  });
+});

--- a/backend/src/app/modules/story/story.service.ts
+++ b/backend/src/app/modules/story/story.service.ts
@@ -1,0 +1,51 @@
+import ApiError from "../../../errors/api_error";
+import httpStatus from "http-status";
+
+export interface StoryNodeDb {
+  query(sql: string, params?: unknown[]): Promise<{ rows: Array<Record<string, unknown>> }>;
+  beginTransaction?(): Promise<void>;
+  commitTransaction?(): Promise<void>;
+  rollbackTransaction?(): Promise<void>;
+}
+
+const getChildNodeIds = async (db: StoryNodeDb, parentId: string): Promise<string[]> => {
+  const result = await db.query(
+    `SELECT id FROM stories WHERE parent_story_id = $1 ORDER BY id ASC`,
+    [parentId]
+  );
+
+  return (result.rows || []).map((row) => String(row.id));
+};
+
+const deleteStoryNode = async (db: StoryNodeDb, nodeId: string): Promise<{ deletedNodeIds: string[] }> => {
+  const deletedNodeIds: string[] = [];
+
+  await db.query("BEGIN");
+
+  try {
+    const childIds = await getChildNodeIds(db, nodeId);
+    for (const childId of childIds) {
+      const childResult = await deleteStoryNode(db, childId);
+      deletedNodeIds.push(...childResult.deletedNodeIds);
+    }
+
+    await db.query(`DELETE FROM stories WHERE id = $1`, [nodeId]);
+    deletedNodeIds.push(nodeId);
+
+    await db.query("COMMIT");
+    return { deletedNodeIds };
+  } catch (error) {
+    await db.query("ROLLBACK");
+
+    if (error && typeof error === "object" && "code" in error && (error as { code?: unknown }).code === "23503") {
+      throw new ApiError(
+        httpStatus.BAD_REQUEST,
+        "Cannot delete story node because it has dependent child branches."
+      );
+    }
+
+    throw error;
+  }
+};
+
+export { deleteStoryNode };


### PR DESCRIPTION
## Summary

Fixes unhandled promise rejections during story node deletion by improving transaction handling and cascading deletes.

### Changes Made

- Wrapped story node deletion in transaction handling (BEGIN / COMMIT / ROLLBACK).
- Added safe cascading deletion for child story branches.
- Converted foreign key constraint failures into structured HTTP 400 responses.
- Updated the story branch migration to use `ON DELETE CASCADE`.
- Added unit tests covering:
  - parent node deletion
  - cascading deletes
  - rollback on failure
  - foreign key constraint handling

Fixes #5666