### PR TITLE
test : added unit tests for config helper

### DIFF
--- a/frontend/src/helpers/__tests__/config.test.ts
+++ b/frontend/src/helpers/__tests__/config.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+/// <reference types="vitest/globals" />
+import { vi } from "vitest";
 
 describe("config helpers", () => {
   beforeEach(() => {

--- a/frontend/src/helpers/__tests__/config.test.ts
+++ b/frontend/src/helpers/__tests__/config.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+describe("config helpers", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("API_V1 is constructed from API_BASE and /api/v1 suffix", async () => {
+    vi.stubEnv("VITE_BASE_URL", "http://localhost:5000");
+    const { API_V1 } = await import("../config");
+    expect(API_V1).toBe("http://localhost:5000/api/v1");
+  });
+
+  it("API_BASE strips trailing slash from VITE_BASE_URL", async () => {
+    vi.stubEnv("VITE_BASE_URL", "http://localhost:5000/");
+    const { API_BASE } = await import("../config");
+    expect(API_BASE).toBe("http://localhost:5000");
+  });
+
+  it("getBaseUrl returns the API_BASE value", async () => {
+    vi.stubEnv("VITE_BASE_URL", "http://localhost:5000/");
+    const { getBaseUrl } = await import("../config");
+    expect(getBaseUrl()).toBe("http://localhost:5000");
+  });
+
+  it("getBaseUrl returns empty string when VITE_BASE_URL is empty", async () => {
+    vi.stubEnv("VITE_BASE_URL", "");
+    const { getBaseUrl } = await import("../config");
+    expect(getBaseUrl()).toBe("");
+  });
+
+  it("API_V1 is empty string when VITE_BASE_URL is empty", async () => {
+    vi.stubEnv("VITE_BASE_URL", "");
+    const { API_V1 } = await import("../config");
+    expect(API_V1).toBe("/api/v1");
+  });
+});


### PR DESCRIPTION
Closes #5818.

Summary of What Has Been Done:
Added unit tests for the getBaseUrl function and API_BASE/API_V1 constants in frontend/src/helpers/config.ts. Tests cover URL normalization (trailing slash removal), correct path construction for API_V1, and behavior when VITE_BASE_URL is empty.

Changes Made:
- frontend/src/helpers/__tests__/config.test.ts: Created new test file with 5 test cases using vitest.

Impact it Made:
- Adds test coverage for a previously untested helper.
- Verified with vitest (5/5 tests passing).