### PR TITLE
fix: invalidate analysis results on text change in StoryConsistencyGuardian

### DIFF
--- a/frontend/src/components/story-consistency/StoryConsistencyGuardian.tsx
+++ b/frontend/src/components/story-consistency/StoryConsistencyGuardian.tsx
@@ -160,7 +160,15 @@ export default function StoryConsistencyGuardian() {
           <label className="text-sm font-semibold text-white/70">Your Story Text</label>
           <textarea
             value={storyText}
-            onChange={(e) => setStoryText(e.target.value)}
+            onChange={(e) => {
+              setStoryText(e.target.value);
+              // Invalidate results whenever the story text changes —
+              // prevents stale analysis results being shown for edited content
+              setResult(null);
+              setFactResult(null);
+              setError("");
+              setFactError("");
+            }}
             rows={10}
             placeholder="Paste your story here (chapters, scenes, full text)..."
             className="w-full bg-white/5 border border-white/10 rounded-xl px-4 py-3 text-sm text-white placeholder-white/30 focus:outline-none focus:ring-2 focus:ring-indigo-500 resize-none"
@@ -325,4 +333,4 @@ export default function StoryConsistencyGuardian() {
       </div>
     </div>
   );
-}
+}


### PR DESCRIPTION
### Description
Adds `setResult(null)`, `setFactResult(null)`, `setError("")`, and
`setFactError("")` to the textarea's `onChange` handler. Any edit to
the story text immediately clears both tab results, ensuring that
displayed analysis always corresponds to the current input. Users
must re-run the analysis after editing, preventing false confidence
from stale results.

### Related Issues
Closes #5779 