### PR TITLE
fix : added SSR guards to readingProgress utility

### DIFF
--- a/frontend/src/utils/readingProgress.ts
+++ b/frontend/src/utils/readingProgress.ts
@@ -2,21 +2,33 @@ export const saveReadingPosition = (
   storyId: string,
   position: number
 ) => {
-  localStorage.setItem(
-    `reading-${storyId}`,
-    position.toString()
-  );
+  if (!storyId || typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(`reading-${storyId}`, position.toString());
+  } catch {
+    // Ignore storage quota error or restriction
+  }
 };
 
 export const getReadingPosition = (
   storyId: string
 ): number => {
-  const value = localStorage.getItem(`reading-${storyId}`);
-  return value ? Number(value) : 0;
+  if (!storyId || typeof window === 'undefined') return 0;
+  try {
+    const value = localStorage.getItem(`reading-${storyId}`);
+    return value ? Number(value) : 0;
+  } catch {
+    return 0;
+  }
 };
 
 export const resetReadingPosition = (
   storyId: string
 ) => {
-  localStorage.removeItem(`reading-${storyId}`);
+  if (!storyId || typeof window === 'undefined') return;
+  try {
+    localStorage.removeItem(`reading-${storyId}`);
+  } catch {
+    // Ignore storage restriction
+  }
 };


### PR DESCRIPTION
Closes #6007.

Summary of What Has Been Done:
Added SSR `typeof window` guards and try-catch error safety to storage functions in `frontend/src/utils/readingProgress.ts`.

Changes Made:
- Updated `saveReadingPosition`, `getReadingPosition`, and `resetReadingPosition`.
- Prevented unhandled `DOMException` storage quota errors.

Impact it Made:
Fixes SSR crashes and improves client-side reading progress tracking safety. Verified locally via ESLint and TypeScript per-file check.

Note: Please assign this PR to the `tmdeveloper007` account.