### PR TITLE
test : added unit tests for dialogueStyleAnalyzer utility

### DIFF
--- a/frontend/src/types/dialogue.ts
+++ b/frontend/src/types/dialogue.ts
@@ -1,0 +1,9 @@
+export interface CharacterDialogueAnalysis {
+  id: number;
+  character: string;
+  uniquenessScore: number;
+  vocabularyStyle: string;
+  speechPattern: string;
+  similarTo?: string;
+  suggestions: string[];
+}

--- a/frontend/src/utils/__tests__/dialogueStyleAnalyzer.test.ts
+++ b/frontend/src/utils/__tests__/dialogueStyleAnalyzer.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { analyzeDialogue } from '../dialogueStyleAnalyzer';
+
+describe('dialogueStyleAnalyzer', () => {
+  it('should return character dialogue analysis array', () => {
+    const storyText = 'Alice said hello. John replied with a quiet smile.';
+    const analysis = analyzeDialogue(storyText);
+
+    expect(Array.isArray(analysis)).toBe(true);
+    expect(analysis.length).toBe(3);
+    expect(analysis[0]).toHaveProperty('character', 'Alice');
+    expect(analysis[0]).toHaveProperty('uniquenessScore');
+    expect(analysis[0]).toHaveProperty('vocabularyStyle');
+    expect(analysis[0]).toHaveProperty('speechPattern');
+    expect(analysis[0]).toHaveProperty('suggestions');
+  });
+
+  it('should return valid uniqueness scores between 65 and 100', () => {
+    const analysis = analyzeDialogue('A sample narrative text.');
+    analysis.forEach((item) => {
+      expect(item.uniquenessScore).toBeGreaterThanOrEqual(65);
+      expect(item.uniquenessScore).toBeLessThanOrEqual(100);
+    });
+  });
+});


### PR DESCRIPTION
Closes #5988.

Summary of What Has Been Done:
Added unit test suite in `frontend/src/utils/__tests__/dialogueStyleAnalyzer.test.ts` and created the missing type definitions in `frontend/src/types/dialogue.ts`.

Changes Made:
- Created missing interface definition `CharacterDialogueAnalysis` in `frontend/src/types/dialogue.ts`.
- Added unit test file `dialogueStyleAnalyzer.test.ts`.
- Verified dialogue analysis output structures and score range bounds.

Impact it Made:
Fixes TypeScript module resolution error for `dialogueStyleAnalyzer.ts` and adds unit test coverage. Verified locally via ESLint and TypeScript compiler.

Note: Please assign this PR to the `tmdeveloper007` account.