### PR TITLE
fix : return zero reading time for empty text in analyzeReadingInfo utility

### DIFF
--- a/frontend/src/utils/storyReadingInfo.ts
+++ b/frontend/src/utils/storyReadingInfo.ts
@@ -33,10 +33,10 @@ export function analyzeReadingInfo(
 
   return {
     wordCount,
-    readingTime: Math.max(
-      1,
-      Math.ceil(wordCount / WORDS_PER_MINUTE)
-    ),
+    readingTime:
+      wordCount === 0
+        ? 0
+        : Math.max(1, Math.ceil(wordCount / WORDS_PER_MINUTE)),
     difficulty,
   };
 }


### PR DESCRIPTION
Closes #6232.

Summary of What Has Been Done:
analyzeReadingInfo returned a reading time of 1 minute for empty text; it now returns 0 when the word count is zero.

Changes Made:
- frontend/src/utils/storyReadingInfo.ts

Impact it Made:
Small, isolated, independently mergeable improvement to the story-spark-ai frontend, verified locally with the commands listed in the issue.

Note: Please assign this PR to the `tmdeveloper007` account.