### PR TITLE
test : added unit tests for useRevisionTimeline hook

### DIFF
--- a/frontend/src/hooks/__tests__/useRevisionTimeline.test.ts
+++ b/frontend/src/hooks/__tests__/useRevisionTimeline.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import useRevisionTimeline from "../useRevisionTimeline";
+
+describe("useRevisionTimeline", () => {
+  it("returns empty revisions array initially", () => {
+    const { result } = renderHook(() => useRevisionTimeline());
+    expect(result.current.revisions).toEqual([]);
+  });
+
+  it("saveRevision adds a revision to the top of the list", () => {
+    const { result } = renderHook(() => useRevisionTimeline());
+    act(() => {
+      result.current.saveRevision("First chapter content.");
+    });
+    expect(result.current.revisions.length).toBe(1);
+    expect(result.current.revisions[0].content).toBe("First chapter content.");
+    expect(result.current.revisions[0].id).toBeDefined();
+    expect(result.current.revisions[0].timestamp).toBeDefined();
+  });
+
+  it("saveRevision prepends new revision, keeping older ones below", () => {
+    const { result } = renderHook(() => useRevisionTimeline());
+    act(() => {
+      result.current.saveRevision("First revision");
+    });
+    act(() => {
+      result.current.saveRevision("Second revision");
+    });
+    expect(result.current.revisions.length).toBe(2);
+    expect(result.current.revisions[0].content).toBe("Second revision");
+    expect(result.current.revisions[1].content).toBe("First revision");
+  });
+
+  it("saveRevision assigns unique ids to each revision", () => {
+    const { result } = renderHook(() => useRevisionTimeline());
+    act(() => {
+      result.current.saveRevision("First");
+    });
+    act(() => {
+      result.current.saveRevision("Second");
+    });
+    const ids = result.current.revisions.map((r) => r.id);
+    const uniqueIds = new Set(ids);
+    expect(uniqueIds.size).toBe(2);
+  });
+
+  it("saveRevision assigns a timestamp to each revision", () => {
+    const { result } = renderHook(() => useRevisionTimeline());
+    act(() => {
+      result.current.saveRevision("Test content");
+    });
+    expect(typeof result.current.revisions[0].timestamp).toBe("string");
+    expect(result.current.revisions[0].timestamp.length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/types/revision.ts
+++ b/frontend/src/types/revision.ts
@@ -1,3 +1,10 @@
+export interface Revision {
+  id: string;
+  timestamp: string;
+  summary: string;
+  content: string;
+}
+
 export interface RevisionTask {
   id: number;
   title: string;


### PR DESCRIPTION
Closes #5898.

Summary of What Has Been Done:
Added 5 vitest unit tests for the useRevisionTimeline hook covering initial empty state, saveRevision adding a revision, ordering (newest first), unique ids, and timestamp assignment.

Changes Made:
- frontend/src/hooks/__tests__/useRevisionTimeline.test.ts: New test file with 5 test cases

Impact it Made:
- Increases frontend test coverage for the hooks layer
- All 5 tests pass locally (vitest run)

Note: Please assign this PR to the `tmdeveloper007` account.