### PR TITLE
fix: add error logging to empty catch in StoryTradingCard

### DIFF
--- a/frontend/src/components/cards/StoryTradingCard.tsx
+++ b/frontend/src/components/cards/StoryTradingCard.tsx
@@ -150,7 +150,8 @@ const StoryTradingCard: React.FC<StoryTradingCardProps> = ({
       setIsCopied(true);
       toast.success("Story copied to clipboard!");
       setTimeout(() => setIsCopied(false), 2000);
-    } catch {
+    } catch (error) {
+      console.error("Failed to copy story text", error);
       toast.error("Could not copy story text.");
     }
   };


### PR DESCRIPTION
Adds error logging when clipboard copy fails.