### PR TITLE
fix : added localStorage SSR guards to storyEditingSessionStatistics utility

### DIFF
--- a/frontend/src/utils/storyEditingSessionStatistics.ts
+++ b/frontend/src/utils/storyEditingSessionStatistics.ts
@@ -48,6 +48,10 @@ export function calculateEditingSession(
 }
 
 export function getSessionHistory(): EditingSessionHistory[] {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
   try {
     return JSON.parse(
       localStorage.getItem("editing-session-history") || "[]"
@@ -60,6 +64,10 @@ export function getSessionHistory(): EditingSessionHistory[] {
 export function saveSessionHistory(
   history: EditingSessionHistory[]
 ) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
   localStorage.setItem(
     "editing-session-history",
     JSON.stringify(history)


### PR DESCRIPTION
Closes #6234.

Summary of What Has Been Done:
getSessionHistory and saveSessionHistory touched localStorage directly, crashing during SSR; both now guard on typeof window before touching storage.

Changes Made:
- frontend/src/utils/storyEditingSessionStatistics.ts

Impact it Made:
Small, isolated, independently mergeable improvement to the story-spark-ai frontend, verified locally with the commands listed in the issue.

Note: Please assign this PR to the `tmdeveloper007` account.