### PR TITLE
fix(analytics): surface load errors instead of empty dashboard

### DIFF
--- a/frontend/src/components/dashboard/analytics/analytics.page.test.tsx
+++ b/frontend/src/components/dashboard/analytics/analytics.page.test.tsx
@@ -1,0 +1,214 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import AnalyticsPage from "./analytics.page";
+
+vi.mock("../../../services/auth.service", () => ({
+  getToken: vi.fn(() => "test-token"),
+}));
+
+vi.mock("../../../helpers/config", () => ({
+  getBaseUrl: vi.fn(() => "http://localhost:5000/api/v1"),
+}));
+
+vi.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: { children?: unknown }) => (
+    <div data-testid="chart">{children as never}</div>
+  ),
+  BarChart: () => <div data-testid="bar-chart" />,
+  Bar: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+  CartesianGrid: () => null,
+  PieChart: () => <div data-testid="pie-chart" />,
+  Pie: () => null,
+  Cell: () => null,
+}));
+
+const emptyOverview = {
+  totalStories: 0,
+  totalWords: 0,
+  currentStreak: 0,
+  longestStreak: 0,
+  totalLikes: 0,
+  totalViews: 0,
+};
+
+const okJson = (data: unknown, status = 200) =>
+  Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => ({ data }),
+  } as Response);
+
+const statusResponse = (status: number) =>
+  Promise.resolve({
+    ok: false,
+    status,
+    json: async () => ({ message: "error" }),
+  } as Response);
+
+const malformedJsonResponse = () =>
+  Promise.resolve({
+    ok: true,
+    status: 200,
+    json: async () => {
+      throw new SyntaxError("Unexpected token");
+    },
+  } as Response);
+
+const endpointFromUrl = (input: RequestInfo | URL) => {
+  const url = String(input);
+  const match = url.match(/\/analytics\/([^/?#]+)/);
+  return match?.[1] ?? "";
+};
+
+const mockAllOk = (overview = emptyOverview) => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((input: RequestInfo | URL) => {
+      const endpoint = endpointFromUrl(input);
+      switch (endpoint) {
+        case "overview":
+          return okJson(overview);
+        case "heatmap":
+          return okJson([]);
+        case "genres":
+          return okJson([]);
+        case "wordcloud":
+          return okJson([]);
+        case "productive-hours":
+          return okJson([]);
+        default:
+          return statusResponse(404);
+      }
+    })
+  );
+};
+
+const renderPage = () =>
+  render(
+    <MemoryRouter>
+      <AnalyticsPage />
+    </MemoryRouter>
+  );
+
+describe("AnalyticsPage request failure handling", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  it("shows an auth-expired state with sign-in for 401 responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => statusResponse(401))
+    );
+
+    renderPage();
+
+    expect(
+      await screen.findByText(
+        "Your session has expired. Sign in again to view analytics."
+      )
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: "Sign in" }).getAttribute("href")
+    ).toBe("/login");
+    expect(screen.queryByText("Your Analytics")).toBeNull();
+    expect(screen.queryByText("No stories yet — generate some!")).toBeNull();
+  });
+
+  it("shows a retryable error state for 5xx responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => statusResponse(500))
+    );
+
+    renderPage();
+
+    expect(
+      await screen.findByText("Failed to load analytics. Please try again.")
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+    expect(screen.queryByText("Your Analytics")).toBeNull();
+  });
+
+  it("treats malformed JSON as a load failure, not empty analytics", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => malformedJsonResponse())
+    );
+
+    renderPage();
+
+    expect(
+      await screen.findByText("Failed to load analytics. Please try again.")
+    ).toBeTruthy();
+    expect(screen.queryByText("No stories yet — generate some!")).toBeNull();
+  });
+
+  it("fails the whole load when one endpoint errors among successful ones", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const endpoint = endpointFromUrl(input);
+        if (endpoint === "genres") {
+          return statusResponse(500);
+        }
+        return okJson(
+          endpoint === "overview" ? emptyOverview : []
+        );
+      })
+    );
+
+    renderPage();
+
+    expect(
+      await screen.findByText("Failed to load analytics. Please try again.")
+    ).toBeTruthy();
+    expect(screen.queryByText("Your Analytics")).toBeNull();
+  });
+
+  it("recovers to the dashboard after Retry succeeds", async () => {
+    let shouldFail = true;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        if (shouldFail) {
+          return statusResponse(500);
+        }
+        const endpoint = endpointFromUrl(input);
+        return okJson(endpoint === "overview" ? emptyOverview : []);
+      })
+    );
+
+    renderPage();
+
+    expect(
+      await screen.findByText("Failed to load analytics. Please try again.")
+    ).toBeTruthy();
+
+    shouldFail = false;
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(await screen.findByText("Your Analytics")).toBeTruthy();
+    expect(screen.getByText("No stories yet — generate some!")).toBeTruthy();
+  });
+
+  it("renders a true zero-activity dashboard when requests succeed with empty data", async () => {
+    mockAllOk(emptyOverview);
+
+    renderPage();
+
+    expect(await screen.findByText("Your Analytics")).toBeTruthy();
+    expect(screen.getAllByText("0").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("0d").length).toBe(2);
+    expect(screen.getByText("No stories yet — generate some!")).toBeTruthy();
+    expect(screen.getByText("No activity data yet — start writing!")).toBeTruthy();
+    expect(
+      screen.queryByText("Failed to load analytics. Please try again.")
+    ).toBeNull();
+  });
+});

