### PR TITLE
fix : added try-catch around JSON.parse in WritingGoalTracker session stats

### DIFF
--- a/frontend/src/components/stories/WritingGoalTracker.tsx
+++ b/frontend/src/components/stories/WritingGoalTracker.tsx
@@ -24,9 +24,14 @@ const WritingGoalTracker: React.FC<WritingGoalTrackerProps> = ({ wordCount }) =>
         completedAt: new Date().toISOString(),
         sessionStart: sessionStart.toISOString(),
       };
-      const existing = JSON.parse(
-        localStorage.getItem("writingSessionStats") || "[]"
-      );
+      let existing: unknown[];
+      try {
+        existing = JSON.parse(
+          localStorage.getItem("writingSessionStats") || "[]"
+        );
+      } catch {
+        existing = [];
+      }
       localStorage.setItem(
         "writingSessionStats",
         JSON.stringify([...existing, stats])


### PR DESCRIPTION
Closes #5839.

Summary of What Has Been Done:
Wrapped the JSON.parse call in the WritingGoalTracker component with a try-catch block. On parse failure, it falls back to an empty array so the component continues to work with fresh session stats.

Changes Made:
- frontend/src/components/stories/WritingGoalTracker.tsx: Wrapped JSON.parse with try-catch. Falls back to empty array on error.

Impact it Made:
- Prevents runtime crash when localStorage contains corrupt session data
- Matches defensive coding pattern used elsewhere in the codebase
- Verified: no lint or tsc errors