### PR TITLE
fix : added try-catch around JSON.parse in storyEditingSessionStatistics getSessionHistory

### DIFF
--- a/frontend/src/utils/storyEditingSessionStatistics.ts
+++ b/frontend/src/utils/storyEditingSessionStatistics.ts
@@ -48,9 +48,13 @@ export function calculateEditingSession(
 }
 
 export function getSessionHistory(): EditingSessionHistory[] {
-  return JSON.parse(
-    localStorage.getItem("editing-session-history") || "[]"
-  );
+  try {
+    return JSON.parse(
+      localStorage.getItem("editing-session-history") || "[]"
+    ) as EditingSessionHistory[];
+  } catch {
+    return [];
+  }
 }
 
 export function saveSessionHistory(


### PR DESCRIPTION
Closes #5862.

Summary of What Has Been Done:
Added a try-catch block around the JSON.parse call in the getSessionHistory function in frontend/src/utils/storyEditingSessionStatistics.ts. If localStorage contains corrupted or malformed JSON data, the function now returns an empty array gracefully instead of throwing an unhandled exception.

Changes Made:
- frontend/src/utils/storyEditingSessionStatistics.ts: wrapped JSON.parse in try-catch, returning an empty array on parse failure

Impact it Made:
- Prevents runtime crashes when localStorage data is corrupted
- Provides graceful degradation matching the pattern used in other similar utilities

Note: Please assign this PR to the `tmdeveloper007` account.