### PR TITLE
fix : added zero and NaN division safety guards to calculateSessionProgress utility

### DIFF
--- a/frontend/src/utils/storyWritingSessionGoalsTracker.ts
+++ b/frontend/src/utils/storyWritingSessionGoalsTracker.ts
@@ -40,20 +40,20 @@ export function calculateSessionProgress(
     (Date.now() - startTime) / 60000
   );
 
-  const wordProgress = Math.min(
-    (wordCount / goals.targetWords) * 100,
-    100
-  );
+  const wordProgress =
+    goals.targetWords > 0
+      ? Math.min((wordCount / goals.targetWords) * 100, 100)
+      : 0;
 
-  const timeProgress = Math.min(
-    (minutes / goals.targetMinutes) * 100,
-    100
-  );
+  const timeProgress =
+    goals.targetMinutes > 0
+      ? Math.min((minutes / goals.targetMinutes) * 100, 100)
+      : 0;
 
-  const chapterProgress = Math.min(
-    (chapterCount / goals.targetChapters) * 100,
-    100
-  );
+  const chapterProgress =
+    goals.targetChapters > 0
+      ? Math.min((chapterCount / goals.targetChapters) * 100, 100)
+      : 0;
 
   let milestone = "Keep Writing!";
 


### PR DESCRIPTION
Closes #6242.

Summary of What Has Been Done:
calculateSessionProgress divided by targetWords/targetMinutes/targetChapters, producing NaN when goals were zero; progress now defaults to 0 for non-positive targets.

Changes Made:
- frontend/src/utils/storyWritingSessionGoalsTracker.ts

Impact it Made:
Small, isolated, independently mergeable improvement to the story-spark-ai frontend, verified locally with the commands listed in the issue.

Note: Please assign this PR to the `tmdeveloper007` account.