### PR TITLE
fix : strip surrounding quotes before counting dialogue in storyComparisonMetrics utility

### DIFF
--- a/frontend/src/utils/storyComparisonMetrics.ts
+++ b/frontend/src/utils/storyComparisonMetrics.ts
@@ -18,6 +18,8 @@ export function calculateStoryMetrics(
     words.map((word) => word.toLowerCase())
   );
 
+  const dialoguePairs = (story.match(/"[^"]*"/g) || []).length;
+
   return {
     wordCount,
     readingTime: Math.max(1, Math.ceil(wordCount / 200)),
@@ -26,9 +28,7 @@ export function calculateStoryMetrics(
     ),
     dialoguePercentage: Math.min(
       100,
-      Math.round(
-        ((story.match(/"/g)?.length || 0) / 2) * 5
-      )
+      Math.round(dialoguePairs * 5)
     ),
     pacing:
       wordCount > 800


### PR DESCRIPTION
Closes #6243.

Summary of What Has Been Done:
calculateStoryMetrics counted every double-quote character, so escaped or stray quotes inflated the dialogue percentage; it now counts complete quoted segments as pairs.

Changes Made:
- frontend/src/utils/storyComparisonMetrics.ts

Impact it Made:
Small, isolated, independently mergeable improvement to the story-spark-ai frontend, verified locally with the commands listed in the issue.

Note: Please assign this PR to the `tmdeveloper007` account.