### PR TITLE
fix: add error logging to empty catch in public profile

### DIFF
--- a/frontend/src/components/profile/public_profile.component.tsx
+++ b/frontend/src/components/profile/public_profile.component.tsx
@@ -53,7 +53,8 @@ const PublicProfileComponent = () => {
       } else {
         toast.success(`Unfollowed ${user?.name || "writer"}.`);
       }
-    } catch {
+    } catch (error) {
+      console.error("Failed to toggle follow", error);
       toast.error("Something went wrong. Please try again.");
     }
   };


### PR DESCRIPTION
Adds error logging when follow/unfollow fails.