### PR TITLE
fix : added fix for empty string in calculateReadingStats utility

### DIFF
--- a/frontend/src/utils/readingStats.ts
+++ b/frontend/src/utils/readingStats.ts
@@ -8,7 +8,19 @@ export interface ReadingStats {
 }
 
 export function calculateReadingStats(text: string): ReadingStats {
-  const words = text.trim().split(/\s+/).filter(Boolean).length;
+  const trimmed = text.trim();
+  const words = trimmed ? trimmed.split(/\s+/).filter(Boolean).length : 0;
+
+  if (words === 0) {
+    return {
+      words: 0,
+      paragraphs: 0,
+      chapters: 0,
+      sentences: 0,
+      averageSentenceLength: 0,
+      readingTime: 0,
+    };
+  }
 
   const paragraphs = text
     .split(/\n\s*\n/)


### PR DESCRIPTION
Closes #5973.

Summary of What Has Been Done:
Updated `calculateReadingStats` in `frontend/src/utils/readingStats.ts` so that empty or whitespace-only inputs correctly return 0 chapters and 0 reading time.

Changes Made:
- Added empty string check at the beginning of `calculateReadingStats`.
- Handled word count calculation safely before performing math operations.

Impact it Made:
Ensures accurate reading time and chapter count metrics for empty or draft documents. Verified locally via ESLint and TypeScript compiler.

Note: Please assign this PR to the `tmdeveloper007` account.