### PR TITLE
fix : added try-catch block to clearStorySession in storyStorage utility

### DIFF
--- a/frontend/src/utils/storyStorage.ts
+++ b/frontend/src/utils/storyStorage.ts
@@ -1,6 +1,10 @@
 export function clearStorySession(): void {
-  if (typeof window === "undefined") {
+  if (typeof window === 'undefined') {
     return;
   }
-  localStorage.removeItem("storySession");
+  try {
+    localStorage.removeItem('storySession');
+  } catch {
+    // Ignore storage restriction error
+  }
 }


### PR DESCRIPTION
Closes #6028.

Summary of What Has Been Done:
Wrapped `localStorage.removeItem` in a try-catch block within `clearStorySession` in `frontend/src/utils/storyStorage.ts`.

Changes Made:
- Updated `clearStorySession` function in `storyStorage.ts`.
- Protected storage removal from throwing DOMExceptions under restricted storage settings.

Impact it Made:
Improves storage cleanup safety for story sessions. Verified locally via ESLint and TypeScript compiler.

Note: Please assign this PR to the `tmdeveloper007` account.