### PR TITLE
fix : added try-catch around JSON.parse in storySessionRecovery getRecoveredDraft

### DIFF
--- a/frontend/src/utils/storySessionRecovery.ts
+++ b/frontend/src/utils/storySessionRecovery.ts
@@ -24,7 +24,11 @@ export function getRecoveredDraft(): StoryRecoveryData | null {
 
   if (!data) return null;
 
-  return JSON.parse(data);
+  try {
+    return JSON.parse(data) as StoryRecoveryData;
+  } catch {
+    return null;
+  }
 }
 
 export function discardRecoveredDraft() {


### PR DESCRIPTION
Closes #5861.

Summary of What Has Been Done:
Added a try-catch block around the JSON.parse call in the getRecoveredDraft function in frontend/src/utils/storySessionRecovery.ts. If localStorage contains corrupted or malformed JSON data, the function now returns null gracefully instead of throwing an unhandled exception.

Changes Made:
- frontend/src/utils/storySessionRecovery.ts: wrapped JSON.parse in try-catch, returning null on parse failure

Impact it Made:
- Prevents runtime crashes when localStorage data is corrupted
- Provides graceful degradation matching the pattern used in other similar utilities (storyBookmarkNotes.ts, story-draft.ts)

Note: Please assign this PR to the `tmdeveloper007` account.