### PR TITLE
fix : added missing closing brace to truncateText utility

### DIFF
--- a/frontend/src/utils/truncateText.ts
+++ b/frontend/src/utils/truncateText.ts
@@ -33,3 +33,4 @@ export const truncateText = (
   }
 
   return truncated + suffix;
+}


### PR DESCRIPTION
Closes #5815.

Summary of What Has Been Done:
Fixed the missing closing brace in the truncateText utility function in frontend/src/utils/truncateText.ts. The function body was incomplete without the final closing brace, which would cause a syntax error at runtime.

Changes Made:
- frontend/src/utils/truncateText.ts: Added the missing closing brace at the end of the truncateText function.

Impact it Made:
- Fixes a runtime JavaScript syntax error that would prevent the module from loading correctly.
- Verified with eslint and tsc type-checking.