### PR TITLE
fix : returned zero metrics for empty string in calculateReadingStats utility

### DIFF
--- a/frontend/src/utils/readingStats.ts
+++ b/frontend/src/utils/readingStats.ts
@@ -8,6 +8,17 @@ export interface ReadingStats {
 }
 
 export function calculateReadingStats(text: string): ReadingStats {
+  if (!text || typeof text !== 'string' || !text.trim()) {
+    return {
+      words: 0,
+      paragraphs: 0,
+      chapters: 0,
+      sentences: 0,
+      averageSentenceLength: 0,
+      readingTime: 0,
+    };
+  }
+
   const words = text.trim().split(/\s+/).filter(Boolean).length;
 
   const paragraphs = text


### PR DESCRIPTION
Closes #6059.

Summary of What Has Been Done:
Updated `calculateReadingStats` in `frontend/src/utils/readingStats.ts` to return 0 for words, paragraphs, chapters, sentences, averageSentenceLength, and readingTime when provided an empty text input.

Changes Made:
- Added empty text string and type guards.
- Returned zeroed `ReadingStats` object for empty drafts.

Impact it Made:
Ensures accurate reading statistics for empty story drafts. Verified locally via ESLint and TypeScript compiler.

Note: Please assign this PR to the `tmdeveloper007` account.