### PR TITLE
fix : guard zero total in getDialogueDistribution utility

### DIFF
--- a/frontend/src/utils/dialogueDistribution.ts
+++ b/frontend/src/utils/dialogueDistribution.ts
@@ -14,6 +14,13 @@ export function getDialogueDistribution(): CharacterDialogue[] {
 
   const total = characters.reduce((sum, c) => sum + c.lines, 0);
 
+  if (total === 0) {
+    return characters.map((c) => ({
+      ...c,
+      percentage: 0,
+    }));
+  }
+
   return characters.map((c) => ({
     ...c,
     percentage: Math.round((c.lines / total) * 100),


### PR DESCRIPTION
Closes #6245.

Summary of What Has Been Done:
getDialogueDistribution divided by the total line count, producing NaN percentages when the total was zero; it now returns zero percentages in that case.

Changes Made:
- frontend/src/utils/dialogueDistribution.ts

Impact it Made:
Small, isolated, independently mergeable improvement to the story-spark-ai frontend, verified locally with the commands listed in the issue.

Note: Please assign this PR to the `tmdeveloper007` account.