### PR TITLE
feat : added highestTensionSection helper to storySuspenseAnalyzer utility

### DIFF
--- a/frontend/src/utils/storySuspenseAnalyzer.ts
+++ b/frontend/src/utils/storySuspenseAnalyzer.ts
@@ -59,6 +59,16 @@ export function analyzeStorySuspense(
   };
 }
 
+export function highestTensionSection(
+  analysis: SuspenseAnalysis
+): SuspenseSection | undefined {
+  if (analysis.sections.length === 0) return undefined;
+
+  return analysis.sections.reduce((highest, section) =>
+    section.tensionScore > highest.tensionScore ? section : highest
+  );
+}
+
 export function refreshSuspenseAnalysis(story: string) {
   return analyzeStorySuspense(story);
 }


### PR DESCRIPTION
Closes #6252.

Summary of What Has Been Done:
Added highestTensionSection to return the section with the maximum tension score for highlighting story peaks.

Changes Made:
- frontend/src/utils/storySuspenseAnalyzer.ts

Impact it Made:
Small, isolated, independently mergeable improvement to the story-spark-ai frontend, verified locally with the commands listed in the issue.

Note: Please assign this PR to the `tmdeveloper007` account.