### PR TITLE
fix : added try-catch around JSON.parse in writingGoals getGoal

### DIFF
--- a/frontend/src/utils/writingGoals.ts
+++ b/frontend/src/utils/writingGoals.ts
@@ -5,9 +5,14 @@ export interface WritingGoal {
 
 export const getGoal = (): WritingGoal => {
   const goal = localStorage.getItem("writing-goal");
-  return goal
-    ? JSON.parse(goal)
-    : { target: 1000, current: 0 };
+  if (!goal) {
+    return { target: 1000, current: 0 };
+  }
+  try {
+    return JSON.parse(goal) as WritingGoal;
+  } catch {
+    return { target: 1000, current: 0 };
+  }
 };
 
 export const saveGoal = (goal: WritingGoal) => {


### PR DESCRIPTION
Closes #5863.

Summary of What Has Been Done:
Added a try-catch block around the JSON.parse call in the getGoal function in frontend/src/utils/writingGoals.ts. If localStorage contains corrupted or malformed JSON data, the function now returns the default goal object gracefully instead of throwing an unhandled exception.

Changes Made:
- frontend/src/utils/writingGoals.ts: wrapped JSON.parse in try-catch, returning the default goal on parse failure

Impact it Made:
- Prevents runtime crashes when localStorage data is corrupted
- Provides graceful degradation matching the pattern used in other similar utilities

Note: Please assign this PR to the `tmdeveloper007` account.