### PR TITLE
docs : added documentation for storySessionRecovery utility

### DIFF
--- a/docs/story-session-recovery.md
+++ b/docs/story-session-recovery.md
@@ -1,0 +1,48 @@
+# storySessionRecovery Utility
+
+The `storySessionRecovery` utilities in
+`frontend/src/utils/storySessionRecovery.ts` persist and restore a draft story
+across page reloads.
+
+## Usage
+
+```ts
+import {
+  saveDraft,
+  getRecoveredDraft,
+  discardRecoveredDraft,
+  formatSavedTime,
+} from "../utils/storySessionRecovery";
+```
+
+## API
+
+- `saveDraft(content: string)` — stores the draft in localStorage under the key
+  `story-session-recovery` and returns the stored `StoryRecoveryData`.
+- `getRecoveredDraft()` — returns `StoryRecoveryData | null`, or `null` when
+  nothing is stored or the stored JSON is invalid.
+- `discardRecoveredDraft()` — removes the stored draft.
+- `formatSavedTime(savedAt: string)` — formats an ISO timestamp using the
+  locale string format.
+
+## Storage Shape
+
+```ts
+interface StoryRecoveryData {
+  content: string;
+  savedAt: string; // ISO timestamp
+}
+```
+
+## Example
+
+```ts
+saveDraft("Chapter one...");
+const draft = getRecoveredDraft(); // { content, savedAt }
+discardRecoveredDraft();
+```
+
+## Tests
+
+Covered by the story session recovery docs and the utility unit tests in
+`frontend/src/utils/__tests__/`.


### PR DESCRIPTION
Closes #6272.

Summary of What Has Been Done:
Document saveDraft, getRecoveredDraft, and discardRecoveredDraft localStorage behaviors.

Changes Made:
- docs/story-session-recovery.md

Impact it Made:
Small, isolated, independently mergeable improvement to the story-spark-ai frontend, verified locally with the commands listed in the issue.

Note: Please assign this PR to the `tmdeveloper007` account.