### PR TITLE
fix : added try-catch around JSON.parse in CharacterExplorer parseCharacters

### DIFF
--- a/frontend/src/components/stories/CharacterExplorer.tsx
+++ b/frontend/src/components/stories/CharacterExplorer.tsx
@@ -23,7 +23,12 @@ const getRoleColor = (role: string) =>
   roleColors[role] ?? "bg-slate-100 text-slate-800 dark:bg-slate-700 dark:text-slate-200";
 
 const parseCharacters = (value: unknown): Character[] => {
-  const parsed = typeof value === "string" ? JSON.parse(value) : value;
+  let parsed: unknown;
+  try {
+    parsed = typeof value === "string" ? JSON.parse(value) : value;
+  } catch {
+    return [];
+  }
   if (!Array.isArray(parsed)) return [];
 
   return parsed


### PR DESCRIPTION
Closes #5837.

Summary of What Has Been Done:
Wrapped the JSON.parse call inside the parseCharacters utility function with a try-catch block. On parse failure, the function returns an empty array instead of throwing an uncaught exception, allowing the CharacterExplorer component to degrade gracefully.

Changes Made:
- frontend/src/components/stories/CharacterExplorer.tsx: Added try-catch around JSON.parse in parseCharacters function.

Impact it Made:
- Prevents component crash on malformed character data
- Matches defensive coding pattern used in similar components
- Verified: no lint or tsc errors