### PR TITLE
feat : added estimateRevisionTime helper to revisionPlanner utility

### DIFF
--- a/frontend/src/utils/revisionPlanner.ts
+++ b/frontend/src/utils/revisionPlanner.ts
@@ -53,3 +53,20 @@ export function generateRevisionPlan(
 
   return tasks;
 }
+
+export function estimateRevisionTime(
+  tasks: RevisionTask[]
+): number {
+  const minutes = tasks.reduce((sum, task) => {
+    switch (task.priority) {
+      case "High":
+        return sum + 45;
+      case "Medium":
+        return sum + 25;
+      default:
+        return sum + 10;
+    }
+  }, 0);
+
+  return minutes;
+}


### PR DESCRIPTION
Closes #6255.

Summary of What Has Been Done:
Added estimateRevisionTime to estimate effort in minutes from task priorities.

Changes Made:
- frontend/src/utils/revisionPlanner.ts

Impact it Made:
Small, isolated, independently mergeable improvement to the story-spark-ai frontend, verified locally with the commands listed in the issue.

Note: Please assign this PR to the `tmdeveloper007` account.