### PR TITLE
fix : added zero-division guard to diversity score in storyVocabularyGrowthTracker utility

### DIFF
--- a/frontend/src/utils/storyVocabularyGrowthTracker.ts
+++ b/frontend/src/utils/storyVocabularyGrowthTracker.ts
@@ -74,9 +74,10 @@ export function analyzeVocabulary(
   return {
     totalWords: words.length,
     uniqueWords: frequency.size,
-    diversityScore: Math.round(
-      (frequency.size / words.length) * 100
-    ),
+    diversityScore:
+      words.length === 0
+        ? 0
+        : Math.round((frequency.size / words.length) * 100),
     overusedWords,
     growthHistory: [
       {


### PR DESCRIPTION
Closes #6233.

Summary of What Has Been Done:
analyzeVocabulary computed diversityScore as unique/total which became NaN for stop-words-only input; it now returns 0 when no content words remain.

Changes Made:
- frontend/src/utils/storyVocabularyGrowthTracker.ts

Impact it Made:
Small, isolated, independently mergeable improvement to the story-spark-ai frontend, verified locally with the commands listed in the issue.

Note: Please assign this PR to the `tmdeveloper007` account.