### PR TITLE
test : added unit tests for splitIntoChapters and renumberChapters utilities

### DIFF
--- a/frontend/src/utils/__tests__/storyFactSheet.test.ts
+++ b/frontend/src/utils/__tests__/storyFactSheet.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { generateFactSheet, copyFactSheet } from "../storyFactSheet";
+
+describe("generateFactSheet", () => {
+  it("extracts capitalized words as characters", () => {
+    const sheet = generateFactSheet("Emma traveled with Liam through the forest.");
+    expect(sheet.characters).toContain("Emma");
+    expect(sheet.characters).toContain("Liam");
+  });
+
+  it("deduplicates repeated character names", () => {
+    const sheet = generateFactSheet("Emma called Emma again.");
+    const emmaCount = sheet.characters.filter((c) => c === "Emma").length;
+    expect(emmaCount).toBe(1);
+  });
+
+  it("caps characters at five entries", () => {
+    const sheet = generateFactSheet("A B C D E F G H I J");
+    expect(sheet.characters.length).toBeLessThanOrEqual(5);
+  });
+
+  it("returns the expected static sheet fields", () => {
+    const sheet = generateFactSheet("A story about a hero.");
+    expect(sheet.locations).toEqual(["Unknown Location"]);
+    expect(sheet.timeline).toBe("Chronological");
+    expect(sheet.genre).toBe("Adventure");
+    expect(sheet.themes).toEqual(["Friendship", "Courage"]);
+  });
+
+  it("handles empty input without throwing", () => {
+    const sheet = generateFactSheet("");
+    expect(Array.isArray(sheet.characters)).toBe(true);
+    expect(sheet.characters).toEqual([]);
+  });
+
+  it("ignores words that are not capitalized", () => {
+    const sheet = generateFactSheet("the quick brown fox jumped over the lazy dog");
+    expect(sheet.characters).toEqual([]);
+  });
+});
+
+describe("copyFactSheet", () => {
+  it("formats every field into the copy text", () => {
+    const sheet = generateFactSheet("Emma and Liam saved the kingdom.");
+    const text = copyFactSheet(sheet);
+    expect(text).toContain("Characters:");
+    expect(text).toContain("Locations:");
+    expect(text).toContain("Timeline:");
+    expect(text).toContain("Genre:");
+    expect(text).toContain("Themes:");
+    expect(text).toContain("Conflict:");
+    expect(text).toContain("Resolution:");
+  });
+
+  it("includes the character names in the copy text", () => {
+    const sheet = generateFactSheet("Emma and Liam saved the kingdom.");
+    const text = copyFactSheet(sheet);
+    expect(text).toContain("Emma");
+    expect(text).toContain("Liam");
+  });
+});


### PR DESCRIPTION
Closes #6208.

Summary of What Has Been Done:
Cover generateFactSheet and copyFactSheet behavior for a previously untested story utility.

Changes Made:
- frontend/src/utils/__tests__/storyFactSheet.test.ts

Impact it Made:
Small, isolated, independently mergeable improvement to the story-spark-ai frontend, verified locally with the commands listed in the issue.

Note: Please assign this PR to the `tmdeveloper007` account.