### PR TITLE
fix : guard zero-length input in generateStoryAnalytics utility

### DIFF
--- a/frontend/src/utils/storyReadingAnalytics.ts
+++ b/frontend/src/utils/storyReadingAnalytics.ts
@@ -13,6 +13,18 @@ export function generateStoryAnalytics(
 ): StoryAnalytics {
   const words = story.trim().split(/\s+/).filter(Boolean).length;
 
+  if (words === 0) {
+    return {
+      totalViews: 0,
+      averageReadingTime: 0,
+      completionRate: 0,
+      likes: 0,
+      bookmarks: 0,
+      shares: 0,
+      engagementTrend: [],
+    };
+  }
+
   return {
     totalViews: 1248,
     averageReadingTime: Math.max(1, Math.ceil(words / 200)),


### PR DESCRIPTION
Closes #6239.

Summary of What Has Been Done:
generateStoryAnalytics returned a positive reading time and fake engagement stats for empty input; it now returns zeroed metrics when the story has no words.

Changes Made:
- frontend/src/utils/storyReadingAnalytics.ts

Impact it Made:
Small, isolated, independently mergeable improvement to the story-spark-ai frontend, verified locally with the commands listed in the issue.

Note: Please assign this PR to the `tmdeveloper007` account.