### PR TITLE
fix : added score bounds check to getReadabilityLevel in vocabularyAnalyzer

### DIFF
--- a/frontend/src/utils/vocabularyAnalyzer.ts
+++ b/frontend/src/utils/vocabularyAnalyzer.ts
@@ -142,6 +142,9 @@ export const refreshVocabularyAnalysis = (
 export const getReadabilityLevel = (
   score: number
 ): string => {
+  if (typeof score !== "number" || isNaN(score) || score <= 0) {
+    return "Needs Improvement";
+  }
   if (score >= 90) return "Excellent";
   if (score >= 75) return "Good";
   if (score >= 60) return "Average";


### PR DESCRIPTION
Closes #6109.

Summary of What Has Been Done:
Updated `getReadabilityLevel` in `frontend/src/utils/vocabularyAnalyzer.ts` to return fallback level `"Needs Improvement"` when passed NaN or non-positive score values.

Changes Made:
- Added NaN, type, and non-positive score checks.
- Returned `"Needs Improvement"` fallback.

Impact it Made:
Ensures reliable readability classification labels across all score values. Verified locally via ESLint and TypeScript compiler.

Note: Please assign this PR to the `tmdeveloper007` account.