### PR TITLE
fix : make analyzeDialogue deterministic in dialogueStyleAnalyzer utility

### DIFF
--- a/frontend/src/utils/dialogueStyleAnalyzer.ts
+++ b/frontend/src/utils/dialogueStyleAnalyzer.ts
@@ -1,48 +1,53 @@
-import { CharacterDialogueAnalysis } from "../types/dialogue";
+export interface CharacterDialogueAnalysis {
+  id: number;
+  character: string;
+  uniquenessScore: number;
+  vocabularyStyle: string;
+  speechPattern: string;
+  similarTo?: string;
+  suggestions: string[];
+}
 
 export function analyzeDialogue(story: string): CharacterDialogueAnalysis[] {
-
   const characters = ["Alice", "John", "King"];
 
   return characters.map((name, index) => {
+    const nameCount = story
+      .toLowerCase()
+      .split(name.toLowerCase())
+      .length - 1;
 
-    let score = Math.floor(Math.random() * 35) + 65;
+    const base = 65 + (index * 5) % 20;
+    const score = Math.min(
+      100,
+      Math.max(65, base + nameCount * 2)
+    );
 
     return {
-
       id: index + 1,
-
       character: name,
-
       uniquenessScore: score,
-
       vocabularyStyle:
         score > 85
           ? "Distinct"
           : "Moderately Distinct",
-
       speechPattern:
         score > 85
           ? "Unique tone and sentence structure"
           : "Similar wording with other characters",
-
       similarTo:
         score < 75
           ? "John"
           : undefined,
-
       suggestions: score < 75
         ? [
             "Use unique catchphrases.",
             "Vary sentence length.",
-            "Adjust vocabulary."
+            "Adjust vocabulary.",
           ]
         : [
-            "Dialogue style is consistent."
-          ]
-
+            "Dialogue style is consistent.",
+          ],
     };
-
   });
-
 }


### PR DESCRIPTION
Closes #6236.

Summary of What Has Been Done:
analyzeDialogue used Math.random for uniqueness scores, giving different results each render, and imported a missing types module; it now derives scores deterministically from character mentions and defines the result type locally.

Changes Made:
- frontend/src/utils/dialogueStyleAnalyzer.ts

Impact it Made:
Small, isolated, independently mergeable improvement to the story-spark-ai frontend, verified locally with the commands listed in the issue.

Note: Please assign this PR to the `tmdeveloper007` account.