### PR TITLE
fix : added null content and empty string guards to formatPreview utility

### DIFF
--- a/frontend/src/utils/previewFormatter.ts
+++ b/frontend/src/utils/previewFormatter.ts
@@ -5,13 +5,19 @@ export interface StoryData {
 }
 
 export function formatPreview(story: StoryData) {
-  const paragraphs = story.content
+  const content = story?.content || '';
+  const paragraphs = content
     .split("\n")
-    .filter((p) => p.trim() !== "");
+    .map((p) => p.trim())
+    .filter(Boolean);
+
+  const words = content.trim().split(/\s+/).filter(Boolean);
 
   return {
-    ...story,
+    title: story?.title || '',
+    author: story?.author || '',
+    content,
     paragraphs,
-    wordCount: story.content.trim().split(/\s+/).length,
+    wordCount: words.length,
   };
 }


### PR DESCRIPTION
Closes #6049.

Summary of What Has Been Done:
Updated `formatPreview` in `frontend/src/utils/previewFormatter.ts` to safely handle null/undefined story objects and empty content.

Changes Made:
- Added safe content fallback `story?.content || ""`.
- Computed `wordCount` by filtering empty string splits.

Impact it Made:
Prevents TypeError crashes when rendering preview cards. Verified locally via ESLint and TypeScript compiler.

Note: Please assign this PR to the `tmdeveloper007` account.