### PR TITLE
fix : removed duplicate function declarations in sanitization.ts

### DIFF
--- a/backend/src/app/utils/sanitization.ts
+++ b/backend/src/app/utils/sanitization.ts
@@ -84,33 +84,3 @@ export const normalizeWhitespace = (input: string): string => {
   if (!input) return '';
   return input.replace(/\s+/g, ' ').trim();
 };
-
-/**
- * Verifies if a URL protocol is safe (http, https, or mailto/tel if needed).
- * Rejects javascript:, data:, vbscript:, file:, about:, jar:, mocha:, livescript:, apt:, etc.
- */
-export const isAllowedUrlProtocol = (url: string): boolean => {
-  if (!url) return false;
-  
-  const trimmed = url.trim().toLowerCase();
-  
-  try {
-    const parsed = new URL(trimmed);
-    const allowed = ['http:', 'https:', 'mailto:', 'tel:'];
-    return allowed.includes(parsed.protocol);
-  } catch (e) {
-    const dangerousPattern = /^(javascript|data|vbscript|file|about|jar|mocha|livescript|apt):/i;
-    if (dangerousPattern.test(trimmed)) {
-      return false;
-    }
-    return !trimmed.includes(':') || trimmed.startsWith('/') || trimmed.startsWith('./') || trimmed.startsWith('../');
-  }
-};
-
-/**
- * Returns a sanitized URL if protocol is allowed, or the fallback string if dangerous.
- */
-export const sanitizeUrl = (url: string, fallback = ''): string => {
-  if (!url) return fallback;
-  return isAllowedUrlProtocol(url) ? url.trim() : fallback;
-};


### PR DESCRIPTION
Closes #6190.

Summary of What Has Been Done:
Removed the duplicate isAllowedUrlProtocol and sanitizeUrl function declarations from backend/src/app/utils/sanitization.ts. The file previously had two definitions of each function, causing TypeScript 'duplicate identifier' compilation errors. The first, more complete implementations were kept; the duplicate second declarations were removed.

Changes Made:
- backend/src/app/utils/sanitization.ts: Removed duplicate isAllowedUrlProtocol (lines 92-108) and duplicate sanitizeUrl (lines 113-115) function declarations

Impact it Made:
- 26 existing sanitization tests all still pass
- Fixes TypeScript 'duplicate identifier' errors for these functions

Note: Please assign this PR to the `tmdeveloper007` account.