### PR TITLE
fix : return computed pacing instead of cycling fixed values in storyPaceHeatmap utility

### DIFF
--- a/frontend/src/utils/storyPaceHeatmap.ts
+++ b/frontend/src/utils/storyPaceHeatmap.ts
@@ -6,6 +6,22 @@ export interface PaceSection {
   suggestion: string;
 }
 
+const SUGGESTIONS: Record<PaceSection["pace"], string> = {
+  Fast: "Consider adding more descriptive details to slow the pacing slightly.",
+  Balanced: "This section has a healthy pacing balance.",
+  Slow: "Consider shortening descriptions or adding dialogue/action.",
+};
+
+function classifyPace(words: string[]): PaceSection["pace"] {
+  const sentences = words.join(" ").split(/[.!?]+/).filter(Boolean).length;
+  const avgWordsPerSentence =
+    sentences === 0 ? 0 : Math.round(words.length / sentences);
+
+  if (avgWordsPerSentence <= 12) return "Fast";
+  if (avgWordsPerSentence >= 24) return "Slow";
+  return "Balanced";
+}
+
 export function analyzeStoryPace(
   story: string
 ): PaceSection[] {
@@ -15,26 +31,23 @@ export function analyzeStoryPace(
     .split(/\n{2,}/)
     .filter(Boolean);
 
-  return sections.map((_, index) => {
-    const paceTypes = ["Fast", "Balanced", "Slow"] as const;
-    const pace = paceTypes[index % 3];
+  return sections.map((section, index) => {
+    const words = section.trim().split(/\s+/).filter(Boolean);
+    const pace = classifyPace(words);
+
+    const score =
+      pace === "Fast"
+        ? 90
+        : pace === "Balanced"
+        ? 65
+        : 35;
 
     return {
       id: index + 1,
       title: `Section ${index + 1}`,
       pace,
-      score:
-        pace === "Fast"
-          ? 90
-          : pace === "Balanced"
-          ? 65
-          : 35,
-      suggestion:
-        pace === "Fast"
-          ? "Consider adding more descriptive details to slow the pacing slightly."
-          : pace === "Balanced"
-          ? "This section has a healthy pacing balance."
-          : "Consider shortening descriptions or adding dialogue/action.",
+      score,
+      suggestion: SUGGESTIONS[pace],
     };
   });
 }


### PR DESCRIPTION
Closes #6237.

Summary of What Has Been Done:
analyzeStoryPace cycled Fast/Balanced/Slow by section index regardless of content; it now derives pace from average words per sentence and gives a consistent suggestion per pace.

Changes Made:
- frontend/src/utils/storyPaceHeatmap.ts

Impact it Made:
Small, isolated, independently mergeable improvement to the story-spark-ai frontend, verified locally with the commands listed in the issue.

Note: Please assign this PR to the `tmdeveloper007` account.