--- a/frontend/src/components/dashboard/analytics/analytics.page.tsx
+++ b/frontend/src/components/dashboard/analytics/analytics.page.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import {
   BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer,
   PieChart, Pie, Cell, CartesianGrid,
@@ -24,6 +25,12 @@ interface IGenre { genre: string; count: number; }
 interface IWordCloud { text: string; value: number; }
 interface IHour { hour: number; count: number; }
 
+type AnalyticsLoadError = {
+  message: string;
+  status?: number;
+  isAuthExpired: boolean;
+};
+
 const HOUR_LABELS = ["12am","1am","2am","3am","4am","5am","6am","7am","8am","9am","10am","11am",
   "12pm","1pm","2pm","3pm","4pm","5pm","6pm","7pm","8pm","9pm","10pm","11pm"];
 
@@ -34,6 +41,8 @@ const AnalyticsPage = () => {
   const [wordCloud, setWordCloud] = useState<IWordCloud[]>([]);
   const [hours, setHours] = useState<IHour[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<AnalyticsLoadError | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
 
   const token = getToken() || "";
 
@@ -48,47 +57,106 @@ const AnalyticsPage = () => {
         signal,
       }
     );
-  
-    if (!res.ok) throw new Error("Request failed");
-const data = await res.json();
-    return data.data;
+
+    if (!res.ok) {
+      const err = new Error(
+        `Request failed with status ${res.status}`
+      ) as Error & { status?: number };
+      err.status = res.status;
+      throw err;
+    }
+
+    let payload: { data?: unknown };
+    try {
+      payload = await res.json();
+    } catch {
+      throw new Error("Invalid JSON response");
+    }
+
+    return payload.data;
   };
+
+  const load = useCallback(
+    async (signal: AbortSignal) => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const [ov, hm, gn, wc, hr] = await Promise.all([
+          fetchData("overview", signal),
+          fetchData("heatmap", signal),
+          fetchData("genres", signal),
+          fetchData("wordcloud", signal),
+          fetchData("productive-hours", signal),
+        ]);
+        setOverview((ov as IOverview) || null);
+        setHeatmap((hm as IHeatmapDay[]) || []);
+        setGenres((gn as IGenre[]) || []);
+        setWordCloud((wc as IWordCloud[]) || []);
+        setHours((hr as IHour[]) || []);
+      } catch (e) {
+        if ((e as Error).name === "AbortError") {
+          return;
+        }
+
+        console.error(e);
+        const status = (e as Error & { status?: number }).status;
+        const isAuthExpired = status === 401;
+        setError({
+          status,
+          isAuthExpired,
+          message: isAuthExpired
+            ? "Your session has expired. Sign in again to view analytics."
+            : "Failed to load analytics. Please try again.",
+        });
+      } finally {
+        if (!signal.aborted) {
+          setLoading(false);
+        }
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [token, reloadKey]
+  );
 
   useEffect(() => {
     const controller = new AbortController();
-
-    const load = async () => {
-      try {
-        const [ov, hm, gn, wc, hr] = await Promise.all([
-          fetchData("overview", controller.signal),
-          fetchData("heatmap", controller.signal),
-          fetchData("genres", controller.signal),
-          fetchData("wordcloud", controller.signal),
-          fetchData("productive-hours", controller.signal),
-        ]);
-        setOverview(ov || null);
-        setHeatmap(hm || []);
-        setGenres(gn || []);
-        setWordCloud(wc || []);
-        setHours(hr || []);
-      } catch (e) {
-        if ((e as Error).name !== "AbortError") {
-          console.error(e);
-        }
-      } finally {
-        setLoading(false);
-      }
-    };
-    load();
-
+    load(controller.signal);
     return () => controller.abort();
-  }, [token]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [load]);
 
   if (loading) return (
     <div className="flex items-center justify-center py-20">
       <div className="text-indigo-400 text-xl animate-pulse">Loading your analytics...</div>
     </div>
   );
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 py-20 text-center">
+        <p className="text-red-500 dark:text-red-400 text-lg font-medium">
+          {error.message}
+        </p>
+        <div className="flex flex-wrap items-center justify-center gap-3">
+          <button
+            type="button"
+            onClick={() => setReloadKey((key) => key + 1)}
+            className="px-5 py-2.5 rounded-xl bg-indigo-600 hover:bg-indigo-500 text-white font-semibold transition-colors cursor-pointer"
+          >
+            Retry
+          </button>
+          {error.isAuthExpired && (
+            <Link
+              to="/login"
+              className="px-5 py-2.5 rounded-xl border border-slate-300 dark:border-white/20 text-slate-700 dark:text-slate-200 font-semibold hover:bg-slate-100 dark:hover:bg-white/5 transition-colors"
+            >
+              Sign in
+            </Link>
+          )}
+        </div>
+      </div>
+    );
+  }
 
   const maxHour = hours.reduce((max, h) => h.count > max.count ? h : max, hours[0] || { count: 0, hour: 0 });
 


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Fixes #5747
- **Description:** Filled in below
- **Screenshots:** N/A — failure/retry UI covered by component tests

## Screenshot (when helpful)

N/A

## What this PR does

Failed `/analytics/*` requests were only logged, so the page dropped into the normal zero/empty dashboard after loading finished.

Track load failures separately, show an error + Retry path (and Sign in on 401), and keep that distinct from a successful empty account. Added coverage for 401, 5xx, bad JSON, partial Promise.all failure, retry recovery, and true zero-activity.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Fixes #5747

## More screenshots (optional)

N/A

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.

Made with [Cursor](https://cursor.com)