### PR TITLE
Fix IssueCard fallback styling for unknown severity values (#5783)

### DIFF
--- a/frontend/src/components/story-consistency/StoryConsistencyGuardian.test.tsx
+++ b/frontend/src/components/story-consistency/StoryConsistencyGuardian.test.tsx
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { getSeverityClasses } from './StoryConsistencyGuardian';
+
+describe('StoryConsistencyGuardian severity styling', () => {
+  it('returns the known class string for high severity', () => {
+    expect(getSeverityClasses('high')).toBe('bg-red-500/10 border-red-500/30 text-red-400');
+  });
+
+  it('returns the known class string for medium severity', () => {
+    expect(getSeverityClasses('medium')).toBe('bg-yellow-500/10 border-yellow-500/30 text-yellow-400');
+  });
+
+  it('returns the default class string for unknown severity values', () => {
+    expect(getSeverityClasses('critical')).toBe('border-white/10 bg-white/5 text-white');
+  });
+
+  it('returns the default class string for missing severity values', () => {
+    expect(getSeverityClasses(undefined)).toBe('border-white/10 bg-white/5 text-white');
+  });
+});

--- a/frontend/src/components/story-consistency/StoryConsistencyGuardian.tsx
+++ b/frontend/src/components/story-consistency/StoryConsistencyGuardian.tsx
@@ -15,6 +15,11 @@ const SEVERITY_COLOR = {
   low: "bg-blue-500/10 border-blue-500/30 text-blue-400",
 };
 
+const DEFAULT_SEVERITY_CLASSES = "border-white/10 bg-white/5 text-white";
+
+export const getSeverityClasses = (severity?: string) =>
+  SEVERITY_COLOR[severity ?? ""] ?? DEFAULT_SEVERITY_CLASSES;
+
 const TYPE_LABEL: Record<string, string> = {
   character_contradiction: "👤 Character",
   timeline_inconsistency: "⏱️ Timeline",
@@ -50,12 +55,12 @@ const ScoreRing = ({ score }: { score: number }) => {
 };
 
 const IssueCard = ({ issue }: { issue: IConsistencyIssue }) => (
-  <div className={`border rounded-xl p-4 space-y-2 ${SEVERITY_COLOR[issue.severity]}`}>
+  <div className={`border rounded-xl p-4 space-y-2 ${getSeverityClasses(issue.severity)}`}>
     <div className="flex items-center justify-between">
       <span className="text-xs font-bold uppercase tracking-wider">
         {TYPE_LABEL[issue.type] ?? issue.type}
       </span>
-      <span className={`text-xs px-2 py-0.5 rounded-full font-bold border ${SEVERITY_COLOR[issue.severity]}`}>
+      <span className={`text-xs px-2 py-0.5 rounded-full font-bold border ${getSeverityClasses(issue.severity)}`}>
         {issue.severity}
       </span>
     </div>
@@ -325,4 +330,4 @@ export default function StoryConsistencyGuardian() {
       </div>
     </div>
   );
-}
+}


### PR DESCRIPTION
## Summary

This PR fixes IssueCard rendering when an unexpected severity value is returned.

### Changes Made

- Added a fallback style for unknown or missing severity values.
- Prevented `"undefined"` from being injected into the `className`.
- Preserved existing styling for all known severity values.
- Added/updated tests covering:
  - known severity values
  - unknown severity values
  - missing severity values

Fixes #5783