### PR TITLE
test : added unit tests for consumeRateLimit and consumeTokenQuota

### DIFF
--- a/backend/src/__tests__/rateLimitStore.test.ts
+++ b/backend/src/__tests__/rateLimitStore.test.ts
@@ -65,6 +65,73 @@ describe("consumeRateLimit", () => {
     );
   });
 
+  it("allows a request within the rate limit window", async () => {
+    const now = new Date();
+    mockFindOneAndUpdate.mockResolvedValueOnce({
+      key: "login_127.0.0.1",
+      count: 3,
+      firstRequestAt: now,
+      blockedUntil: null,
+      expireAt: new Date(now.getTime() + 16 * 60 * 1000),
+    });
+
+    const result = await consumeRateLimit({
+      key: "login_127.0.0.1",
+      windowMs: 15 * 60 * 1000,
+      maxRequests: 10,
+      blockTimeMs: 15 * 60 * 1000,
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(result.retryAfterSec).toBe(0);
+    expect(result.remaining).toBe(7);
+  });
+
+  it("blocks a request that exceeds the rate limit", async () => {
+    const now = new Date();
+    mockFindOneAndUpdate.mockResolvedValueOnce({
+      key: "login_127.0.0.1",
+      count: 11,
+      firstRequestAt: now,
+      blockedUntil: new Date(now.getTime() + 15 * 60 * 1000),
+      expireAt: new Date(now.getTime() + 16 * 60 * 1000),
+    });
+
+    const result = await consumeRateLimit({
+      key: "login_127.0.0.1",
+      windowMs: 15 * 60 * 1000,
+      maxRequests: 10,
+      blockTimeMs: 15 * 60 * 1000,
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.retryAfterSec).toBeGreaterThan(0);
+    expect(result.remaining).toBe(0);
+  });
+
+  it("blocks a request when already in the block window", async () => {
+    const now = new Date();
+    const blockUntil = new Date(now.getTime() + 5 * 60 * 1000);
+    mockFindOneAndUpdate.mockResolvedValueOnce({
+      key: "login_127.0.0.1",
+      count: 15,
+      firstRequestAt: now,
+      blockedUntil: blockUntil,
+      expireAt: new Date(now.getTime() + 16 * 60 * 1000),
+    });
+
+    const result = await consumeRateLimit({
+      key: "login_127.0.0.1",
+      windowMs: 15 * 60 * 1000,
+      maxRequests: 10,
+      blockTimeMs: 15 * 60 * 1000,
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.retryAfterSec).toBeGreaterThan(0);
+    expect(result.remaining).toBe(0);
+  });
+
   it("falls back to allowing token quota checks when Redis is not ready", async () => {
     const result = await consumeTokenQuota("user-123", 2, 10);
 
@@ -76,5 +143,53 @@ describe("consumeRateLimit", () => {
     expect(mockRedisClient.get).not.toHaveBeenCalled();
     expect(mockRedisClient.incrby).not.toHaveBeenCalled();
     expect(mockRedisClient.expire).not.toHaveBeenCalled();
+  });
+});
+
+describe("consumeTokenQuota with Redis ready", () => {
+  beforeEach(() => {
+    mockRedisClient.status = "ready";
+    mockRedisClient.get.mockReset();
+    mockRedisClient.incrby.mockReset();
+    mockRedisClient.expire.mockReset();
+  });
+
+  it("allows a request within the token quota", async () => {
+    mockRedisClient.get.mockResolvedValueOnce("3");
+
+    const result = await consumeTokenQuota("user-123", 2, 10);
+
+    expect(result.allowed).toBe(true);
+    expect(result.remainingTokens).toBe(5);
+    expect(result.retryAfterSec).toBe(0);
+    expect(mockRedisClient.incrby).toHaveBeenCalledWith(
+      expect.stringContaining("token_quota:user-123:"),
+      2
+    );
+    expect(mockRedisClient.expire).toHaveBeenCalledWith(
+      expect.stringContaining("token_quota:user-123:"),
+      48 * 60 * 60
+    );
+  });
+
+  it("blocks a request that would exceed the token quota", async () => {
+    mockRedisClient.get.mockResolvedValueOnce("9");
+
+    const result = await consumeTokenQuota("user-123", 2, 10);
+
+    expect(result.allowed).toBe(false);
+    expect(result.remainingTokens).toBe(1);
+    expect(result.retryAfterSec).toBeGreaterThan(0);
+    expect(mockRedisClient.incrby).not.toHaveBeenCalled();
+  });
+
+  it("fails closed on Redis error", async () => {
+    mockRedisClient.get.mockRejectedValueOnce(new Error("Redis connection refused"));
+
+    const result = await consumeTokenQuota("user-123", 2, 10);
+
+    expect(result.allowed).toBe(false);
+    expect(result.remainingTokens).toBe(0);
+    expect(result.retryAfterSec).toBe(60);
   });
 });


### PR DESCRIPTION
Closes #5819.

Summary of What Has Been Done:
Added comprehensive unit tests for the consumeRateLimit and consumeTokenQuota functions in backend/src/app/middleware/rate_limit.store.ts. The test file was extended with tests covering: allowed requests within the rate limit window, blocked requests when limit is exceeded, blocked requests when already in the block window, token quota allowance when Redis is unavailable, allowed requests within token quota with Redis, blocked requests exceeding token quota, and fail-closed behavior on Redis errors.

Changes Made:
- backend/src/__tests__/rateLimitStore.test.ts: Extended the existing test file with 6 additional test cases (8 total).

Impact it Made:
- Adds test coverage for previously untested rate limiting and token quota logic.
- Verified with jest (8/8 tests passing).