### PR TITLE
test : added unit tests for clicheDetector utility

### DIFF
--- a/frontend/src/utils/__tests__/clicheDetector.test.ts
+++ b/frontend/src/utils/__tests__/clicheDetector.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { detectCliches } from "../clicheDetector";
+
+describe("detectCliches", () => {
+  it("returns an empty array for text with no cliches", () => {
+    const result = detectCliches(
+      "The hero set out on a grand adventure through the ancient forest."
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("detects the once upon a time cliche", () => {
+    const result = detectCliches("Once upon a time there lived a king.");
+    expect(result).toHaveLength(1);
+    expect(result[0].phrase).toBe("once upon a time");
+    expect(result[0].reason).toBeTruthy();
+    expect(result[0].suggestion).toBeTruthy();
+  });
+
+  it("detects the happily ever after cliche", () => {
+    const result = detectCliches("The couple lived happily ever after.");
+    expect(result).toHaveLength(1);
+    expect(result[0].phrase).toBe("happily ever after");
+  });
+
+  it("detects the chosen one cliche", () => {
+    const result = detectCliches("He was the chosen one, destined to save the world.");
+    expect(result).toHaveLength(1);
+    expect(result[0].phrase).toBe("chosen one");
+  });
+
+  it("detects the it was all a dream cliche", () => {
+    const result = detectCliches("In the end, it was all a dream.");
+    expect(result).toHaveLength(1);
+    expect(result[0].phrase).toBe("it was all a dream");
+  });
+
+  it("detects multiple cliches in the same text", () => {
+    const result = detectCliches(
+      "Once upon a time, he was the chosen one, and it was all a dream."
+    );
+    expect(result).toHaveLength(3);
+    const phrases = result.map((r) => r.phrase);
+    expect(phrases).toContain("once upon a time");
+    expect(phrases).toContain("chosen one");
+    expect(phrases).toContain("it was all a dream");
+  });
+
+  it("is case insensitive", () => {
+    const result = detectCliches("ONCE UPON A TIME there was a story.");
+    expect(result).toHaveLength(1);
+    expect(result[0].phrase).toBe("once upon a time");
+  });
+
+  it("returns non-empty suggestion and reason for each result", () => {
+    const result = detectCliches(
+      "Once upon a time, happily ever after."
+    );
+    expect(result).toHaveLength(2);
+    for (const cliche of result) {
+      expect(typeof cliche.reason).toBe("string");
+      expect(cliche.reason.length).toBeGreaterThan(0);
+      expect(typeof cliche.suggestion).toBe("string");
+      expect(cliche.suggestion.length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
Closes #5841.

Summary of What Has Been Done:
Added vitest unit tests for the detectCliches function in frontend/src/utils/clicheDetector.ts. Tests cover: text with no cliches, each individual cliche phrase, multiple cliches in the same text, case-insensitive detection, and verification that suggestion and reason fields are non-empty.

Changes Made:
- frontend/src/utils/__tests__/clicheDetector.test.ts: Added 8 test cases covering all cliche detection behavior.

Impact it Made:
- Increases test coverage for the cliche detection utility
- Verified: no lint or tsc errors