### PR TITLE
fix: only log CACHE HIT when storyData is valid and non-null #5938

### DIFF
--- a/backend/src/services/ai.service.ts
+++ b/backend/src/services/ai.service.ts
@@ -170,7 +170,10 @@ export async function generateStory(
   try {
     const existingCache = await StoryCache.findOne({ promptKey: cacheKey });
     if (existingCache) {
-      console.log("[CACHE HIT] Serving story instantly from MongoDB cache");
+     console.log(existingCache.storyData
+  ? "[CACHE HIT] Serving valid cached story from MongoDB cache"
+  : "[CACHE WARN] Cache entry found but storyData is null"
+);
       return {
         story: existingCache.storyData,
         provider: existingCache.provider as "openai" | "gemini" | "anthropic",


### PR DESCRIPTION
## What this PR does
Fixes misleading cache hit logging in `ai.service.ts` where 
`[CACHE HIT]` was logged even when `storyData` was null or empty.

**The Bug:**
The log `[CACHE HIT] Serving story instantly from MongoDB cache` 
fired immediately when a cache entry was found, before validating 
whether `storyData` was actually present and valid. This made 
debugging harder and made cache effectiveness metrics inaccurate.

**The Fix:**
Changed the single `console.log` to conditionally log either:
- `[CACHE HIT] Serving valid cached story from MongoDB cache` 
  when `storyData` is present and valid
- `[CACHE WARN] Cache entry found but storyData is null` 
  when the entry exists but data is missing

Only 1 line changed — no structural changes to the try/catch 
or return statements.

## Type of change
- [x] Bug fix

## Related issue
Closes #5938

## Screenshot
N/A — logging fix with no UI changes

## Checklist
- [x] I have added screenshots or a recording when they help explain 
  this PR, or noted N/A with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.