### PR TITLE
fix : added SSR guard to scrollToChapter helper

### DIFF
--- a/frontend/src/utils/scroll-to-chapter.ts
+++ b/frontend/src/utils/scroll-to-chapter.ts
@@ -6,6 +6,7 @@
  * shared ref or context.
  */
 export function scrollToChapter(chapterId: number): void {
+  if (typeof document === "undefined") return;
   const node = document.getElementById(`chapter-${chapterId}`);
   if (!node) return;
   node.scrollIntoView({ behavior: "smooth", block: "start" });


### PR DESCRIPTION
Closes #6246.

Summary of What Has Been Done:
scrollToChapter called document.getElementById directly, crashing in non-browser environments; it now returns early when document is unavailable.

Changes Made:
- frontend/src/utils/scroll-to-chapter.ts

Impact it Made:
Small, isolated, independently mergeable improvement to the story-spark-ai frontend, verified locally with the commands listed in the issue.

Note: Please assign this PR to the `tmdeveloper007` account.