### PR TITLE
feat: presist variationCount setting in localStorage

### DIFF
--- a/frontend/src/components/StoryGenerator.tsx
+++ b/frontend/src/components/StoryGenerator.tsx
@@ -1,5 +1,5 @@
 // frontend/src/components/StoryGenerator.tsx
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import api from '../services/api';
 
 interface StoryGeneratorProps {
@@ -8,13 +8,21 @@ interface StoryGeneratorProps {
 
 const MIN_PROMPT_LENGTH = 10;
 const MAX_PROMPT_LENGTH = 1000;
+const STORAGE_KEY_VARIATION_COUNT = 'story_generator_variation_count';
 
 export const StoryGenerator: React.FC<StoryGeneratorProps> = ({ onStoryGenerated }) => {
   const [prompt, setPrompt] = useState('');
-  const [variationCount, setVariationCount] = useState(3);
+  const [variationCount, setVariationCount] = useState<number>(() => {
+    const saved = localStorage.getItem(STORAGE_KEY_VARIATION_COUNT);
+    return saved ? Number(saved) : 3;
+  });
   const [isLoading, setIsLoading] = useState(false);
   const [stories, setStories] = useState<any[]>([]);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY_VARIATION_COUNT,variationCount.toString());
+  },[variationCount]);
 
   // Derived values used both in JSX and inside handleGenerate
   const trimmedPrompt = prompt.trim();


### PR DESCRIPTION
### 📌 Description
Fixes #5963 by persisting the selected `variationCount` setting in `localStorage`. This ensures that user preferences for story generation variations are remembered across page reloads and browser sessions instead of resetting to the default value.

### 🧪 Changes Made
- Introduced `STORAGE_KEY_VARIATION_COUNT` constant for local storage management.
- Updated `variationCount` state initialization in `StoryGenerator.tsx` to lazily load saved values from `localStorage` (falling back to `3`).
- Added a `useEffect` hook to automatically sync `variationCount` changes to `localStorage`.

### 🔍 How to Test
1. Go to the Story Generator component.
2. Change the "Number of Variations" slider to a value other than 3 (e.g., 4 or 5).
3. Refresh the page or navigate away and return.
4. Verify that the selected variation count remains set to your last chosen value.