### PR TITLE
fix : added localStorage SSR guards to storySessionRecovery utility

### DIFF
--- a/frontend/src/utils/storySessionRecovery.ts
+++ b/frontend/src/utils/storySessionRecovery.ts
@@ -11,15 +11,21 @@ export function saveDraft(content: string) {
     savedAt: new Date().toISOString(),
   };
 
-  localStorage.setItem(
-    STORAGE_KEY,
-    JSON.stringify(draft)
-  );
+  if (typeof window !== "undefined") {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify(draft)
+    );
+  }
 
   return draft;
 }
 
 export function getRecoveredDraft(): StoryRecoveryData | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
   const data = localStorage.getItem(STORAGE_KEY);
 
   if (!data) return null;
@@ -32,6 +38,10 @@ export function getRecoveredDraft(): StoryRecoveryData | null {
 }
 
 export function discardRecoveredDraft() {
+  if (typeof window === "undefined") {
+    return;
+  }
+
   localStorage.removeItem(STORAGE_KEY);
 }
 


### PR DESCRIPTION
Closes #6235.

Summary of What Has Been Done:
saveDraft, getRecoveredDraft, and discardRecoveredDraft used localStorage without guards, crashing in non-browser environments; all three now check typeof window first.

Changes Made:
- frontend/src/utils/storySessionRecovery.ts

Impact it Made:
Small, isolated, independently mergeable improvement to the story-spark-ai frontend, verified locally with the commands listed in the issue.

Note: Please assign this PR to the `tmdeveloper007` account.