### PR TITLE
fix : returned zero minutes for empty string in getReadingTime utility

### DIFF
--- a/frontend/src/utils/readingTime.ts
+++ b/frontend/src/utils/readingTime.ts
@@ -1,8 +1,8 @@
 export function getReadingTime(text: string): { minutes: number; wordCount: number } {
-  const trimmed = text.trim();
-  if (!trimmed) {
-    return { minutes: 1, wordCount: 0 };
+  if (!text || typeof text !== 'string' || !text.trim()) {
+    return { minutes: 0, wordCount: 0 };
   }
+  const trimmed = text.trim();
   const wordCount = trimmed.split(/\s+/).length;
   const minutes = Math.max(1, Math.round(wordCount / 200));
   return { minutes, wordCount };


### PR DESCRIPTION
Closes #6089.

Summary of What Has Been Done:
Updated `getReadingTime` in `frontend/src/utils/readingTime.ts` to return `{ minutes: 0, wordCount: 0 }` for empty text strings.

Changes Made:
- Added empty text and null checks.
- Returned zeroed minutes and word count.

Impact it Made:
Fixes inaccurate 1 minute reading time displays for empty story drafts. Verified locally via ESLint and TypeScript compiler.

Note: Please assign this PR to the `tmdeveloper007` account.