### PR TITLE
fix: invalidate user profile cache after writer application

### DIFF
--- a/frontend/src/redux/apis/writer_application.api.ts
+++ b/frontend/src/redux/apis/writer_application.api.ts
@@ -8,7 +8,7 @@ export const writerApplicationApi = baseApi.injectEndpoints({
         method: "POST",
         data,
       }),
-      invalidatesTags: ["User"],
+      invalidatesTags: ["user"],
     }),
     getAllWriterApplications: build.query({
       query: () => ({
@@ -23,7 +23,7 @@ export const writerApplicationApi = baseApi.injectEndpoints({
         method: "PATCH",
         data: { status },
       }),
-      invalidatesTags: ["WriterApplication", "User"],
+      invalidatesTags: ["WriterApplication", "user"],
     }),
   }),
 });


### PR DESCRIPTION
## Summary

This PR fixes the RTK Query cache invalidation for writer applications.

### Changes made

- Replaced `invalidatesTags: ["User"]` with `invalidatesTags: ["user"]`.
- Updated both writer application mutations to invalidate the correct user cache tag.

### Result

After a successful writer application, the user profile cache is invalidated correctly, allowing the profile to refresh and display the "Application Under Review" state without requiring a page reload.

Closes #5749