### PR TITLE
feat : added scene count and word density helpers to storySceneNavigator utility

### DIFF
--- a/frontend/src/utils/storySceneNavigator.ts
+++ b/frontend/src/utils/storySceneNavigator.ts
@@ -29,3 +29,24 @@ export function renameScene(
       : scene
   );
 }
+
+export function getSceneCount(
+  story: string
+): number {
+  return detectScenes(story).length;
+}
+
+export function getSceneWordDensity(
+  scenes: StoryScene[]
+): number {
+  if (scenes.length === 0) return 0;
+
+  const totalWords = scenes.reduce(
+    (sum, scene) =>
+      sum +
+      scene.content.trim().split(/\s+/).filter(Boolean).length,
+    0
+  );
+
+  return Math.round(totalWords / scenes.length);
+}


### PR DESCRIPTION
Closes #6248.

Summary of What Has Been Done:
Added getSceneCount and getSceneWordDensity helpers so components can show scene metrics without re-splitting the story.

Changes Made:
- frontend/src/utils/storySceneNavigator.ts

Impact it Made:
Small, isolated, independently mergeable improvement to the story-spark-ai frontend, verified locally with the commands listed in the issue.

Note: Please assign this PR to the `tmdeveloper007` account.