### PR TITLE
test : added unit tests for analyzeFoilCharacters utility

### DIFF
--- a/frontend/src/utils/__tests__/foilCharacterAnalyzer.test.ts
+++ b/frontend/src/utils/__tests__/foilCharacterAnalyzer.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { analyzeFoilCharacters } from "../foilCharacterAnalyzer";
+
+describe("analyzeFoilCharacters", () => {
+  it("returns a non-empty list of foil pairs", () => {
+    const pairs = analyzeFoilCharacters();
+    expect(pairs.length).toBeGreaterThan(0);
+  });
+
+  it("returns pairs with the expected shape", () => {
+    const pairs = analyzeFoilCharacters();
+    const pair = pairs[0];
+    expect(pair).toHaveProperty("protagonist");
+    expect(pair).toHaveProperty("foil");
+    expect(pair).toHaveProperty("contrast");
+    expect(pair).toHaveProperty("suggestion");
+  });
+
+  it("includes distinct protagonist and foil names", () => {
+    const pairs = analyzeFoilCharacters();
+    for (const pair of pairs) {
+      expect(pair.protagonist).not.toBe(pair.foil);
+    }
+  });
+
+  it("provides a non-empty contrast for every pair", () => {
+    const pairs = analyzeFoilCharacters();
+    for (const pair of pairs) {
+      expect(pair.contrast.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("provides a non-empty suggestion for every pair", () => {
+    const pairs = analyzeFoilCharacters();
+    for (const pair of pairs) {
+      expect(pair.suggestion.length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
Closes #6222.

Summary of What Has Been Done:
Cover foil-pair shape and contrast/suggestion content in foilCharacterAnalyzer.

Changes Made:
- frontend/src/utils/__tests__/foilCharacterAnalyzer.test.ts

Impact it Made:
Small, isolated, independently mergeable improvement to the story-spark-ai frontend, verified locally with the commands listed in the issue.

Note: Please assign this PR to the `tmdeveloper007` account.