### PR TITLE
test : added unit tests for useAccessibility hook

### DIFF
--- a/frontend/src/hooks/__tests__/useAccessibility.test.js
+++ b/frontend/src/hooks/__tests__/useAccessibility.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+// Mock localStorage before importing the hook
+const mockStore = {};
+
+global.localStorage = {
+  getItem: vi.fn((key) => mockStore[key] ?? null),
+  setItem: vi.fn((key, value) => {
+    mockStore[key] = String(value);
+  }),
+  removeItem: vi.fn((key) => {
+    delete mockStore[key];
+  }),
+};
+
+const { useAccessibility } = await import("../useAccessibility.js");
+
+describe("useAccessibility hook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.keys(mockStore).forEach((k) => delete mockStore[k]);
+  });
+
+  it("should initialize with highContrast and reducedMotion as false", () => {
+    const { result } = renderHook(() => useAccessibility());
+    expect(result.current.highContrast).toBe(false);
+    expect(result.current.reducedMotion).toBe(false);
+  });
+
+  it("should load saved highContrast from localStorage on mount", () => {
+    mockStore["accessibility-contrast"] = "true";
+    const { result } = renderHook(() => useAccessibility());
+    expect(result.current.highContrast).toBe(true);
+  });
+
+  it("should toggle highContrast to true and persist to localStorage", () => {
+    const { result } = renderHook(() => useAccessibility());
+    result.current.toggleContrast();
+    expect(result.current.highContrast).toBe(true);
+    expect(mockStore["accessibility-contrast"]).toBe("true");
+  });
+
+  it("should toggle highContrast back to false", () => {
+    mockStore["accessibility-contrast"] = "true";
+    const { result } = renderHook(() => useAccessibility());
+    result.current.toggleContrast();
+    expect(result.current.highContrast).toBe(false);
+    expect(mockStore["accessibility-contrast"]).toBe("false");
+  });
+
+  it("should toggle reducedMotion and persist to localStorage", () => {
+    const { result } = renderHook(() => useAccessibility());
+    result.current.toggleMotion();
+    expect(result.current.reducedMotion).toBe(true);
+    expect(mockStore["accessibility-motion"]).toBe("true");
+  });
+
+  it("should toggle reducedMotion back to false", () => {
+    mockStore["accessibility-motion"] = "true";
+    const { result } = renderHook(() => useAccessibility());
+    result.current.toggleMotion();
+    expect(result.current.reducedMotion).toBe(false);
+    expect(mockStore["accessibility-motion"]).toBe("false");
+  });
+});


### PR DESCRIPTION
Closes #5751.

Summary of What Has Been Done:
Added vitest unit tests for the useAccessibility hook which manages highContrast and reducedMotion preferences via localStorage. Tests cover initial state, localStorage loading, toggleContrast and toggleMotion functions, and persistence to localStorage.

Changes Made:
- Created frontend/src/hooks/__tests__/useAccessibility.test.js with 6 test cases
- Mocked global localStorage for isolated testing
- Used @testing-library/react renderHook for testing React hooks

Impact it Made:
- Increases frontend test coverage for accessibility feature
- Verifies toggleContrast and toggleMotion correctly update state and persist to localStorage
- Verified locally: eslint (0 errors), tsc --noEmit (0 errors)

Note: Please assign this PR to the `tmdeveloper007` account.