### PR TITLE
fix: add error logging to empty catches in CollectionDetailCard

### DIFF
--- a/frontend/src/components/collections/CollectionDetailCard.tsx
+++ b/frontend/src/components/collections/CollectionDetailCard.tsx
@@ -26,7 +26,8 @@ const CollectionDetailCard: React.FC<Props> = ({ collection, isOwner, onDelete }
       toast.success("Collection deleted.");
       onDelete?.();
       navigate(-1);
-    } catch {
+    } catch (error) {
+      console.error("Failed to delete collection", error);
       toast.error("Failed to delete collection.");
     }
   };
@@ -35,7 +36,8 @@ const CollectionDetailCard: React.FC<Props> = ({ collection, isOwner, onDelete }
     try {
       await removeStory({ collectionId: collection._id, storyId }).unwrap();
       toast.success("Story removed from collection.");
-    } catch {
+    } catch (error) {
+      console.error("Failed to remove story from collection", error);
       toast.error("Failed to remove story.");
     }
   };
@@ -48,7 +50,8 @@ const CollectionDetailCard: React.FC<Props> = ({ collection, isOwner, onDelete }
         data: { visibility: newVisibility },
       }).unwrap();
       toast.success(`Collection is now ${newVisibility}.`);
-    } catch {
+    } catch (error) {
+      console.error("Failed to update collection visibility", error);
       toast.error("Failed to update visibility.");
     }
   };


### PR DESCRIPTION
Adds error logging when collection operations fail.