### PR TITLE
feat: add story reading statistics widget

### DIFF
--- a/frontend/src/components/readingStats/ReadingStatsWidget.tsx
+++ b/frontend/src/components/readingStats/ReadingStatsWidget.tsx
@@ -1,0 +1,55 @@
+import useReadingStats from "../../hooks/useReadingStats";
+
+interface Props {
+  story: string;
+}
+
+export default function ReadingStatsWidget({
+  story,
+}: Props) {
+  const stats = useReadingStats(story);
+
+  return (
+    <div className="rounded-lg border p-5 shadow bg-white">
+
+      <h2 className="text-xl font-bold mb-4">
+        Reading Statistics
+      </h2>
+
+      <div className="grid grid-cols-2 gap-4">
+
+        <div>
+          <strong>Words</strong>
+          <p>{stats.words}</p>
+        </div>
+
+        <div>
+          <strong>Reading Time</strong>
+          <p>{stats.readingTime} min</p>
+        </div>
+
+        <div>
+          <strong>Paragraphs</strong>
+          <p>{stats.paragraphs}</p>
+        </div>
+
+        <div>
+          <strong>Chapters</strong>
+          <p>{stats.chapters}</p>
+        </div>
+
+        <div>
+          <strong>Sentences</strong>
+          <p>{stats.sentences}</p>
+        </div>
+
+        <div>
+          <strong>Average Sentence</strong>
+          <p>{stats.averageSentenceLength} words</p>
+        </div>
+
+      </div>
+
+    </div>
+  );
+}

--- a/frontend/src/hooks/useReadingStats.ts
+++ b/frontend/src/hooks/useReadingStats.ts
@@ -1,0 +1,8 @@
+import { useMemo } from "react";
+import { calculateReadingStats } from "../utils/readingStats";
+
+export default function useReadingStats(text: string) {
+  return useMemo(() => {
+    return calculateReadingStats(text);
+  }, [text]);
+}

--- a/frontend/src/utils/readingStats.ts
+++ b/frontend/src/utils/readingStats.ts
@@ -1,0 +1,42 @@
+export interface ReadingStats {
+  words: number;
+  paragraphs: number;
+  chapters: number;
+  sentences: number;
+  averageSentenceLength: number;
+  readingTime: number;
+}
+
+export function calculateReadingStats(text: string): ReadingStats {
+  const words = text.trim().split(/\s+/).filter(Boolean).length;
+
+  const paragraphs = text
+    .split(/\n\s*\n/)
+    .filter((p) => p.trim() !== "").length;
+
+  const chapters = Math.max(
+    1,
+    (text.match(/chapter/gi) || []).length
+  );
+
+  const sentences = text
+    .split(/[.!?]+/)
+    .filter((s) => s.trim()).length;
+
+  const averageSentenceLength =
+    sentences === 0 ? 0 : Math.round(words / sentences);
+
+  const readingTime = Math.max(
+    1,
+    Math.ceil(words / 200)
+  );
+
+  return {
+    words,
+    paragraphs,
+    chapters,
+    sentences,
+    averageSentenceLength,
+    readingTime,
+  };
+}


### PR DESCRIPTION
## Description

This PR introduces a **Story Reading Statistics Widget** that provides readers with useful information about a story before they begin reading.

### Features

- Display total word count
- Show estimated reading time
- Count paragraphs
- Count chapters
- Count sentences
- Calculate average sentence length
- Automatically update statistics after edits
- Responsive UI

### Acceptance Criteria

- [x] Display reading statistics
- [x] Update automatically after edits
- [x] Show estimated reading duration
- [x] Support responsive layouts

Closes #5789