### PR TITLE
feat : added estimatedReadTimeSeconds helper to storyPublishingReadiness utility

### DIFF
--- a/frontend/src/utils/storyPublishingReadiness.ts
+++ b/frontend/src/utils/storyPublishingReadiness.ts
@@ -75,6 +75,17 @@ export function analyzePublishingReadiness(
   };
 }
 
+export function estimatedReadTimeSeconds(
+  story: string,
+  wordsPerMinute = 200
+): number {
+  const words = story.trim().split(/\s+/).filter(Boolean).length;
+
+  if (words === 0 || wordsPerMinute <= 0) return 0;
+
+  return Math.ceil((words / wordsPerMinute) * 60);
+}
+
 export function rerunPublishingAnalysis(
   story: string
 ) {


### PR DESCRIPTION
Closes #6258.

Summary of What Has Been Done:
Added estimatedReadTimeSeconds to estimate story reading time in seconds for reader-facing UI.

Changes Made:
- frontend/src/utils/storyPublishingReadiness.ts

Impact it Made:
Small, isolated, independently mergeable improvement to the story-spark-ai frontend, verified locally with the commands listed in the issue.

Note: Please assign this PR to the `tmdeveloper007` account.