### PR TITLE
feat(story): add AI Reader Room for story playtesting and feedback

### DIFF
--- a/backend/src/routes/story.routes.ts
+++ b/backend/src/routes/story.routes.ts
@@ -19,6 +19,12 @@ import { runWithQuotaCleanup } from "../app/modules/ai_model/quota.lifecycle";
 import mongoose from "mongoose";
 import { Post } from "../app/modules/post/post.model";
 import rateLimit from "express-rate-limit";
+// add to imports
+import { generateReaderRoomFeedback } from "../services/ai.service";
+import idempotencyMiddleware, {
+  completeIdempotentRequest,
+  releaseIdempotentRequest,
+} from "../app/middleware/idempotency.middleware";
 
 const router = express.Router();
 
@@ -255,5 +261,78 @@ router.patch(
     });
   })
 );
+
+/** AI READER ROOM: multi-persona feedback before publishing */
+router.post(
+  "/:id/reader-room",
+  auth(
+    ENUM_USER_ROLE.USER,
+    ENUM_USER_ROLE.WRITER,
+    ENUM_USER_ROLE.ADMIN,
+    ENUM_USER_ROLE.SUPER_ADMIN
+  ),
+  storyGenerationRateLimiter,
+  checkRequestLimit(),
+  catchAsync(async (req: Request, res: Response) => {
+    const { id } = req.params;
+    const { targetAudience, provider } = req.body as {
+      targetAudience?: string;
+      provider?: string;
+    };
+    const userId = (req as any).user?._id;
+    const guard = res.locals.quotaRefundGuard;
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      res.status(400).json({ success: false, message: "Invalid story id." });
+      return;
+    }
+    if (!targetAudience) {
+      res.status(400).json({ success: false, message: "targetAudience is required." });
+      return;
+    }
+    if (!guard) {
+      throw new Error("Quota guard missing — checkRequestLimit middleware is required");
+    }
+
+    const story = await Post.findOne({ _id: id, author: userId, isDeleted: { $ne: true } });
+    if (!story) {
+      res.status(404).json({
+        success: false,
+        message: "Story not found, or you don't have permission to review it.",
+      });
+      return;
+    }
+
+    // Post.content is a single string (see #5664 notes) — split into
+    // pseudo-chapters on the same markdown-style headers the export flow uses,
+    // falling back to one chapter if none are found.
+    const chapters = story.content
+      .split(/\n(?=## )/)
+      .filter((c) => c.trim().length > 0)
+      .map((c, i) => {
+        const titleMatch = c.match(/^##\s*(.+)/);
+        return {
+          title: titleMatch ? titleMatch[1].trim() : `Chapter ${i + 1}`,
+          content: c.replace(/^##\s*.+\n?/, "").trim(),
+        };
+      });
+
+    if (chapters.length === 0) {
+      chapters.push({ title: story.title, content: story.content });
+    }
+
+    await runWithQuotaCleanup(guard, async () => {
+      const result = await generateReaderRoomFeedback(chapters, targetAudience, provider);
+      sendResponse(res, {
+        statusCode: httpStatus.OK,
+        success: true,
+        message: "Reader Room feedback generated.",
+        data: result,
+      });
+    });
+  })
+);
+
+
 
 export default router;

--- a/backend/src/services/ai.service.ts
+++ b/backend/src/services/ai.service.ts
@@ -259,7 +259,7 @@ export async function generateStory(
     }
   }
 
-  // ── Populate Cache Before Returning ────────────────────────────────
+  // ── Populate Cache Before Returning ────────────────────────────
   try {
     await StoryCache.create({
       promptKey: cacheKey,
@@ -272,4 +272,199 @@ export async function generateStory(
   }
 
   return finalResult;
+}
+
+// ─── Reader Room: multi-persona feedback ──────────────────────────────────
+
+export interface ReaderPersona {
+  name: string;
+  audienceType: string;
+  description: string;
+}
+
+export interface WeakSection {
+  chapterIndex: number;
+  chapterTitle: string;
+  issue: string;
+  rewriteSuggestion: string;
+}
+
+export interface ReaderRoomFeedback {
+  persona: ReaderPersona;
+  engagement: {
+    summary: string;
+    dropOffChapters: number[];
+    mostInvestedChapters: number[];
+  };
+  clarity: {
+    summary: string;
+    confusingMoments: string[];
+  };
+  emotionalImpact: {
+    summary: string;
+    highs: string[];
+    lows: string[];
+  };
+  pacing: {
+    summary: string;
+    tooSlowChapters: number[];
+    tooFastChapters: number[];
+  };
+  ending: {
+    satisfying: boolean;
+    summary: string;
+    unresolvedThreads: string[];
+  };
+  genreExpectations: {
+    metExpectations: string[];
+    missedOpportunities: string[];
+  };
+  overallScore: number; // 1-10
+}
+
+export interface EngagementTimelinePoint {
+  chapterIndex: number;
+  chapterTitle: string;
+  averageEngagementScore: number; // 1-10, averaged across personas
+  isPeak: boolean;
+  isLowPoint: boolean;
+}
+
+export interface ReaderRoomResult {
+  targetAudience: string;
+  personas: ReaderPersona[];
+  feedback: ReaderRoomFeedback[];
+  engagementTimeline: EngagementTimelinePoint[];
+  weakSections: WeakSection[];
+  overallSummary: string;
+  provider: "openai" | "gemini" | "anthropic";
+}
+
+const READER_ROOM_SYSTEM_PROMPT = `You are simulating a panel of distinct reader personas reviewing a story manuscript. You must respond with ONLY valid JSON matching the exact schema described in the user prompt — no prose, no markdown fences, no commentary outside the JSON object.`;
+
+function buildReaderRoomPrompt(
+  chapters: { title: string; content: string }[],
+  targetAudience: string
+): string {
+  const chapterList = chapters
+    .map((ch, i) => `--- Chapter ${i + 1}: ${ch.title} ---\n${ch.content}`)
+    .join("\n\n");
+
+  return `Target audience: ${targetAudience}
+
+Generate 3 to 5 distinct reader personas appropriate for this audience (e.g. for "YA Fantasy Readers": a worldbuilding purist, a romance-forward reader, a plot-twist hunter). Each persona reads the full story below and gives feedback.
+
+Respond with ONLY a JSON object matching this exact shape:
+{
+  "personas": [{ "name": string, "audienceType": string, "description": string }],
+  "feedback": [{
+    "persona": { "name": string, "audienceType": string, "description": string },
+    "engagement": { "summary": string, "dropOffChapters": number[], "mostInvestedChapters": number[] },
+    "clarity": { "summary": string, "confusingMoments": string[] },
+    "emotionalImpact": { "summary": string, "highs": string[], "lows": string[] },
+    "pacing": { "summary": string, "tooSlowChapters": number[], "tooFastChapters": number[] },
+    "ending": { "satisfying": boolean, "summary": string, "unresolvedThreads": string[] },
+    "genreExpectations": { "metExpectations": string[], "missedOpportunities": string[] },
+    "overallScore": number
+  }],
+  "weakSections": [{ "chapterIndex": number, "chapterTitle": string, "issue": string, "rewriteSuggestion": string }],
+  "overallSummary": string
+}
+
+Chapter indices are 0-based, matching the order below. "weakSections" should list every chapter that at least 2 personas flagged as a drop-off point, slow, or confusing, with one concrete rewrite suggestion each (a short paragraph the writer could use as a starting point, not a full rewrite of the chapter).
+
+STORY:
+${chapterList}`;
+}
+
+function buildEngagementTimeline(
+  chapters: { title: string }[],
+  feedback: ReaderRoomFeedback[]
+): EngagementTimelinePoint[] {
+  return chapters.map((chapter, index) => {
+    const scoresForChapter = feedback.map((f) => {
+      let score = 5;
+      if (f.engagement.mostInvestedChapters.includes(index)) score += 3;
+      if (f.engagement.dropOffChapters.includes(index)) score -= 3;
+      if (f.pacing.tooSlowChapters.includes(index)) score -= 1;
+      if (f.pacing.tooFastChapters.includes(index)) score -= 1;
+      return Math.max(1, Math.min(10, score));
+    });
+    const average =
+      scoresForChapter.reduce((sum, s) => sum + s, 0) / (scoresForChapter.length || 1);
+
+    return {
+      chapterIndex: index,
+      chapterTitle: chapter.title,
+      averageEngagementScore: Math.round(average * 10) / 10,
+      isPeak: average >= 7,
+      isLowPoint: average <= 4,
+    };
+  });
+}
+
+/**
+ * Generates multi-persona reader feedback for a story. Reuses the same
+ * provider clients and fallback pattern as generateStory() — tries the
+ * requested provider, falls back to Gemini on retryable failures.
+ */
+export async function generateReaderRoomFeedback(
+  chapters: { title: string; content: string }[],
+  targetAudience: string,
+  provider?: string
+): Promise<ReaderRoomResult> {
+  assertAIProviderConfigured();
+
+  if (!chapters.length) {
+    throw new Error("Story has no chapters to review.");
+  }
+
+  const userPrompt = buildReaderRoomPrompt(chapters, targetAudience);
+  const chosenProvider = provider?.toLowerCase();
+
+  let rawJson: string;
+  let usedProvider: "openai" | "gemini" | "anthropic";
+
+  try {
+    if (chosenProvider === "anthropic" || chosenProvider === "claude") {
+      rawJson = await generateWithAnthropic(READER_ROOM_SYSTEM_PROMPT, userPrompt);
+      usedProvider = "anthropic";
+    } else if (chosenProvider === "gemini") {
+      rawJson = await generateWithGemini(READER_ROOM_SYSTEM_PROMPT, userPrompt);
+      usedProvider = "gemini";
+    } else {
+      rawJson = await generateWithOpenAI(READER_ROOM_SYSTEM_PROMPT, userPrompt);
+      usedProvider = "openai";
+    }
+  } catch (primaryError) {
+    console.warn(
+      "[Reader Room] Primary provider failed, falling back to Gemini:",
+      primaryError instanceof Error ? primaryError.message : primaryError
+    );
+    rawJson = await generateWithGemini(READER_ROOM_SYSTEM_PROMPT, userPrompt);
+    usedProvider = "gemini";
+  }
+
+  let parsed: {
+    personas: ReaderPersona[];
+    feedback: ReaderRoomFeedback[];
+    weakSections: WeakSection[];
+    overallSummary: string;
+  };
+
+  try {
+    parsed = JSON.parse(rawJson);
+  } catch {
+    throw new Error("Reader Room AI response was not valid JSON. Please try again.");
+  }
+
+  return {
+    targetAudience,
+    personas: parsed.personas,
+    feedback: parsed.feedback,
+    weakSections: parsed.weakSections,
+    engagementTimeline: buildEngagementTimeline(chapters, parsed.feedback),
+    overallSummary: parsed.overallSummary,
+    provider: usedProvider,
+  };
 }

--- a/frontend/src/components/reader-room/ReaderRoomModal.tsx
+++ b/frontend/src/components/reader-room/ReaderRoomModal.tsx
@@ -1,0 +1,199 @@
+import { useState } from "react";
+import api from "../../services/api";
+import logger from "../../utils/logger.util";
+
+interface ReaderRoomModalProps {
+  storyId: string;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const AUDIENCES = [
+  "YA Fantasy Readers",
+  "Romance Fans",
+  "Thriller Readers",
+  "Mystery Enthusiasts",
+  "Sci-Fi Readers",
+  "General Fiction Readers",
+];
+
+interface ReaderRoomResult {
+  targetAudience: string;
+  personas: { name: string; audienceType: string; description: string }[];
+  feedback: any[];
+  engagementTimeline: {
+    chapterIndex: number;
+    chapterTitle: string;
+    averageEngagementScore: number;
+    isPeak: boolean;
+    isLowPoint: boolean;
+  }[];
+  weakSections: {
+    chapterIndex: number;
+    chapterTitle: string;
+    issue: string;
+    rewriteSuggestion: string;
+  }[];
+  overallSummary: string;
+}
+
+const ReaderRoomModal = ({ storyId, isOpen, onClose }: ReaderRoomModalProps) => {
+  const [audience, setAudience] = useState(AUDIENCES[0]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<ReaderRoomResult | null>(null);
+  const [expandedSection, setExpandedSection] = useState<number | null>(null);
+
+  if (!isOpen) return null;
+
+  const runAnalysis = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await api.post(`/story/${storyId}/reader-room`, {
+        targetAudience: audience,
+      });
+      setResult(response.data.data);
+    } catch (err) {
+      logger.error("Reader Room analysis failed:", err);
+      setError("Couldn't generate feedback right now. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4" onClick={onClose}>
+      <div
+        className="w-full max-w-2xl max-h-[85vh] overflow-y-auto rounded-2xl border border-zinc-800 bg-zinc-900 p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-bold text-white">📚 AI Reader Room</h2>
+          <button onClick={onClose} className="text-slate-400 hover:text-white text-xl leading-none cursor-pointer">
+            &times;
+          </button>
+        </div>
+
+        {!result && (
+          <>
+            <p className="text-sm text-slate-400 mb-4">
+              Get private feedback from simulated reader personas before you publish.
+            </p>
+            <label className="block text-xs text-slate-400 mb-1">Target audience</label>
+            <select
+              value={audience}
+              onChange={(e) => setAudience(e.target.value)}
+              className="w-full bg-zinc-800 text-white text-sm rounded px-3 py-2 border border-zinc-700 mb-4"
+            >
+              {AUDIENCES.map((a) => (
+                <option key={a} value={a}>{a}</option>
+              ))}
+            </select>
+
+            {error && <p className="text-sm text-rose-400 mb-3" role="alert">{error}</p>}
+
+            <button
+              onClick={runAnalysis}
+              disabled={loading}
+              className="w-full bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-lg py-2.5 font-semibold cursor-pointer transition"
+            >
+              {loading ? "Gathering reader feedback…" : "Run Reader Room"}
+            </button>
+          </>
+        )}
+
+        {result && (
+          <div className="space-y-6">
+            <p className="text-sm text-slate-300">{result.overallSummary}</p>
+
+            <div>
+              <h3 className="text-white font-bold text-sm mb-2">📈 Engagement Timeline</h3>
+              <div className="flex items-end gap-1 h-24 bg-zinc-950 rounded-lg p-3 border border-zinc-800">
+                {result.engagementTimeline.map((point) => (
+                  <div
+                    key={point.chapterIndex}
+                    className="flex-1 flex flex-col items-center justify-end gap-1"
+                    title={`${point.chapterTitle}: ${point.averageEngagementScore}/10`}
+                  >
+                    <div
+                      className={`w-full rounded-t ${
+                        point.isPeak
+                          ? "bg-emerald-500"
+                          : point.isLowPoint
+                          ? "bg-rose-500"
+                          : "bg-indigo-500"
+                      }`}
+                      style={{ height: `${point.averageEngagementScore * 8}px` }}
+                    />
+                    <span className="text-[10px] text-slate-500">{point.chapterIndex + 1}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {result.weakSections.length > 0 && (
+              <div>
+                <h3 className="text-white font-bold text-sm mb-2">🔍 Weak Sections</h3>
+                <div className="space-y-2">
+                  {result.weakSections.map((section) => (
+                    <div key={section.chapterIndex} className="rounded-lg border border-zinc-800 bg-zinc-950 p-3">
+                      <button
+                        onClick={() =>
+                          setExpandedSection(
+                            expandedSection === section.chapterIndex ? null : section.chapterIndex
+                          )
+                        }
+                        className="w-full text-left flex items-center justify-between cursor-pointer"
+                      >
+                        <span className="text-sm text-white font-medium">
+                          {section.chapterTitle}
+                        </span>
+                        <span className="text-xs text-slate-500">
+                          {expandedSection === section.chapterIndex ? "▲" : "▼"}
+                        </span>
+                      </button>
+                      {expandedSection === section.chapterIndex && (
+                        <div className="mt-2 text-xs text-slate-400 space-y-2">
+                          <p><span className="text-rose-400 font-semibold">Issue: </span>{section.issue}</p>
+                          <p><span className="text-emerald-400 font-semibold">Suggestion: </span>{section.rewriteSuggestion}</p>
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div>
+              <h3 className="text-white font-bold text-sm mb-2">
+                👥 Reader Personas ({result.personas.length})
+              </h3>
+              <div className="grid grid-cols-1 gap-3">
+                {result.feedback.map((f, i) => (
+                  <div key={i} className="rounded-lg border border-zinc-800 bg-zinc-950 p-3">
+                    <div className="flex items-center justify-between mb-1">
+                      <span className="text-sm font-semibold text-white">{f.persona.name}</span>
+                      <span className="text-xs text-indigo-400">{f.overallScore}/10</span>
+                    </div>
+                    <p className="text-xs text-slate-500 mb-2">{f.persona.description}</p>
+                    <p className="text-xs text-slate-400">{f.engagement.summary}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <button
+              onClick={() => setResult(null)}
+              className="w-full bg-zinc-800 hover:bg-zinc-700 text-white rounded-lg py-2 text-sm cursor-pointer transition"
+            >
+              Run again with a different audience
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ReaderRoomModal;

--- a/frontend/src/utils/logger.util.ts
+++ b/frontend/src/utils/logger.util.ts
@@ -1,0 +1,18 @@
+const isDev = import.meta.env.DEV;
+
+const logger = {
+  debug: (...args: unknown[]) => {
+    if (isDev) console.log(...args);
+  },
+  info: (...args: unknown[]) => {
+    if (isDev) console.info(...args);
+  },
+  warn: (...args: unknown[]) => {
+    console.warn(...args);
+  },
+  error: (...args: unknown[]) => {
+    console.error(...args);
+  },
+};
+
+export default logger;


### PR DESCRIPTION
## Description

Implements #5253 — writers can now select a target audience and get private feedback from 3–5 simulated AI reader personas before publishing, covering engagement, pacing, clarity, emotional impact, ending quality, and genre expectations, plus a visual engagement timeline and rewrite suggestions for flagged weak sections.

## Changes Made

- `backend/src/services/ai.service.ts` — added `generateReaderRoomFeedback()`, reusing the same provider clients and fallback pattern as `generateStory()`.
- `backend/src/routes/story.routes.ts` — added `POST /story/:id/reader-room`, quota- and rate-limit-protected like other AI endpoints.
- `frontend/src/components/reader-room/ReaderRoomModal.tsx` *(new)* — audience picker, persona feedback cards, engagement timeline bar chart, expandable weak-section rewrite suggestions.
- `frontend/src/utils/logger.util.ts` — recreated (had gone missing locally).

## Known scope limits (flagged honestly)

- **`Post.content` is a single string, not a real `chapters[]` array.** The route splits on `## Heading` markers as a best-effort proxy for chapters. Stories not written with those headers get treated as one long chapter, reducing feedback granularity.
- **"Real community beta readers" replacing AI personas** (mentioned in the issue as a future direction) is not built — that needs invites, roles, and a review-request workflow, which is a substantially larger, separate feature.

## How to test

1. Open a story you own, click "Reader Room," pick a target audience, run the analysis.
2. Confirm 3–5 personas render with distinct feedback.
3. Confirm the engagement timeline renders one bar per detected chapter.
4. Click a weak section to expand its issue + rewrite suggestion.
5. Confirm the endpoint respects the existing quota/rate-limit middleware (same as `/generate`).

Closes #5253

## Checklist

- [x] PR title follows Conventional Commits (`feat: add AI Reader Room for story playtesting and feedback`)
- [x] Linked the issue this PR closes (Closes #5253)
- [x] Tested locally (`npm run dev` after setting up `.env` files)
- [ ] Added/updated tests