### PR TITLE
fix: validate plot_holes response shape before access in PlotHoleAnalyzer

### DIFF
--- a/frontend/src/components/writing-assistant/PlotHoleAnalyzer.tsx
+++ b/frontend/src/components/writing-assistant/PlotHoleAnalyzer.tsx
@@ -35,9 +35,11 @@ export default function PlotHoleAnalyzer({ storyText }: PlotHoleAnalyzerProps) {
         storyText,
       });
 
-      if (response.data && response.data.success) {
-        setPlotHoles(response.data.data.plot_holes);
-        const count = response.data.data.plot_holes.length;
+      const plotHolesData = response.data?.data?.plot_holes;
+
+      if (response.data?.success && Array.isArray(plotHolesData)) {
+        setPlotHoles(plotHolesData);
+        const count = plotHolesData.length;
         if (count === 0) {
           toast.success("Brilliant! No logical consistency errors found.", { id: toastId });
         } else {


### PR DESCRIPTION
### Description
Extracts `response.data?.data?.plot_holes` with optional chaining and
guards with `Array.isArray()` before calling `.length` or `setPlotHoles`.
Invalid response shapes now throw the descriptive "Invalid response
format received from backend." error caught by the existing catch block,
instead of a raw TypeError exposed directly to users.

### Related Issues
Closes #5853