### PR TITLE
test : added unit tests for generateEndingAlternatives utility

### DIFF
--- a/frontend/src/utils/__tests__/storyEndingAlternatives.test.ts
+++ b/frontend/src/utils/__tests__/storyEndingAlternatives.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import {
+  generateEndingAlternatives,
+  regenerateEndingAlternatives,
+} from "../storyEndingAlternatives";
+
+describe("generateEndingAlternatives", () => {
+  it("returns an empty array for empty text", () => {
+    expect(generateEndingAlternatives("")).toEqual([]);
+    expect(generateEndingAlternatives("   ")).toEqual([]);
+  });
+
+  it("returns alternatives for a non-empty story", () => {
+    const result = generateEndingAlternatives("The heroes approached the final gate.");
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("returns alternatives with the expected shape", () => {
+    const result = generateEndingAlternatives("The final battle begins.");
+    const alt = result[0];
+    expect(alt).toHaveProperty("id");
+    expect(alt).toHaveProperty("title");
+    expect(alt).toHaveProperty("style");
+    expect(alt).toHaveProperty("emotionalImpact");
+    expect(alt).toHaveProperty("content");
+  });
+
+  it("assigns sequential ids", () => {
+    const result = generateEndingAlternatives("The journey is ending.");
+    result.forEach((alt, index) => {
+      expect(alt.id).toBe(index + 1);
+    });
+  });
+
+  it("provides non-empty content for every alternative", () => {
+    const result = generateEndingAlternatives("The quest has concluded.");
+    for (const alt of result) {
+      expect(alt.content.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("regenerateEndingAlternatives returns the same result", () => {
+    const story = "The heroes won the day.";
+    expect(regenerateEndingAlternatives(story)).toEqual(generateEndingAlternatives(story));
+  });
+});


### PR DESCRIPTION
Closes #6231.

Summary of What Has Been Done:
Cover ending-alternative shape and empty-input behavior in storyEndingAlternatives.

Changes Made:
- frontend/src/utils/__tests__/storyEndingAlternatives.test.ts

Impact it Made:
Small, isolated, independently mergeable improvement to the story-spark-ai frontend, verified locally with the commands listed in the issue.

Note: Please assign this PR to the `tmdeveloper007` account.