### PR TITLE
fix : added try-catch error handling to local-storage utility

### DIFF
--- a/frontend/src/utils/local-storage.ts
+++ b/frontend/src/utils/local-storage.ts
@@ -2,19 +2,33 @@ export const setToLocalStorage = (key: string, value: string) => {
   if (!key || typeof window === "undefined") {
     return "";
   }
-  return localStorage.setItem(key, value);
+  try {
+    localStorage.setItem(key, value);
+    return value;
+  } catch {
+    return "";
+  }
 };
 
 export const getFromLocalStorage = (key: string) => {
   if (!key || typeof window === "undefined") {
     return "";
   }
-  return localStorage.getItem(key);
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return "";
+  }
 };
 
 export const removeFromLocalStorage = (key: string) => {
   if (!key || typeof window === "undefined") {
     return "";
   }
-  return localStorage.removeItem(key);
+  try {
+    localStorage.removeItem(key);
+    return "";
+  } catch {
+    return "";
+  }
 };


### PR DESCRIPTION
Closes #5983.

Summary of What Has Been Done:
Wrapped `localStorage` operations (`setItem`, `getItem`, `removeItem`) in `frontend/src/utils/local-storage.ts` with try-catch blocks to prevent unhandled storage exceptions.

Changes Made:
- Added try-catch guards to `setToLocalStorage`, `getFromLocalStorage`, and `removeFromLocalStorage`.
- Returned empty string fallback when storage access is restricted or throws.

Impact it Made:
Improves storage safety across private browsing modes and restricted client environments. Verified locally via ESLint and TypeScript per-file check.

Note: Please assign this PR to the `tmdeveloper007` account.