### PR TITLE
test : added unit tests for socket-url helper

### DIFF
--- a/frontend/src/helpers/__tests__/socket-url.test.ts
+++ b/frontend/src/helpers/__tests__/socket-url.test.ts
@@ -1,5 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { vi } from "vitest";
 
 describe("resolveSocketUrl", () => {
   beforeEach(() => {
@@ -9,7 +8,7 @@ describe("resolveSocketUrl", () => {
   it("returns the VITE_SOCKET_URL value when it is set", async () => {
     const url = "http://localhost:5000";
     vi.stubEnv("VITE_SOCKET_URL", url);
-    vi.stubEnv("DEV", "false");
+    vi.stubEnv("DEV", false);
 
     const mod = await import("../socket-url");
     expect(mod.resolveSocketUrl()).toBe(url);
@@ -17,7 +16,7 @@ describe("resolveSocketUrl", () => {
 
   it("returns empty string when VITE_SOCKET_URL is not set in production", async () => {
     vi.stubEnv("VITE_SOCKET_URL", "");
-    vi.stubEnv("DEV", "false");
+    vi.stubEnv("DEV", false);
 
     const mod = await import("../socket-url");
     expect(mod.resolveSocketUrl()).toBe("");
@@ -25,7 +24,7 @@ describe("resolveSocketUrl", () => {
 
   it("returns empty string when VITE_SOCKET_URL is undefined in production", async () => {
     vi.stubEnv("VITE_SOCKET_URL", undefined);
-    vi.stubEnv("DEV", "false");
+    vi.stubEnv("DEV", false);
 
     const mod = await import("../socket-url");
     expect(mod.resolveSocketUrl()).toBe("");

--- a/frontend/src/helpers/__tests__/socket-url.test.ts
+++ b/frontend/src/helpers/__tests__/socket-url.test.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest/globals" />
 import { vi } from "vitest";
 
 describe("resolveSocketUrl", () => {

--- a/frontend/src/helpers/__tests__/socket-url.test.ts
+++ b/frontend/src/helpers/__tests__/socket-url.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+describe("resolveSocketUrl", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("returns the VITE_SOCKET_URL value when it is set", async () => {
+    const url = "http://localhost:5000";
+    vi.stubEnv("VITE_SOCKET_URL", url);
+    vi.stubEnv("DEV", "false");
+
+    const mod = await import("../socket-url");
+    expect(mod.resolveSocketUrl()).toBe(url);
+  });
+
+  it("returns empty string when VITE_SOCKET_URL is not set in production", async () => {
+    vi.stubEnv("VITE_SOCKET_URL", "");
+    vi.stubEnv("DEV", "false");
+
+    const mod = await import("../socket-url");
+    expect(mod.resolveSocketUrl()).toBe("");
+  });
+
+  it("returns empty string when VITE_SOCKET_URL is undefined in production", async () => {
+    vi.stubEnv("VITE_SOCKET_URL", undefined);
+    vi.stubEnv("DEV", "false");
+
+    const mod = await import("../socket-url");
+    expect(mod.resolveSocketUrl()).toBe("");
+  });
+});


### PR DESCRIPTION
Closes #5817.

Summary of What Has Been Done:
Added unit tests for the resolveSocketUrl function in frontend/src/helpers/socket-url.ts. The tests cover: returning the configured VITE_SOCKET_URL value when set, returning an empty string when not set in production, and returning an empty string when undefined in production.

Changes Made:
- frontend/src/helpers/__tests__/socket-url.test.ts: Created new test file with 3 test cases using vitest.

Impact it Made:
- Adds test coverage for a previously untested helper.
- Verified with vitest (3/3 tests passing).