### PR TITLE
fix : added zero and NaN division safety guards to writingGoal progress calculations

### DIFF
--- a/frontend/src/utils/writingGoal.ts
+++ b/frontend/src/utils/writingGoal.ts
@@ -15,21 +15,27 @@ export const calculateWordProgress = (
   current: number,
   target: number
 ) => {
-  return Math.min((current / target) * 100, 100);
+  if (!target || target <= 0 || isNaN(target)) return 0;
+  const safeCurrent = Math.max(0, isNaN(current) ? 0 : current);
+  return Math.min((safeCurrent / target) * 100, 100);
 };
 
 export const calculateStoryProgress = (
   current: number,
   target: number
 ) => {
-  return Math.min((current / target) * 100, 100);
+  if (!target || target <= 0 || isNaN(target)) return 0;
+  const safeCurrent = Math.max(0, isNaN(current) ? 0 : current);
+  return Math.min((safeCurrent / target) * 100, 100);
 };
 
 export const calculatePromptProgress = (
   current: number,
   target: number
 ) => {
-  return Math.min((current / target) * 100, 100);
+  if (!target || target <= 0 || isNaN(target)) return 0;
+  const safeCurrent = Math.max(0, isNaN(current) ? 0 : current);
+  return Math.min((safeCurrent / target) * 100, 100);
 };
 
 export const isGoalCompleted = (


### PR DESCRIPTION
Closes #6139.

Summary of What Has Been Done:
Updated `calculateWordProgress`, `calculateStoryProgress`, and `calculatePromptProgress` in `frontend/src/utils/writingGoal.ts` to return 0 when `target` is zero, negative, or NaN.

Changes Made:
- Added `target` zero, negative, and NaN checks.
- Added `current` non-negative and NaN bounds checks.

Impact it Made:
Prevents NaN and Infinity values from corrupting writing goal progress bars. Verified locally via ESLint and TypeScript compiler.

Note: Please assign this PR to the `tmdeveloper007` account.