### PR TITLE
fix: add fallback flag and message when character network extraction …

### DIFF
--- a/backend/src/app/modules/story_version/character_network.utils.ts
+++ b/backend/src/app/modules/story_version/character_network.utils.ts
@@ -25,6 +25,8 @@ export interface IRelationship {
 export interface ICharacterNetworkResponse {
   characters: ICharacter[];
   relationships: IRelationship[];
+  fallback?: boolean;
+  fallbackMessage?: string;
 }
 
 const COMMON_STOP_WORDS = new Set([
@@ -45,10 +47,14 @@ const COMMON_STOP_WORDS = new Set([
 
 // Offline fallback extractor using regex and heuristics
 export function extractCharacterNetworkOffline(content: string): ICharacterNetworkResponse {
-  if (!content || !content.trim()) {
-    return { characters: [], relationships: [] };
+ if (!content || !content.trim()) {
+    return {
+      characters: [],
+      relationships: [],
+      fallback: true,
+      fallbackMessage: "No story content provided to analyze.",
+    };
   }
-
   // 1. Sentence-based split
   const sentences = content.split(/[.!?]+/).map(s => s.trim()).filter(Boolean);
   
@@ -93,7 +99,7 @@ export function extractCharacterNetworkOffline(content: string): ICharacterNetwo
     name => rawNamesCount[name] >= minAppearances
   );
 
-  if (filteredNames.length === 0) {
+ if (filteredNames.length === 0) {
     return {
       characters: [
         { id: "hero", name: "Hero", appearanceCount: 5, importanceScore: 80 },
@@ -108,7 +114,9 @@ export function extractCharacterNetworkOffline(content: string): ICharacterNetwo
           strength: 70,
           interactionCount: 3
         }
-      ]
+      ],
+      fallback: true,
+      fallbackMessage: "No characters detected. Try using proper capitalization for character names.",
     };
   }
 


### PR DESCRIPTION
## What this PR does
Fixes poor UX when character network extraction returns empty results 
by adding a `fallback` flag and `fallbackMessage` to the response.

**Changes to `character_network.utils.ts`:**

1. **Updated `ICharacterNetworkResponse` interface** — Added optional 
   `fallback?: boolean` and `fallbackMessage?: string` fields so the 
   frontend knows when to show a user-friendly notification.

2. **Empty content check** — Returns `fallback: true` with message 
   "No story content provided to analyze." when content is empty.

3. **No characters detected** — Returns `fallback: true` with message 
   "No characters detected. Try using proper capitalization for 
   character names." when regex extraction finds no capitalized names,
   instead of silently returning placeholder data.

## Type of change
- [x] Bug fix

## Related issue
Closes #5932

## Screenshot
N/A — backend utility fix with no direct UI changes

## Checklist
- [x] I have added screenshots or a recording when they help explain 
  this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.


## What this PR does

<!-- Short summary: what problem does this solve, and how? -->




## Type of change

Check all that apply (if more than one, explain in “What this PR does”).

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

<!-- Example: Closes #123 or Fixes #45. Use “None” if there is no issue. -->



## More screenshots (optional)

<!-- Extra before/after images, flows, or recordings for reviewers. -->



## Checklist

- [ ] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [ ] I have filled in the related issue number when there is one.
- [ ] I have tested my changes.
- [ ] I have done a self-review of the code.
