### PR TITLE
fix : added SSR guard to downloadBlob in story-export.utils.ts

### DIFF
--- a/frontend/src/utils/story-export.utils.ts
+++ b/frontend/src/utils/story-export.utils.ts
@@ -16,6 +16,9 @@ export const getSafeFileName = (
 };
 
 export const downloadBlob = (blob: Blob, fileName: string): void => {
+  if (typeof window === "undefined") {
+    return;
+  }
   const url = URL.createObjectURL(blob);
   const link = document.createElement("a");
 


### PR DESCRIPTION
Closes #6164.

Summary of What Has Been Done:
Added a typeof window !== undefined guard to the downloadBlob function in frontend/src/utils/story-export.utils.ts. The function directly uses browser APIs (document.createElement, URL.createObjectURL) which are not available during server-side rendering.

Changes Made:
- frontend/src/utils/story-export.utils.ts: Added SSR guard to downloadBlob

Impact it Made:
- Prevents SSR crash when downloadBlob is called during server-side rendering
- Makes the function safe to import in SSR contexts

Note: Please assign this PR to the `tmdeveloper007` account.