### PR TITLE
feat: add cursor style picker (Off/Sparkle/Glow Orb/Trail)

### DIFF
--- a/frontend/src/components/hero/nav_list.component.tsx
+++ b/frontend/src/components/hero/nav_list.component.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Link, NavLink } from "react-router-dom";
 import { isLoggedIn, removeUserInfo } from "../../services/auth.service";
 import ThemeToggle from "../theme/theme_toggle.component";
+import CursorStylePicker from "../theme/cursor_style_picker.component";
 import { ArrowRight, Sparkles } from "lucide-react";
 import { AnimatePresence, motion } from "framer-motion";
 import { useNavigate, useLocation } from "react-router-dom";
@@ -157,6 +158,7 @@ return (
       </nav>
 
       <div className="flex items-center gap-3">
+        <CursorStylePicker />
         <ThemeToggle />
         {loggedIn ? (
           <button

--- a/frontend/src/components/magic-cursor/magic_cursor.component.tsx
+++ b/frontend/src/components/magic-cursor/magic_cursor.component.tsx
@@ -12,8 +12,11 @@ type Sparkle = {
 const MAX_SPARKLES = 9;
 const SPARKLE_LIFETIME = 760;
 
+const MAX_TRAIL_PARTICLES = 14;
+const TRAIL_PARTICLE_LIFETIME = 420;
+
 const MagicCursorComponent = () => {
-  const { glowEnabled } = useTheme();
+  const { cursorStyle } = useTheme();
   const [enabled, setEnabled] = useState(false);
   const [sparkles, setSparkles] = useState<Sparkle[]>([]);
   const cursorRef = useRef<HTMLDivElement | null>(null);
@@ -24,6 +27,10 @@ const MagicCursorComponent = () => {
   const nextSparkleId = useRef(1);
   const frameId = useRef<number | null>(null);
   const sparkleTimers = useRef<number[]>([]);
+
+  const showSparkles = cursorStyle === "sparkle";
+  const showTrail = cursorStyle === "trail";
+  const isPremiumGlow = cursorStyle === "glow-orb";
 
   useEffect(() => {
     const pointerQuery = window.matchMedia("(hover: hover) and (pointer: fine)");
@@ -44,7 +51,7 @@ const MagicCursorComponent = () => {
   }, []);
 
   useEffect(() => {
-    if (!enabled) {
+    if (!enabled || cursorStyle === "off") {
       if (frameId.current) {
         window.cancelAnimationFrame(frameId.current);
         frameId.current = null;
@@ -53,9 +60,9 @@ const MagicCursorComponent = () => {
       return;
     }
 
-    const addSparkle = (x: number, y: number) => {
+    const addParticle = (x: number, y: number, lifetime: number, cap: number) => {
       const id = nextSparkleId.current++;
-      const sparkle = {
+      const particle = {
         id,
         x,
         y,
@@ -63,46 +70,50 @@ const MagicCursorComponent = () => {
         delay: Math.random() * 90,
       };
 
-      setSparkles((items) => [...items.slice(-(MAX_SPARKLES - 1)), sparkle]);
+      setSparkles((items) => [...items.slice(-(cap - 1)), particle]);
 
       const timerId = window.setTimeout(() => {
         setSparkles((items) => items.filter((item) => item.id !== id));
         sparkleTimers.current = sparkleTimers.current.filter((timer) => timer !== timerId);
-      }, SPARKLE_LIFETIME);
+      }, lifetime);
 
       sparkleTimers.current.push(timerId);
     };
 
+    const addSparkle = (x: number, y: number) => addParticle(x, y, SPARKLE_LIFETIME, MAX_SPARKLES);
+    const addTrailParticle = (x: number, y: number) =>
+      addParticle(x, y, TRAIL_PARTICLE_LIFETIME, MAX_TRAIL_PARTICLES);
+
     const handlePointerMove = (event: PointerEvent) => {
-  const targetElement = event.target as HTMLElement;
+      const targetElement = event.target as HTMLElement;
 
-  const isTypingElement =
-    targetElement.tagName === "TEXTAREA" ||
-    targetElement.tagName === "INPUT" ||
-    targetElement.isContentEditable;
+      const isTypingElement =
+        targetElement.tagName === "TEXTAREA" ||
+        targetElement.tagName === "INPUT" ||
+        targetElement.isContentEditable;
 
-  if (isTypingElement) {
-    return;
-  }
+      if (isTypingElement) {
+        return;
+      }
 
-  target.current = { x: event.clientX, y: event.clientY };
+      target.current = { x: event.clientX, y: event.clientY };
 
-  const dx = event.clientX - lastSparkle.current.x;
-  const dy = event.clientY - lastSparkle.current.y;
-  const distance = Math.hypot(dx, dy);
-  const now = performance.now();
+      const dx = event.clientX - lastSparkle.current.x;
+      const dy = event.clientY - lastSparkle.current.y;
+      const distance = Math.hypot(dx, dy);
+      const now = performance.now();
 
-  if (distance > 30 && now - lastSparkle.current.time > 85) {
-    addSparkle(event.clientX, event.clientY);
-    lastSparkle.current = {
-      x: event.clientX,
-      y: event.clientY,
-      time: now,
+      if (showSparkles && distance > 30 && now - lastSparkle.current.time > 85) {
+        addSparkle(event.clientX, event.clientY);
+        lastSparkle.current = { x: event.clientX, y: event.clientY, time: now };
+      } else if (showTrail && distance > 12 && now - lastSparkle.current.time > 35) {
+        addTrailParticle(event.clientX, event.clientY);
+        lastSparkle.current = { x: event.clientX, y: event.clientY, time: now };
+      }
     };
-  }
-};
 
     const handlePointerDown = (event: PointerEvent) => {
+      if (!showSparkles) return;
       addSparkle(event.clientX - 8, event.clientY + 4);
       addSparkle(event.clientX + 7, event.clientY - 6);
     };
@@ -138,24 +149,27 @@ const MagicCursorComponent = () => {
       sparkleTimers.current.forEach((timerId) => window.clearTimeout(timerId));
       sparkleTimers.current = [];
     };
-  }, [enabled]);
+  }, [enabled, cursorStyle, showSparkles, showTrail]);
 
   const isInputFocused =
-  document.activeElement instanceof HTMLInputElement ||
-  document.activeElement instanceof HTMLTextAreaElement;
+    document.activeElement instanceof HTMLInputElement ||
+    document.activeElement instanceof HTMLTextAreaElement;
 
-  if (!enabled || isInputFocused || !glowEnabled) {
-  return null;
-}
+  if (!enabled || isInputFocused || cursorStyle === "off") {
+    return null;
+  }
 
   return (
     <div className="magic-cursor-layer" aria-hidden="true">
-      <div ref={glowRef} className="magic-cursor-glow" />
+      <div
+        ref={glowRef}
+        className={isPremiumGlow ? "magic-cursor-glow magic-cursor-glow-premium" : "magic-cursor-glow"}
+      />
       <div ref={cursorRef} className="magic-cursor-dot" />
       {sparkles.map((sparkle) => (
         <span
           key={sparkle.id}
-          className="magic-cursor-sparkle"
+          className={showTrail ? "magic-cursor-trail-particle" : "magic-cursor-sparkle"}
           style={{
             left: sparkle.x,
             top: sparkle.y,
@@ -166,7 +180,6 @@ const MagicCursorComponent = () => {
         />
       ))}
     </div>
-    
   );
 };
 

--- a/frontend/src/components/theme/cursor_style_picker.component.tsx
+++ b/frontend/src/components/theme/cursor_style_picker.component.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useRef, useState } from "react";
+import { MousePointer2, Sparkles, Wind, X } from "lucide-react";
+import { CURSOR_STYLES, useTheme, type CursorStyle } from "./theme.context";
+
+const STYLE_ICONS: Record<CursorStyle, typeof Sparkles> = {
+  off: X,
+  sparkle: Sparkles,
+  "glow-orb": MousePointer2,
+  trail: Wind,
+};
+
+const CursorStylePicker = () => {
+  const { cursorStyle, setCursorStyle } = useTheme();
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleEscape);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, [open]);
+
+  const ActiveIcon = STYLE_ICONS[cursorStyle];
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        className={`grid h-10 w-10 place-items-center rounded-full border transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/50 ${
+          cursorStyle !== "off"
+            ? "border-indigo-200 bg-indigo-50 text-indigo-600 shadow-sm dark:border-indigo-500/30 dark:bg-indigo-500/10 dark:text-indigo-400"
+            : "border-slate-200/80 bg-white/60 text-slate-400 hover:text-slate-600 dark:border-white/10 dark:bg-white/[0.06] dark:text-slate-500 dark:hover:text-slate-300"
+        }`}
+        title="Cursor style"
+        aria-label="Choose cursor style"
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        <ActiveIcon className="h-[18px] w-[18px]" strokeWidth={2.5} />
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 top-12 z-50 w-40 overflow-hidden rounded-2xl border border-slate-200/80 bg-white/95 py-1.5 shadow-xl shadow-slate-900/10 backdrop-blur-xl dark:border-white/10 dark:bg-slate-900/95"
+        >
+          {CURSOR_STYLES.map(({ value, label }) => {
+            const Icon = STYLE_ICONS[value];
+            const isActive = value === cursorStyle;
+            return (
+              <button
+                key={value}
+                type="button"
+                role="menuitemradio"
+                aria-checked={isActive}
+                onClick={() => {
+                  setCursorStyle(value);
+                  setOpen(false);
+                }}
+                className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm font-medium transition-colors ${
+                  isActive
+                    ? "bg-indigo-50 text-indigo-600 dark:bg-indigo-500/10 dark:text-indigo-400"
+                    : "text-slate-600 hover:bg-slate-50 dark:text-slate-300 dark:hover:bg-white/5"
+                }`}
+              >
+                <Icon className="h-4 w-4" strokeWidth={2.5} />
+                {label}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CursorStylePicker;

--- a/frontend/src/components/theme/theme.context.tsx
+++ b/frontend/src/components/theme/theme.context.tsx
@@ -2,11 +2,25 @@ import React, { createContext, useContext, useEffect, useMemo, useState } from "
 
 type Theme = "light" | "dark";
 
+export type CursorStyle = "off" | "sparkle" | "glow-orb" | "trail";
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const CURSOR_STYLES: { value: CursorStyle; label: string }[] = [
+  { value: "off", label: "Off" },
+  { value: "sparkle", label: "Sparkle" },
+  { value: "glow-orb", label: "Glow Orb" },
+  { value: "trail", label: "Trail" },
+];
+
 interface ThemeContextValue {
   theme: Theme;
   isDark: boolean;
   toggleTheme: () => void;
+  cursorStyle: CursorStyle;
+  setCursorStyle: (style: CursorStyle) => void;
+  /** @deprecated use cursorStyle instead. Kept for backward compatibility. */
   glowEnabled: boolean;
+  /** @deprecated use setCursorStyle instead. Toggles between "off" and "sparkle". */
   toggleGlow: () => void;
 }
 
@@ -25,18 +39,30 @@ const getInitialTheme = (): Theme => {
   return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
 };
 
-const getInitialGlow = (): boolean => {
+const VALID_CURSOR_STYLES: CursorStyle[] = ["off", "sparkle", "glow-orb", "trail"];
+
+const getInitialCursorStyle = (): CursorStyle => {
   if (typeof window === "undefined") {
-    return true;
+    return "sparkle";
   }
 
-  const storedGlow = localStorage.getItem("cursorGlow");
-  return storedGlow !== "false";
+  const stored = localStorage.getItem("cursorStyle");
+  if (stored && VALID_CURSOR_STYLES.includes(stored as CursorStyle)) {
+    return stored as CursorStyle;
+  }
+
+  // Migrate from the legacy boolean flag if present.
+  const legacyGlow = localStorage.getItem("cursorGlow");
+  if (legacyGlow === "false") {
+    return "off";
+  }
+
+  return "sparkle";
 };
 
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [theme, setTheme] = useState<Theme>(getInitialTheme);
-  const [glowEnabled, setGlowEnabled] = useState<boolean>(getInitialGlow);
+  const [cursorStyle, setCursorStyle] = useState<CursorStyle>(getInitialCursorStyle);
 
   useEffect(() => {
     const root = document.documentElement;
@@ -46,18 +72,22 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
   }, [theme]);
 
   useEffect(() => {
-    localStorage.setItem("cursorGlow", glowEnabled ? "true" : "false");
-  }, [glowEnabled]);
+    localStorage.setItem("cursorStyle", cursorStyle);
+    // Keep the legacy key in sync for any external code still reading it.
+    localStorage.setItem("cursorGlow", cursorStyle === "off" ? "false" : "true");
+  }, [cursorStyle]);
 
   const value = useMemo(
     () => ({
       theme,
       isDark: theme === "dark",
       toggleTheme: () => setTheme((prev) => (prev === "dark" ? "light" : "dark")),
-      glowEnabled,
-      toggleGlow: () => setGlowEnabled((prev) => !prev),
+      cursorStyle,
+      setCursorStyle,
+      glowEnabled: cursorStyle !== "off",
+      toggleGlow: () => setCursorStyle((prev) => (prev === "off" ? "sparkle" : "off")),
     }),
-    [theme, glowEnabled],
+    [theme, cursorStyle],
   );
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -359,6 +359,41 @@ html, body {
   opacity: 0.82;
 }
 
+.magic-cursor-glow-premium {
+  width: 96px;
+  height: 96px;
+  background: radial-gradient(
+    circle,
+    rgba(255, 255, 255, 0.55) 0%,
+    rgba(147, 197, 253, 0.55) 22%,
+    rgba(99, 102, 241, 0.28) 48%,
+    rgba(168, 85, 247, 0.1) 72%,
+    transparent 85%
+  );
+  filter: blur(2px);
+  opacity: 0.95;
+}
+
+.magic-cursor-trail-particle {
+  position: fixed;
+  border-radius: 9999px;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.9), rgba(147, 197, 253, 0.5) 55%, transparent 78%);
+  pointer-events: none;
+  transform: translate(-50%, -50%) scale(0.7);
+  animation: magic-trail-fade 420ms ease-out forwards;
+}
+
+@keyframes magic-trail-fade {
+  0% {
+    opacity: 0.75;
+    transform: translate(-50%, -50%) scale(0.9);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.2);
+  }
+}
+
 .magic-cursor-sparkle {
   position: fixed;
   border-radius: 9999px;
@@ -982,12 +1017,16 @@ html.dark body {
   .group:hover .motion-image,
   .magic-cursor-dot,
   .magic-cursor-glow,
-  .magic-cursor-sparkle {
+  .magic-cursor-glow-premium,
+  .magic-cursor-sparkle,
+  .magic-cursor-trail-particle {
     transform: none;
   }
   .magic-cursor-sparkle,
+  .magic-cursor-trail-particle,
   .magic-cursor-dot,
-  .magic-cursor-glow {
+  .magic-cursor-glow,
+  .magic-cursor-glow-premium {
     display: none;
   }
 }
@@ -1406,7 +1445,9 @@ html.dark .contact-input::placeholder { color: rgba(148, 163, 184, 0.78); }
   .group:hover .motion-image,
   .magic-cursor-dot,
   .magic-cursor-glow,
+  .magic-cursor-glow-premium,
   .magic-cursor-sparkle,
+  .magic-cursor-trail-particle,
   .contact-col-left,
   .contact-col-right,
   .contact-badge {
@@ -1416,8 +1457,10 @@ html.dark .contact-input::placeholder { color: rgba(148, 163, 184, 0.78); }
   }
   
   .magic-cursor-sparkle,
+  .magic-cursor-trail-particle,
   .magic-cursor-dot,
   .magic-cursor-glow,
+  .magic-cursor-glow-premium,
   .contact-form-glow-ring {
     display: none !important;
   }


### PR DESCRIPTION
## Before you open this PR
- **Issue:** Closes #5765 
- **Description:** filled in below
- **Screenshots:** N/A this time — see note in the Screenshot section below for why

## Screenshot (when helpful)
N/A. I wasn't able to get a local screenshot because `main` currently has
several pre-existing, unrelated syntax errors that block `npm run dev`
from starting at all — confirmed on a completely fresh clone with none of
my changes applied (errors in `App.tsx`, `CollabRoom.tsx`,
`stories.component.tsx`, `StoryWorkspace.tsx`, `theme_toggle.component.tsx`,
`useSpeechSynthesis.ts`). Happy to open a separate issue documenting these
if useful — none of them are touched by this PR.

In place of a screenshot, here's what I verified instead (see Checklist/testing note below): ESLint clean on every file this PR touches, a standalone TypeScript syntax check clean on the same files, and the test suite showing identical results before and after my changes (29 failed / 30 passed either way — confirming zero regressions from this PR specifically).

## What this PR does
Extends the existing Magic Cursor toggle into a 4-way style picker
(Off / Sparkle / Glow Orb / Trail), addressing the request for a more
premium glow effect while keeping the current Sparkle behavior unchanged.

- `theme.context.tsx` now tracks `cursorStyle` instead of a plain boolean,
  fully backward-compatible with the old `glowEnabled`/`toggleGlow` API
  (still work, now derived from the new state)
- `magic_cursor.component.tsx` branches its animation per style: Sparkle
  behaves exactly as before, Glow Orb shows a bigger/brighter glow with no
  sparkles, Trail spawns lightweight fading particles
- New `cursor_style_picker.component.tsx` dropdown, matching the existing
  button/icon styling conventions
- Mounted in `nav_list.component.tsx`, the actual live navbar, next to the
  existing theme toggle

## Type of change
- [x] New feature

## Related issue
Closes  #5765

## More screenshots (optional)
N/A — see note above.

## Checklist
- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes. (ESLint clean, standalone TS check clean, test suite unchanged before/after — see Screenshot section for details on why a live browser check wasn't possible)
- [x] I have done a self-review of the code.