### PR TITLE
fix: save translated story as content not prompt in handleSaveAsDraft — prevents AI overflow and wrong generation input

### DIFF
--- a/frontend/src/components/translate/StoryTranslator.tsx
+++ b/frontend/src/components/translate/StoryTranslator.tsx
@@ -168,19 +168,21 @@ export default function StoryTranslator({ story, isLogin, onClose }: Props) {
 
   // ── Action 3: Save as Draft ──────────────────────────────────────────────
   const handleSaveAsDraft = () => {
+    // Save translated content as story content, not as a generation prompt.
+    // A prompt is a short AI instruction; translatedContent is the full story output.
     const draftData = {
-      prompt: translatedContent,
+      title: translatedTitle || story.title,
+      content: translatedContent,
       genre: story.tag || "",
-      length: "medium",
       language: selectedLanguage,
     };
     try {
       localStorage.setItem("story_spark_draft", JSON.stringify(draftData));
-      toast.success("Saved as draft! Redirecting to story generator...");
+      toast.success("Saved as draft! Redirecting to story editor...");
       setTimeout(() => {
         onClose();
         navigate("/stories", {
-          state: { prompt: translatedContent },
+          state: { draftContent: translatedContent, draftTitle: translatedTitle },
         });
       }, 1200);
     } catch {


### PR DESCRIPTION
### Description
Changes the draft structure from `{ prompt: translatedContent }` to
`{ title, content, genre, language }`. Updates navigation state from
`{ prompt: translatedContent }` to `{ draftContent, draftTitle }`.
The translated story is now correctly treated as story content for
editing, not as a short AI generation instruction.

### Related Issues
Closes #5923 