### PR TITLE
fix : derive overall suspense score from sections in storySuspenseAnalyzer utility

### DIFF
--- a/frontend/src/utils/storySuspenseAnalyzer.ts
+++ b/frontend/src/utils/storySuspenseAnalyzer.ts
@@ -12,6 +12,60 @@ export interface SuspenseAnalysis {
   sections: SuspenseSection[];
 }
 
+const TENSION_KEYWORDS = [
+  "suddenly",
+  "mystery",
+  "secret",
+  "unknown",
+  "dark",
+  "shadow",
+  "danger",
+  "fear",
+  "chase",
+  "discover",
+];
+
+function scoreSection(text: string): number {
+  const lower = text.toLowerCase();
+  const hits = TENSION_KEYWORDS.reduce(
+    (sum, keyword) => sum + (lower.match(new RegExp(keyword, "g")) || []).length,
+    0
+  );
+  const words = lower.split(/\s+/).filter(Boolean).length;
+
+  if (words === 0) return 0;
+
+  return Math.min(100, Math.round((hits / words) * 500));
+}
+
+function statusFor(score: number): SuspenseSection["status"] {
+  if (score >= 70) return "High";
+  if (score >= 40) return "Medium";
+  return "Low";
+}
+
+function observationFor(status: SuspenseSection["status"]): string {
+  switch (status) {
+    case "High":
+      return "Conflict escalates effectively with strong anticipation.";
+    case "Medium":
+      return "The section builds moderate tension.";
+    default:
+      return "The section resolves calmly without strong suspense.";
+  }
+}
+
+function suggestionFor(status: SuspenseSection["status"]): string {
+  switch (status) {
+    case "High":
+      return "Maintain momentum by increasing uncertainty before the climax.";
+    case "Medium":
+      return "Introduce a small twist or hidden detail to raise stakes.";
+    default:
+      return "Delay key revelations and introduce unexpected twists for greater impact.";
+  }
+}
+
 export function analyzeStorySuspense(
   story: string
 ): SuspenseAnalysis {
@@ -22,40 +76,35 @@ export function analyzeStorySuspense(
     };
   }
 
+  const sections = story
+    .split(/\n{2,}/)
+    .filter((section) => section.trim());
+
+  const analyzed = sections.map((section, index) => {
+    const tensionScore = scoreSection(section);
+    const status = statusFor(tensionScore);
+
+    return {
+      id: index + 1,
+      title: `Section ${index + 1}`,
+      tensionScore,
+      status,
+      observation: observationFor(status),
+      suggestion: suggestionFor(status),
+    };
+  });
+
+  const overallScore =
+    analyzed.length === 0
+      ? 0
+      : Math.round(
+          analyzed.reduce((sum, s) => sum + s.tensionScore, 0) /
+            analyzed.length
+        );
+
   return {
-    overallScore: 84,
-    sections: [
-      {
-        id: 1,
-        title: "Opening",
-        tensionScore: 72,
-        status: "Medium",
-        observation:
-          "The opening establishes context but introduces conflict slowly.",
-        suggestion:
-          "Begin with a stronger hook or mystery to capture attention immediately.",
-      },
-      {
-        id: 2,
-        title: "Middle",
-        tensionScore: 91,
-        status: "High",
-        observation:
-          "Conflict escalates effectively with strong anticipation.",
-        suggestion:
-          "Maintain momentum by increasing uncertainty before the climax.",
-      },
-      {
-        id: 3,
-        title: "Ending",
-        tensionScore: 63,
-        status: "Low",
-        observation:
-          "The final reveal feels predictable and lacks a strong cliffhanger.",
-        suggestion:
-          "Delay key revelations and introduce unexpected twists for greater impact.",
-      },
-    ],
+    overallScore,
+    sections: analyzed,
   };
 }
 


### PR DESCRIPTION
Closes #6238.

Summary of What Has Been Done:
analyzeStorySuspense returned fixed scores and a hardcoded overall score regardless of input; it now computes per-section tension from keyword density and averages the section scores.

Changes Made:
- frontend/src/utils/storySuspenseAnalyzer.ts

Impact it Made:
Small, isolated, independently mergeable improvement to the story-spark-ai frontend, verified locally with the commands listed in the issue.

Note: Please assign this PR to the `tmdeveloper007` account.