### PR TITLE
fix: handle partial failures in batch chapter illustration using Promise.allSettled #5941

### DIFF
--- a/backend/src/app/modules/chapter_illustration/chapter_illustration.integration.ts
+++ b/backend/src/app/modules/chapter_illustration/chapter_illustration.integration.ts
@@ -56,6 +56,13 @@ export async function generateIllustrationForChapter(payload: {
  * Generate illustrations for multiple chapters in sequence
  * Useful for batch chapter creation or importing stories
  */
+export interface IBatchIllustrationResult {
+  illustrations: Map<string, string>;
+  failedChapterIds: string[];
+  failedCount: number;
+  successCount: number;
+}
+
 export async function generateIllustrationsForChapters(
   chapters: Array<{
     chapterId: string;
@@ -68,39 +75,63 @@ export async function generateIllustrationsForChapters(
     quality?: "standard" | "hd";
     signal?: AbortSignal;
   }
-): Promise<Map<string, string>> {
-  const results = new Map<string, string>();
+): Promise<IBatchIllustrationResult> {
+  const illustrations = new Map<string, string>();
+  const failedChapterIds: string[] = [];
 
-  try {
-    const payloads: IChapterIllustrationPayload[] = chapters.map((chapter) => ({
-      ...chapter,
-      style: options?.style || "illustration",
-      quality: options?.quality || "standard",
-    }));
+  const payloads: IChapterIllustrationPayload[] = chapters.map((chapter) => ({
+    ...chapter,
+    style: options?.style || "illustration",
+    quality: options?.quality || "standard",
+  }));
 
-    const generatedResults =
-      await ChapterIllustrationService.generateBatchIllustrations(
-        payloads,
-        options?.signal
-      );
+  // Use Promise.allSettled so one chapter failure doesn't cancel all others
+  const settledResults = await Promise.allSettled(
+    payloads.map((payload) =>
+      ChapterIllustrationService.generateChapterIllustration(payload)
+    )
+  );
 
-    // Map results by chapter ID for easy access
-    for (const result of generatedResults) {
+  for (let i = 0; i < settledResults.length; i++) {
+    const settled = settledResults[i];
+    const chapterId = chapters[i].chapterId;
+
+    if (settled.status === "fulfilled") {
+      const result = settled.value;
       if (result.imageStatus !== "failed" && result.imageUrl) {
-        results.set(result.chapterId, result.imageUrl);
+        illustrations.set(chapterId, result.imageUrl);
+      } else {
+        console.warn(
+          `[Chapter Illustration Integration] Chapter ${chapterId} returned failed status`
+        );
+        failedChapterIds.push(chapterId);
       }
+    } else {
+      console.error(
+        `[Chapter Illustration Integration] Chapter ${chapterId} failed:`,
+        settled.reason
+      );
+      failedChapterIds.push(chapterId);
     }
-
-    return results;
-  } catch (error) {
-    console.error(
-      "[Chapter Illustration Integration] Batch generation error:",
-      error
-    );
-    return results; // Return partial results if available
   }
-}
 
+  const successCount = illustrations.size;
+  const failedCount = failedChapterIds.length;
+
+  if (failedCount > 0) {
+    console.warn(
+      `[Chapter Illustration Integration] Partial failure: ${successCount} succeeded, ${failedCount} failed`,
+      { failedChapterIds }
+    );
+  }
+
+  return {
+    illustrations,
+    failedChapterIds,
+    failedCount,
+    successCount,
+  };
+}
 /**
  * Check if an illustration exists in cache for a chapter
  * Useful for avoiding redundant generations


### PR DESCRIPTION
## What this PR does
Fixes partial failure handling in `chapter_illustration.integration.ts`.

**The Bug:**
`generateIllustrationsForChapters` used `generateBatchIllustrations` 
wrapped in a single try/catch. If any chapter illustration failed, 
the entire batch would throw and the user would lose all results — 
even successfully generated illustrations.

**The Fix:**
Replaced the single batch call with `Promise.allSettled` on individual 
`generateChapterIllustration` calls. This ensures:

- Each chapter illustration is attempted independently
- A failure in one chapter does not cancel others
- Partial results are always returned to the user
- Failed chapter IDs are tracked and logged with a warning
- The return type now includes `IBatchIllustrationResult` with:
  - `illustrations` — Map of successful chapter ID → image URL
  - `failedChapterIds` — Array of chapter IDs that failed
  - `successCount` — Number of successful illustrations
  - `failedCount` — Number of failed illustrations

**Example:** For a 5-chapter story where chapter 3 fails, the user 
now receives illustrations for chapters 1, 2, 4, and 5 instead 
of losing everything.

## Type of change
- [x] Bug fix
- [x] Code refactor

## Related issue
Closes #5941

## Screenshot
N/A — backend service fix with no UI changes

## Checklist
- [x] I have added screenshots or a recording when they help explain 
  this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.