### PR TITLE
fix : added non-positive maxLength guard to truncateText utility

### DIFF
--- a/frontend/src/utils/truncateText.ts
+++ b/frontend/src/utils/truncateText.ts
@@ -13,7 +13,7 @@ export const truncateText = (
   maxLength: number,
   suffix: string = "..."
 ): string => {
-  if (!text || typeof text !== "string") {
+  if (!text || typeof text !== "string" || maxLength <= 0) {
     return "";
   }
 


### PR DESCRIPTION
Closes #6099.

Summary of What Has Been Done:
Updated `truncateText` in `frontend/src/utils/truncateText.ts` to return an empty string when `maxLength` is non-positive or negative.

Changes Made:
- Added non-positive `maxLength` check.
- Returned empty string fallback.

Impact it Made:
Prevents negative index string truncation bugs. Verified locally via ESLint and TypeScript compiler.

Note: Please assign this PR to the `tmdeveloper007` account.