### PR TITLE
feat: add story metadata editor

### DIFF
--- a/frontend/src/components/storyMetadata/StoryMetadataEditor.tsx
+++ b/frontend/src/components/storyMetadata/StoryMetadataEditor.tsx
@@ -1,0 +1,87 @@
+import useStoryMetadata from "../../hooks/useStoryMetadata";
+import { validateMetadata } from "../../utils/storyMetadata";
+
+export default function StoryMetadataEditor() {
+  const { metadata, updateField } = useStoryMetadata();
+
+  const status = validateMetadata(metadata);
+
+  const fields = [
+    ["title", "Story Title"],
+    ["subtitle", "Subtitle"],
+    ["description", "Description"],
+    ["genre", "Genre"],
+    ["themes", "Themes"],
+    ["audience", "Target Audience"],
+    ["keywords", "Keywords"],
+    ["readingTime", "Estimated Reading Time"],
+    ["tags", "Custom Tags"],
+  ];
+
+  return (
+    <div className="max-w-3xl mx-auto bg-white rounded-lg shadow border p-6">
+      <h2 className="text-2xl font-bold mb-6">
+        Story Metadata Editor
+      </h2>
+
+      {fields.map(([key, label]) => (
+        <div className="mb-4" key={key}>
+          <label className="block font-medium mb-2">
+            {label}
+          </label>
+
+          <input
+            type="text"
+            value={metadata[key as keyof typeof metadata]}
+            onChange={(e) =>
+              updateField(
+                key as keyof typeof metadata,
+                e.target.value
+              )
+            }
+            className="w-full border rounded-lg p-2"
+          />
+        </div>
+      ))}
+
+      <div className="mt-6 p-4 rounded bg-gray-100">
+        <h3 className="font-semibold mb-3">
+          Metadata Preview
+        </h3>
+
+        <p>
+          <strong>Title:</strong> {metadata.title || "-"}
+        </p>
+
+        <p>
+          <strong>Genre:</strong> {metadata.genre || "-"}
+        </p>
+
+        <p>
+          <strong>Audience:</strong> {metadata.audience || "-"}
+        </p>
+
+        <p>
+          <strong>Reading Time:</strong>{" "}
+          {metadata.readingTime || "-"}
+        </p>
+
+        <p>
+          <strong>Tags:</strong> {metadata.tags || "-"}
+        </p>
+
+        <div className="mt-4">
+          {status.valid ? (
+            <span className="text-green-600 font-medium">
+              ✓ Metadata Complete
+            </span>
+          ) : (
+            <span className="text-red-600 font-medium">
+              Required fields are missing
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useStoryMetadata.ts
+++ b/frontend/src/hooks/useStoryMetadata.ts
@@ -1,0 +1,25 @@
+import { useState } from "react";
+import {
+  StoryMetadata,
+  defaultMetadata,
+} from "../utils/storyMetadata";
+
+export default function useStoryMetadata() {
+  const [metadata, setMetadata] =
+    useState<StoryMetadata>(defaultMetadata);
+
+  const updateField = (
+    field: keyof StoryMetadata,
+    value: string
+  ) => {
+    setMetadata((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
+
+  return {
+    metadata,
+    updateField,
+  };
+}

--- a/frontend/src/utils/storyMetadata.ts
+++ b/frontend/src/utils/storyMetadata.ts
@@ -1,0 +1,32 @@
+export interface StoryMetadata {
+  title: string;
+  subtitle: string;
+  description: string;
+  genre: string;
+  themes: string;
+  audience: string;
+  keywords: string;
+  readingTime: string;
+  tags: string;
+}
+
+export const defaultMetadata: StoryMetadata = {
+  title: "",
+  subtitle: "",
+  description: "",
+  genre: "",
+  themes: "",
+  audience: "",
+  keywords: "",
+  readingTime: "",
+  tags: "",
+};
+
+export function validateMetadata(data: StoryMetadata) {
+  return {
+    valid:
+      data.title.trim() !== "" &&
+      data.description.trim() !== "" &&
+      data.genre.trim() !== "",
+  };
+}


### PR DESCRIPTION
## Description

This PR introduces a **Story Metadata Editor** that enables writers to manage and preview important story metadata before publishing.

### Features

- Edit title, subtitle, description, genre, themes, target audience, keywords, estimated reading time, and custom tags
- Validate required metadata fields
- Display live metadata preview
- Responsive layout
- Easy integration with publishing workflow

### Acceptance Criteria

- [x] Edit all story metadata
- [x] Validate required fields
- [x] Auto-save ready hook structure
- [x] Display metadata preview
- [x] Responsive design

Closes #5798