### PR TITLE
test : added unit tests for useReadingStats hook

### DIFF
--- a/frontend/src/utils/__tests__/narrativeFlowAnalyzer.test.ts
+++ b/frontend/src/utils/__tests__/narrativeFlowAnalyzer.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { analyzeNarrativeFlow } from "../narrativeFlowAnalyzer";
+
+describe("analyzeNarrativeFlow", () => {
+  it("returns an empty array for a clean story", () => {
+    const issues = analyzeNarrativeFlow("The hero walked calmly through the valley.");
+    expect(issues).toEqual([]);
+  });
+
+  it("flags 'Suddenly' as an abrupt transition", () => {
+    const issues = analyzeNarrativeFlow("Suddenly the door burst open.");
+    const abrupt = issues.find((i) => i.type === "Abrupt Transition");
+    expect(abrupt).toBeDefined();
+    expect(abrupt?.severity).toBe("High");
+  });
+
+  it("flags repeated 'Then' usage as repetition", () => {
+    const story = "Then he left. Then she cried. Then he returned. Then they talked. Then they parted. Then it ended.";
+    const issues = analyzeNarrativeFlow(story);
+    const repetition = issues.find((i) => i.type === "Repetition");
+    expect(repetition).toBeDefined();
+    expect(repetition?.severity).toBe("Medium");
+  });
+
+  it("does not flag a single 'Then'", () => {
+    const issues = analyzeNarrativeFlow("Then he left.");
+    expect(issues.find((i) => i.type === "Repetition")).toBeUndefined();
+  });
+
+  it("returns issues with the expected shape", () => {
+    const issues = analyzeNarrativeFlow("Suddenly everything changed.");
+    const issue = issues[0];
+    expect(issue).toHaveProperty("id");
+    expect(issue).toHaveProperty("type");
+    expect(issue).toHaveProperty("severity");
+    expect(issue).toHaveProperty("scene");
+    expect(issue).toHaveProperty("explanation");
+    expect(issue).toHaveProperty("suggestion");
+  });
+});


### PR DESCRIPTION
Closes #6294.

Summary of What Has Been Done:
Cover analyzeNarrativeFlow abrupt-transition and repetition detection.

Changes Made:
- frontend/src/utils/__tests__/narrativeFlowAnalyzer.test.ts

Impact it Made:
Small, isolated, independently mergeable improvement to the story-spark-ai frontend, verified locally with the commands listed in the issue.

Note: Please assign this PR to the `tmdeveloper007` account.