### PR TITLE
fix: enforce 150-char minimum length in PlotHoleAnalyzer before firing AI analysis API

### DIFF
--- a/frontend/src/components/writing-assistant/PlotHoleAnalyzer.tsx
+++ b/frontend/src/components/writing-assistant/PlotHoleAnalyzer.tsx
@@ -19,9 +19,17 @@ export default function PlotHoleAnalyzer({ storyText }: PlotHoleAnalyzerProps) {
   const [plotHoles, setPlotHoles] = useState<IPlotHole[] | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  const MIN_STORY_LENGTH = 150;
+
   const handleAnalyze = async () => {
     if (!storyText || storyText.trim().length === 0) {
       toast.error("Please provide a story draft to analyze.");
+      return;
+    }
+    if (storyText.trim().length < MIN_STORY_LENGTH) {
+      toast.error(
+        `Story is too short for analysis. Please provide at least ${MIN_STORY_LENGTH} characters.`
+      );
       return;
     }
 


### PR DESCRIPTION
### Description
Adds a `MIN_STORY_LENGTH = 150` guard in `handleAnalyze` after the
empty check. Short inputs are rejected with a descriptive toast before
any network request is made. Matches the 100-char minimum pattern
used in `StoryConsistencyGuardian` and prevents wasted API calls on
inputs too short for meaningful plot-hole detection.

### Related Issues
Closes #5855 