### PR TITLE
fix: move blink keyframe injection out of JSX render in AIWritingAssistant

### DIFF
--- a/frontend/src/components/writing-assistant/writing_assistant.component.tsx
+++ b/frontend/src/components/writing-assistant/writing_assistant.component.tsx
@@ -65,6 +65,17 @@ const demoLines = [
   "He remembered the fire, but not how it started.",
 ];
 
+// Keyframe injected once at module level — not inside render
+const blinkStyleSheet = typeof document !== "undefined" && (() => {
+  const existing = document.getElementById("blink-keyframe");
+  if (!existing) {
+    const s = document.createElement("style");
+    s.id = "blink-keyframe";
+    s.textContent = "@keyframes blink { 0%,100%{opacity:1} 50%{opacity:0} }";
+    document.head.appendChild(s);
+  }
+})();
+
 export default function AIWritingAssistant() {
   const [typedText, setTypedText] = useState("");
   const [lineIdx, setLineIdx] = useState(0);
@@ -205,7 +216,6 @@ export default function AIWritingAssistant() {
               animation: "blink 1s step-end infinite",
             }}
           />
-          <style>{`@keyframes blink { 0%,100%{opacity:1} 50%{opacity:0} }`}</style>
         </div>
 
         <div style={{ display: "flex", gap: "1rem", flexWrap: "wrap", justifyContent: "center" }}>


### PR DESCRIPTION
### Description
Removes the `<style>` tag from the component JSX return. Injects the
`@keyframes blink` rule once into `document.head` at module load time
using a guarded `getElementById` check to prevent duplication. This
runs once per page, not once per render.

### Related Issues
Closes #5809