### PR TITLE
feat : added story sentiment score analyzer utility

### DIFF
--- a/frontend/src/utils/storySentimentAnalyzer.ts
+++ b/frontend/src/utils/storySentimentAnalyzer.ts
@@ -1,0 +1,54 @@
+export interface StorySentimentResult {
+  positiveScore: number;
+  negativeScore: number;
+  neutralScore: number;
+  dominantTone: 'Positive' | 'Negative' | 'Neutral';
+}
+
+export function analyzeStorySentiment(story: string): StorySentimentResult {
+  if (!story || !story.trim()) {
+    return {
+      positiveScore: 0,
+      negativeScore: 0,
+      neutralScore: 100,
+      dominantTone: 'Neutral',
+    };
+  }
+
+  const text = story.toLowerCase();
+  const positiveWords = ['happy', 'joy', 'bright', 'love', 'hope', 'victory', 'smile', 'triumph'];
+  const negativeWords = ['sad', 'gloom', 'dark', 'loss', 'fear', 'tragedy', 'pain', 'defeat'];
+
+  let posCount = 0;
+  let negCount = 0;
+
+  positiveWords.forEach((w) => {
+    if (text.includes(w)) posCount += 1;
+  });
+  negativeWords.forEach((w) => {
+    if (text.includes(w)) negCount += 1;
+  });
+
+  if (posCount > negCount) {
+    return {
+      positiveScore: 70,
+      negativeScore: 20,
+      neutralScore: 10,
+      dominantTone: 'Positive',
+    };
+  } else if (negCount > posCount) {
+    return {
+      positiveScore: 20,
+      negativeScore: 70,
+      neutralScore: 10,
+      dominantTone: 'Negative',
+    };
+  }
+
+  return {
+    positiveScore: 30,
+    negativeScore: 30,
+    neutralScore: 40,
+    dominantTone: 'Neutral',
+  };
+}


### PR DESCRIPTION
Closes #6003.

Summary of What Has Been Done:
Created `frontend/src/utils/storySentimentAnalyzer.ts` implementing `analyzeStorySentiment` to score positive, negative, and neutral tones across narrative text.

Changes Made:
- Added `frontend/src/utils/storySentimentAnalyzer.ts`.
- Exported `StorySentimentResult` interface and `analyzeStorySentiment` function.

Impact it Made:
Enables sentiment tone analysis for story toolbars and analytics components. Verified locally via ESLint and TypeScript compiler.

Note: Please assign this PR to the `tmdeveloper007` account.