### PR TITLE
fix: enforce rate limiting and payload sanitization on prompt analysis endpoints #5479

### DIFF
--- a/backend/src/app/middleware/prompt.rate-limiter.ts
+++ b/backend/src/app/middleware/prompt.rate-limiter.ts
@@ -1,0 +1,81 @@
+import rateLimit from "express-rate-limit";
+import { Request, Response } from "express";
+
+/**
+ * Rate limiter for prompt analysis endpoints.
+ * Caps requests to 10 per minute per IP to prevent DoS attacks.
+ */
+export const promptRateLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 10, // max 10 requests per minute per IP
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: {
+    success: false,
+    statusCode: 429,
+    message: "Too many requests. Please wait before sending more prompts.",
+  },
+  handler: (req: Request, res: Response) => {
+    res.status(429).json({
+      success: false,
+      statusCode: 429,
+      message: "Too many requests. Please wait before sending more prompts.",
+    });
+  },
+});
+
+/**
+ * Middleware to enforce 100KB payload size limit.
+ * Returns HTTP 413 if the request body exceeds the limit.
+ */
+export const promptPayloadLimit = (
+  req: Request,
+  res: Response,
+  next: Function
+) => {
+  const MAX_PAYLOAD_BYTES = 100 * 1024; // 100KB
+
+  const contentLength = parseInt(req.headers["content-length"] || "0", 10);
+
+  if (contentLength > MAX_PAYLOAD_BYTES) {
+    res.status(413).json({
+      success: false,
+      statusCode: 413,
+      message: "Payload Too Large. Request body must not exceed 100KB.",
+    });
+    return;
+  }
+
+  next();
+};
+
+/**
+ * Middleware to sanitize incoming JSON keys.
+ * Rejects requests containing unrecognized extra attributes.
+ */
+export const sanitizePromptPayload = (
+  req: Request,
+  res: Response,
+  next: Function
+) => {
+  const ALLOWED_KEYS = ["prompt", "language", "genre", "tone"];
+
+  const body = req.body as Record<string, unknown>;
+
+  if (body && typeof body === "object") {
+    const unknownKeys = Object.keys(body).filter(
+      (key) => !ALLOWED_KEYS.includes(key)
+    );
+
+    if (unknownKeys.length > 0) {
+      res.status(400).json({
+        success: false,
+        statusCode: 400,
+        message: `Unrecognized fields in request body: ${unknownKeys.join(", ")}`,
+      });
+      return;
+    }
+  }
+
+  next();
+};

--- a/backend/src/app/modules/prompt_analysis/prompt_analysis.router.ts
+++ b/backend/src/app/modules/prompt_analysis/prompt_analysis.router.ts
@@ -2,33 +2,46 @@ import express from "express";
 import validateRequest from "../../middleware/validate.request";
 import { PromptAnalysisValidator } from "./prompt_analysis.validation";
 import { PromptAnalysisController } from "./prompt_analysis.controller";
+import {
+  promptRateLimiter,
+  promptPayloadLimit,
+  sanitizePromptPayload,
+} from "../../middleware/prompt.rate-limiter";
 
 const router = express.Router();
 
+// Apply rate limiting and payload limit to all prompt analysis routes
+router.use(promptRateLimiter);
+router.use(promptPayloadLimit);
+
 /**
  * POST /api/v1/prompt-analysis/analyze
- * Analyze a prompt and get creativity score + enhancements
  */
 router.post(
   "/analyze",
+  sanitizePromptPayload,
   validateRequest(PromptAnalysisValidator.analyzePrompt),
   PromptAnalysisController.analyzePrompt
 );
 
 /**
  * POST /api/v1/prompt-analysis/enhance
- * Get enhanced version of a prompt (subset of full analysis)
  */
 router.post(
   "/enhance",
+  sanitizePromptPayload,
   validateRequest(PromptAnalysisValidator.analyzePrompt),
   PromptAnalysisController.enhancePrompt
 );
 
 /**
  * POST /api/v1/prompt-analysis/batch
- * Analyze multiple prompts in one request
  */
-router.post("/batch", PromptAnalysisController.batchAnalyzePrompts);
+router.post(
+  "/batch",
+  promptRateLimiter,
+  promptPayloadLimit,
+  PromptAnalysisController.batchAnalyzePrompts
+);
 
 export default router;


### PR DESCRIPTION
## What this PR does
Enforces strict rate limiting, payload size limits, and JSON key 
sanitization on all AI prompt analysis endpoints to prevent DoS attacks 
via multi-megabyte JSON payloads and request flooding.

**Changes made:**

**New file — `backend/src/app/middleware/prompt.rate-limiter.ts`:**
- `promptRateLimiter` — caps requests to 10 per minute per IP using 
  `express-rate-limit`, returns HTTP 429 on violation
- `promptPayloadLimit` — checks `Content-Length` header and returns 
  HTTP 413 if request body exceeds 100KB
- `sanitizePromptPayload` — rejects requests containing unrecognized 
  JSON keys outside of `prompt`, `language`, `genre`, `tone`, 
  returns HTTP 400 with list of unknown fields

**Updated — `prompt_analysis.router.ts`:**
- Applied `promptRateLimiter` and `promptPayloadLimit` globally to 
  all routes via `router.use()`
- Applied `sanitizePromptPayload` to `/analyze` and `/enhance` routes
- `/batch` route gets additional rate limiting due to higher risk

## Type of change
- [x] Bug fix
- [x] New feature

## Related issue
Closes #5479

## Screenshot
N/A — backend security middleware with no UI changes

## Checklist
- [x] I have added screenshots or a recording when they help explain 
  this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.