### PR TITLE
feat : added topOverusedWord helper to storyVocabularyGrowthTracker utility

### DIFF
--- a/frontend/src/utils/storyVocabularyGrowthTracker.ts
+++ b/frontend/src/utils/storyVocabularyGrowthTracker.ts
@@ -95,6 +95,12 @@ export function analyzeVocabulary(
   };
 }
 
+export function topOverusedWord(
+  stats: VocabularyStats
+): VocabularyStats["overusedWords"][number] | undefined {
+  return stats.overusedWords[0];
+}
+
 export function refreshVocabularyAnalysis(
   story: string
 ) {


### PR DESCRIPTION
Closes #6256.

Summary of What Has Been Done:
Added topOverusedWord to return the single most overused word for quick-fix surfaces.

Changes Made:
- frontend/src/utils/storyVocabularyGrowthTracker.ts

Impact it Made:
Small, isolated, independently mergeable improvement to the story-spark-ai frontend, verified locally with the commands listed in the issue.

Note: Please assign this PR to the `tmdeveloper007` account.