### PR TITLE
test : added unit tests for storyTitleABComparison utility

### DIFF
--- a/frontend/src/utils/__tests__/storyTitleABComparison.test.ts
+++ b/frontend/src/utils/__tests__/storyTitleABComparison.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { generateStoryTitleOptions, regenerateStoryTitles } from '../storyTitleABComparison';
+
+describe('storyTitleABComparison', () => {
+  it('should return empty array when story text is empty or whitespace', () => {
+    expect(generateStoryTitleOptions('')).toEqual([]);
+    expect(generateStoryTitleOptions('   \n\t ')).toEqual([]);
+    expect(regenerateStoryTitles('')).toEqual([]);
+  });
+
+  it('should generate story title options for valid story input', () => {
+    const story = 'Once upon a time in a galaxy far away...';
+    const options = generateStoryTitleOptions(story);
+
+    expect(options.length).toBeGreaterThan(0);
+    expect(options[0]).toHaveProperty('id');
+    expect(options[0]).toHaveProperty('title');
+    expect(options[0]).toHaveProperty('creativity');
+    expect(options[0]).toHaveProperty('relevance');
+    expect(options[0]).toHaveProperty('memorability');
+    expect(options[0]).toHaveProperty('emotionalAppeal');
+    expect(options[0]).toHaveProperty('feedback');
+  });
+
+  it('should produce identical results for regenerateStoryTitles', () => {
+    const story = 'A hero begins an unexpected journey.';
+    const options1 = generateStoryTitleOptions(story);
+    const options2 = regenerateStoryTitles(story);
+
+    expect(options1).toEqual(options2);
+  });
+});


### PR DESCRIPTION
Closes #5979.

Summary of What Has Been Done:
Added unit test suite for `generateStoryTitleOptions` and `regenerateStoryTitles` in `frontend/src/utils/__tests__/storyTitleABComparison.test.ts`.

Changes Made:
- Created unit test file `storyTitleABComparison.test.ts`.
- Verified empty string behavior, title option property shapes, and function equivalence.

Impact it Made:
Improves test coverage for frontend story utilities. Verified locally via ESLint and TypeScript per-file type checker.

Note: Please assign this PR to the `tmdeveloper007` account.