### PR TITLE
fix : added try-catch for JSON.parse in useAccessibility localStorage read

### DIFF
--- a/frontend/src/hooks/useAccessibility.js
+++ b/frontend/src/hooks/useAccessibility.js
@@ -7,7 +7,13 @@ export const useAccessibility = () => {
   useEffect(() => {
     if (typeof window === 'undefined') return;
     const saved = localStorage.getItem('accessibility-contrast');
-    if (saved) setHighContrast(JSON.parse(saved));
+    if (saved) {
+      try {
+        setHighContrast(JSON.parse(saved));
+      } catch {
+        setHighContrast(false);
+      }
+    }
   }, []);
 
   const toggle = (setter, key) => {


### PR DESCRIPTION
Closes #5753.

Summary of What Has Been Done:
Added a try-catch around the JSON.parse call in the useAccessibility hook's useEffect that reads the saved accessibility-contrast value from localStorage. Previously, if localStorage contained corrupted or non-JSON data, the application would throw an unhandled exception and crash. Now it gracefully falls back to false.

Changes Made:
- frontend/src/hooks/useAccessibility.js: wrapped JSON.parse in try-catch, defaulting to false on error

Impact it Made:
- Prevents runtime crashes from corrupted localStorage data
- Makes the hook resilient to data corruption scenarios
- Verified locally: eslint (0 errors)

Note: Please assign this PR to the `tmdeveloper007` account.