### PR TITLE
fix : added try-catch around JSON.parse in useAccessibility hook

### DIFF
--- a/frontend/src/hooks/useAccessibility.js
+++ b/frontend/src/hooks/useAccessibility.js
@@ -7,7 +7,13 @@ export const useAccessibility = () => {
   useEffect(() => {
     if (typeof window === 'undefined') return;
     const saved = localStorage.getItem('accessibility-contrast');
-    if (saved) setHighContrast(JSON.parse(saved));
+    if (saved) {
+      try {
+        setHighContrast(JSON.parse(saved));
+      } catch {
+        // Invalid JSON in localStorage, default to false
+      }
+    }
   }, []);
 
   const toggle = (setter, key) => {


### PR DESCRIPTION
Closes #5816.

Summary of What Has Been Done:
Wrapped the JSON.parse call in the useAccessibility hook with a try-catch block. Previously, if localStorage contained invalid JSON, this would throw an unhandled exception. Now it gracefully defaults to false.

Changes Made:
- frontend/src/hooks/useAccessibility.js: Wrapped JSON.parse in a try-catch block with a no-op catch handler.

Impact it Made:
- Prevents runtime crashes when localStorage contains corrupted accessibility preference data.
- Makes the hook resilient to malformed JSON input.