### PR TITLE
fix : handle titles with only whitespace in analyzeTitle utility

### DIFF
--- a/frontend/src/utils/storyTitleRating.ts
+++ b/frontend/src/utils/storyTitleRating.ts
@@ -12,7 +12,21 @@ export interface TitleAnalysis {
 export function analyzeTitle(
   title: string
 ): TitleAnalysis {
-  const length = title.trim().length;
+  const trimmed = title.trim();
+  const length = trimmed.length;
+
+  if (length === 0) {
+    return {
+      score: 0,
+      creativity: 0,
+      relevance: 0,
+      clarity: 0,
+      appeal: 0,
+      strengths: [],
+      weaknesses: ["The title is empty."],
+      suggestions: ["Add a short, memorable title."],
+    };
+  }
 
   const score =
     length > 10 && length < 50 ? 88 : 70;
@@ -34,9 +48,9 @@ export function analyzeTitle(
     ],
 
     suggestions: [
-      `${title} Chronicles`,
-      `The ${title}`,
-      `${title}: A New Beginning`,
+      `${trimmed} Chronicles`,
+      `The ${trimmed}`,
+      `${trimmed}: A New Beginning`,
     ],
   };
 }


### PR DESCRIPTION
Closes #6244.

Summary of What Has Been Done:
analyzeTitle produced nonsense suggestions for whitespace-only titles; it now returns a zeroed report with a helpful suggestion for blank titles.

Changes Made:
- frontend/src/utils/storyTitleRating.ts

Impact it Made:
Small, isolated, independently mergeable improvement to the story-spark-ai frontend, verified locally with the commands listed in the issue.

Note: Please assign this PR to the `tmdeveloper007` account.