### PR TITLE
test : added unit tests for DisabledRedisClient in redis.client utility

### DIFF
--- a/backend/src/app/utils/__tests__/redis.client.test.ts
+++ b/backend/src/app/utils/__tests__/redis.client.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Test the DisabledRedisClient fallback class.
+ * When REDIS_URL is not set, the module exports a DisabledRedisClient
+ * that gracefully degrades instead of crashing.
+ */
+
+// Mock process.env before importing redis.client
+const originalEnv = process.env;
+beforeEach(() => {
+  jest.resetModules();
+  process.env = { ...originalEnv, REDIS_URL: "" };
+});
+
+afterAll(() => {
+  process.env = originalEnv;
+});
+
+describe("DisabledRedisClient", () => {
+  it("returns null on get()", async () => {
+    const { default: redis } = await import("../redis.client");
+    const result = await redis.get("any-key");
+    expect(result).toBeNull();
+  });
+
+  it("returns 'OK' on set()", async () => {
+    const { default: redis } = await import("../redis.client");
+    const result = await redis.set("key", "value");
+    expect(result).toBe("OK");
+  });
+
+  it("returns 0 on del()", async () => {
+    const { default: redis } = await import("../redis.client");
+    const result = await redis.del("any-key");
+    expect(result).toBe(0);
+  });
+
+  it("returns 0 on incrby()", async () => {
+    const { default: redis } = await import("../redis.client");
+    const result = await redis.incrby("counter", 1);
+    expect(result).toBe(0);
+  });
+
+  it("returns 0 on expire()", async () => {
+    const { default: redis } = await import("../redis.client");
+    const result = await redis.expire("key", 60);
+    expect(result).toBe(0);
+  });
+
+  it("on() returns this for chainability", async () => {
+    const { default: redis } = await import("../redis.client");
+    const result = redis.on("ready", () => {});
+    expect(result).toBe(redis);
+  });
+
+  it("status is 'end' indicating disabled state", async () => {
+    const { default: redis } = await import("../redis.client");
+    expect(redis.status).toBe("end");
+  });
+});


### PR DESCRIPTION
Closes #5772.

Summary of What Has Been Done:
Created unit tests for the DisabledRedisClient fallback class in redis.client.ts. The tests verify that the fallback gracefully degrades when Redis is unavailable, returning safe default values for all Redis operations.

Changes Made:
- backend/src/app/utils/__tests__/redis.client.test.ts: New test file with 7 test cases covering get, set, del, incrby, expire, on(), and status

Impact it Made:
- Tests a critical fault-tolerance path in the caching layer
- Ensures graceful degradation when Redis is unavailable

Note: Please assign this PR to the `tmdeveloper007` account.