### PR TITLE
fix : added null array guard to normalizeWeights in genreWeights utility

### DIFF
--- a/frontend/src/utils/genreWeights.ts
+++ b/frontend/src/utils/genreWeights.ts
@@ -10,7 +10,7 @@ export interface GenreWeightConfig {
 export const normalizeWeights = (
   config: GenreWeightConfig
 ): GenreWeightConfig => {
-  if (config.genres.length === 0) {
+  if (!config || !Array.isArray(config.genres) || config.genres.length === 0) {
     return { genres: [] };
   }
 
@@ -34,6 +34,7 @@ export const normalizeWeights = (
 export const validateWeights = (
   config: GenreWeightConfig
 ): boolean => {
+  if (!config || !Array.isArray(config.genres)) return false;
   return (
     config.genres.reduce((s, g) => s + g.weight, 0) === 100
   );
@@ -42,6 +43,7 @@ export const validateWeights = (
 export const buildGenrePrompt = (
   config: GenreWeightConfig
 ): string => {
+  if (!config || !Array.isArray(config.genres)) return "";
   return config.genres
     .map((g) => `${g.genre} (${g.weight}%)`)
     .join(", ");


### PR DESCRIPTION
Closes #5997.

Summary of What Has Been Done:
Added null/undefined and array validation guards to `normalizeWeights`, `validateWeights`, and `buildGenrePrompt` in `frontend/src/utils/genreWeights.ts`.

Changes Made:
- Protected `normalizeWeights` against undefined `config` or `config.genres`.
- Added safety fallbacks to `validateWeights` and `buildGenrePrompt`.

Impact it Made:
Prevents runtime `TypeError` crashes when parsing uninitialized genre configurations. Verified locally via ESLint and TypeScript per-file check.

Note: Please assign this PR to the `tmdeveloper007` account.