### PR TITLE
test : added unit tests for readingProgress utility

### DIFF
--- a/frontend/src/utils/__tests__/readingProgress.test.ts
+++ b/frontend/src/utils/__tests__/readingProgress.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { saveReadingPosition, getReadingPosition, resetReadingPosition } from '../readingProgress';
+
+describe('readingProgress utility', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('should save and retrieve reading position', () => {
+    saveReadingPosition('story-123', 450);
+    expect(getReadingPosition('story-123')).toBe(450);
+  });
+
+  it('should reset reading position', () => {
+    saveReadingPosition('story-123', 450);
+    resetReadingPosition('story-123');
+    expect(getReadingPosition('story-123')).toBe(0);
+  });
+
+  it('should return 0 when storyId is empty or non-existent', () => {
+    expect(getReadingPosition('')).toBe(0);
+    expect(getReadingPosition('non-existent')).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #6009.

Summary of What Has Been Done:
Added unit test suite for reading scroll offset tracking in `frontend/src/utils/__tests__/readingProgress.test.ts`.

Changes Made:
- Created unit test file `readingProgress.test.ts`.
- Verified `saveReadingPosition`, `getReadingPosition`, and `resetReadingPosition`.

Impact it Made:
Improves test coverage for reading progress state management. Verified locally via ESLint and TypeScript compiler.

Note: Please assign this PR to the `tmdeveloper007` account.