### PR TITLE
fix: handle review submission errors with unwrap

### DIFF
--- a/frontend/src/components/home/writer_feedback/ReviewForm.tsx
+++ b/frontend/src/components/home/writer_feedback/ReviewForm.tsx
@@ -88,7 +88,13 @@ const ReviewForm: React.FC = () => {
     }
 
     try {
-      await createReview({ name, role, feedback, rating, imgSrc: "" });
+      await createReview({
+        name,
+        role,
+        feedback,
+        rating,
+        imgSrc: "",
+      }).unwrap();
       setSuccess(true);
       setName("");
       setRole("");


### PR DESCRIPTION
## Summary

This PR fixes the review submission flow by using RTK Query's `.unwrap()` on the `createReview` mutation.

### Changes made

- Added `.unwrap()` to the `createReview` mutation.
- Ensures failed API requests throw an error.
- Prevents the success message from being displayed on failed submissions.
- Prevents the review form from being cleared when the request fails.

Closes #5750