### PR TITLE
fix : added typeof window guard to storyBookmarkNotes localStorage calls

### DIFF
--- a/frontend/src/utils/storyBookmarkNotes.ts
+++ b/frontend/src/utils/storyBookmarkNotes.ts
@@ -9,6 +9,7 @@ export interface BookmarkNote {
 const STORAGE_KEY = "story-bookmark-notes";
 
 export function loadBookmarkNotes(): BookmarkNote[] {
+  if (typeof window === "undefined") return [];
   const saved = localStorage.getItem(STORAGE_KEY);
 
   if (!saved) return [];
@@ -23,6 +24,7 @@ export function loadBookmarkNotes(): BookmarkNote[] {
 export function saveBookmarkNotes(
   notes: BookmarkNote[]
 ) {
+  if (typeof window === "undefined") return;
   localStorage.setItem(
     STORAGE_KEY,
     JSON.stringify(notes)


### PR DESCRIPTION
Closes #5899.

Summary of What Has Been Done:
Added typeof window !== 'undefined' guard at the top of loadBookmarkNotes and saveBookmarkNotes in storyBookmarkNotes.ts. This prevents runtime crashes when these functions are called in environments where localStorage is not available (SSR, worker threads, or environments without a DOM).

Changes Made:
- frontend/src/utils/storyBookmarkNotes.ts: Added SSR guards to loadBookmarkNotes and saveBookmarkNotes (2 lines added)

Impact it Made:
- Fixes potential runtime errors in SSR environments
- Matches the guard pattern used by other localStorage utilities in the codebase (e.g., local-storage.ts)

Note: Please assign this PR to the `tmdeveloper007` account.