### PR TITLE
fix : returned 0 reading time and chapters for empty text in readingStats

### DIFF
--- a/frontend/src/utils/readingStats.ts
+++ b/frontend/src/utils/readingStats.ts
@@ -8,6 +8,17 @@ export interface ReadingStats {
 }
 
 export function calculateReadingStats(text: string): ReadingStats {
+  if (!text || typeof text !== 'string' || !text.trim()) {
+    return {
+      words: 0,
+      paragraphs: 0,
+      chapters: 0,
+      sentences: 0,
+      averageSentenceLength: 0,
+      readingTime: 0,
+    };
+  }
+
   const words = text.trim().split(/\s+/).filter(Boolean).length;
 
   const paragraphs = text


### PR DESCRIPTION
Closes #6149.

Summary of What Has Been Done:
Updated `calculateReadingStats` in `frontend/src/utils/readingStats.ts` to return zero values across all fields when text is empty or whitespace-only.

Changes Made:
- Added early return guard for empty or whitespace-only strings.
- Returned `readingTime: 0` and `chapters: 0` for empty inputs.

Impact it Made:
Ensures accurate reading stats calculation for empty story drafts. Verified locally via ESLint and TypeScript compiler.

Note: Please assign this PR to the `tmdeveloper007` account.