### PR TITLE
fix : clamp negative weights in normalizeWeights utility in genreWeights

### DIFF
--- a/frontend/src/utils/genreWeights.ts
+++ b/frontend/src/utils/genreWeights.ts
@@ -14,7 +14,12 @@ export const normalizeWeights = (
     return { genres: [] };
   }
 
-  const total = config.genres.reduce(
+  const clamped = config.genres.map((g) => ({
+    ...g,
+    weight: Math.max(0, g.weight),
+  }));
+
+  const total = clamped.reduce(
     (sum, g) => sum + g.weight,
     0
   );
@@ -24,7 +29,7 @@ export const normalizeWeights = (
   }
 
   return {
-    genres: config.genres.map((g) => ({
+    genres: clamped.map((g) => ({
       ...g,
       weight: Math.round((g.weight / total) * 100),
     })),


### PR DESCRIPTION
Closes #6240.

Summary of What Has Been Done:
normalizeWeights divided by the raw sum, so negative weights skewed percentages; individual weights are now clamped to non-negative values before normalization.

Changes Made:
- frontend/src/utils/genreWeights.ts

Impact it Made:
Small, isolated, independently mergeable improvement to the story-spark-ai frontend, verified locally with the commands listed in the issue.

Note: Please assign this PR to the `tmdeveloper007` account.