### PR TITLE
fix: clear copy timeout on unmount in StoryTranslator — prevents state update on unmounted component

### DIFF
--- a/frontend/src/components/translate/StoryTranslator.tsx
+++ b/frontend/src/components/translate/StoryTranslator.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import toast, { Toaster } from "react-hot-toast";
 import { useTranslateStoryMutation, useTranslateFreeStoryMutation } from "../../redux/apis/ai.model.api";
@@ -70,9 +70,18 @@ export default function StoryTranslator({ story, isLogin, onClose }: Props) {
 
   // Guard against concurrent translation requests
   const isRequestInFlight = useRef(false);
+  // Track copy timeout to cancel it if the component unmounts before it fires
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [translateStory] = useTranslateStoryMutation();
   const [translateFreeStory] = useTranslateFreeStoryMutation();
+
+  // Cleanup copy timeout on unmount to prevent state update on unmounted component
+  useEffect(() => {
+    return () => {
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+    };
+  }, []);
 
   const handleTranslate = async () => {
     // ── Input validation ──────────────────────────────────────────────
@@ -145,7 +154,9 @@ export default function StoryTranslator({ story, isLogin, onClose }: Props) {
       await navigator.clipboard.writeText(text);
       setIsCopied(true);
       toast.success("Translation copied to clipboard!");
-      setTimeout(() => setIsCopied(false), 2500);
+      // Clear any previous timeout before setting a new one
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+      copyTimeoutRef.current = setTimeout(() => setIsCopied(false), 2500);
     } catch {
       toast.error("Failed to copy. Please try again.");
     }


### PR DESCRIPTION
### Description
Adds `copyTimeoutRef` to track the `isCopied` reset timeout.
A `useEffect` cleanup clears the timeout on unmount. Also clears
any previous timeout before starting a new one in `handleCopy` to
handle rapid repeated copy actions. Follows the same `useRef` pattern
already used in the file for `isRequestInFlight`.

### Related Issues
Closes #5925 