### PR TITLE
test : added unit tests for useThemeConsistency hook

### DIFF
--- a/frontend/src/utils/__tests__/storyRewrite.test.ts
+++ b/frontend/src/utils/__tests__/storyRewrite.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import {
+  rewriteStory,
+  getCreativityDescription,
+} from "../storyRewrite";
+
+describe("rewriteStory", () => {
+  it("returns the story unchanged in the response", () => {
+    const result = rewriteStory({ story: "A tale.", creativity: "Balanced" });
+    expect(result.rewrittenStory).toBe("A tale.");
+  });
+
+  it("returns the expected response shape", () => {
+    const result = rewriteStory({ story: "A tale.", creativity: "High" });
+    expect(result).toHaveProperty("rewrittenStory");
+  });
+});
+
+describe("getCreativityDescription", () => {
+  it("describes the Low level", () => {
+    expect(getCreativityDescription("Low")).toContain("original wording");
+  });
+
+  it("describes the Balanced level", () => {
+    expect(getCreativityDescription("Balanced")).toContain("originality");
+  });
+
+  it("describes the High level", () => {
+    expect(getCreativityDescription("High")).toContain("creative");
+  });
+
+  it("describes the Experimental level", () => {
+    expect(getCreativityDescription("Experimental")).toContain("stylistic");
+  });
+});


### PR DESCRIPTION
Closes #6296.

Summary of What Has Been Done:
Cover rewriteStory response shape and getCreativityDescription tiers.

Changes Made:
- frontend/src/utils/__tests__/storyRewrite.test.ts

Impact it Made:
Small, isolated, independently mergeable improvement to the story-spark-ai frontend, verified locally with the commands listed in the issue.

Note: Please assign this PR to the `tmdeveloper007` account.