### PR TITLE
fix: throw descriptive error when baseUrl is empty in PlotHoleAnalyzer — prevents silent relative-path API requests

### DIFF
--- a/frontend/src/components/writing-assistant/PlotHoleAnalyzer.tsx
+++ b/frontend/src/components/writing-assistant/PlotHoleAnalyzer.tsx
@@ -30,7 +30,12 @@ export default function PlotHoleAnalyzer({ storyText }: PlotHoleAnalyzerProps) {
     const toastId = toast.loading("AI Editor is reviewing your story...");
 
     try {
-      const baseUrl = getBaseUrl() || import.meta.env.VITE_BASE_URL || "";
+      const baseUrl = getBaseUrl() || import.meta.env.VITE_BASE_URL;
+      if (!baseUrl) {
+        throw new Error(
+          "API base URL is not configured. Set VITE_BASE_URL in your environment."
+        );
+      }
       const response = await axios.post(`${baseUrl}/ai-editor/analyze`, {
         storyText,
       });


### PR DESCRIPTION
### Description
Removes the `|| ""` fallback. If both `getBaseUrl()` and
`VITE_BASE_URL` are falsy, throws a descriptive configuration error
before making any network request. The error is caught by the existing
catch block and shown via `toast.error()` — giving the developer an
actionable message instead of a cryptic 404.

### Related Issues
Closes #5857 