### PR TITLE
test : added unit tests for generateNames utility

### DIFF
--- a/frontend/src/utils/__tests__/storyNamingAssistant.test.ts
+++ b/frontend/src/utils/__tests__/storyNamingAssistant.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { generateNames } from "../storyNamingAssistant";
+
+describe("generateNames", () => {
+  it("returns fantasy character names", () => {
+    const names = generateNames("Fantasy", "Character");
+    expect(names.length).toBeGreaterThan(0);
+    expect(names[0].name.length).toBeGreaterThan(0);
+  });
+
+  it("returns sci-fi city names", () => {
+    const names = generateNames("SciFi", "City");
+    expect(names.length).toBeGreaterThan(0);
+  });
+
+  it("assigns sequential ids", () => {
+    const names = generateNames("Fantasy", "Artifact");
+    names.forEach((name, index) => {
+      expect(name.id).toBe(index + 1);
+    });
+  });
+
+  it("sets the entity type on every suggestion", () => {
+    const names = generateNames("Fantasy", "Kingdom");
+    for (const name of names) {
+      expect(name.entityType).toBe("Kingdom");
+    }
+  });
+
+  it("returns an empty array for an unknown genre", () => {
+    const names = generateNames("Horror", "Character");
+    expect(names).toEqual([]);
+  });
+
+  it("returns an empty array for an unknown entity type", () => {
+    const names = generateNames("Fantasy", "Spaceship");
+    expect(names).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #6223.

Summary of What Has Been Done:
Cover genre/entityType name lookups and empty results for unknown genres in storyNamingAssistant.

Changes Made:
- frontend/src/utils/__tests__/storyNamingAssistant.test.ts

Impact it Made:
Small, isolated, independently mergeable improvement to the story-spark-ai frontend, verified locally with the commands listed in the issue.

Note: Please assign this PR to the `tmdeveloper007` account.