### PR TITLE
fix : added try-catch around JSON.parse in useAccessibility hook

### DIFF
--- a/frontend/src/hooks/useAccessibility.js
+++ b/frontend/src/hooks/useAccessibility.js
@@ -7,7 +7,13 @@ export const useAccessibility = () => {
   useEffect(() => {
     if (typeof window === 'undefined') return;
     const saved = localStorage.getItem('accessibility-contrast');
-    if (saved) setHighContrast(JSON.parse(saved));
+    if (saved) {
+      try {
+        setHighContrast(JSON.parse(saved));
+      } catch {
+        // Malformed JSON in localStorage - keep default false
+      }
+    }
   }, []);
 
   const toggle = (setter, key) => {


### PR DESCRIPTION
Closes #5770.

Summary of What Has Been Done:
Wrapped the JSON.parse call in useAccessibility.js in a try-catch block. Previously, if localStorage contained malformed JSON (e.g., the literal string 'true' instead of boolean true), JSON.parse would throw and crash the hook. This is the same bug that was already fixed in the TypeScript version of this hook in PR #5759.

Changes Made:
- frontend/src/hooks/useAccessibility.js: Wrapped JSON.parse(saved) in try-catch; if parsing fails, the hook keeps the default false state

Impact it Made:
- Prevents runtime crashes when localStorage contains unexpected data
- Consistent error handling between JS and TS versions of the hook

Note: Please assign this PR to the `tmdeveloper007` account.