### PR TITLE
feat : added getPaceDistribution helper to storyPaceHeatmap utility

### DIFF
--- a/frontend/src/utils/storyPaceHeatmap.ts
+++ b/frontend/src/utils/storyPaceHeatmap.ts
@@ -39,6 +39,18 @@ export function analyzeStoryPace(
   });
 }
 
+export function getPaceDistribution(
+  sections: PaceSection[]
+): { Fast: number; Balanced: number; Slow: number } {
+  return sections.reduce(
+    (counts, section) => {
+      counts[section.pace] += 1;
+      return counts;
+    },
+    { Fast: 0, Balanced: 0, Slow: 0 }
+  );
+}
+
 export function refreshPaceAnalysis(
   story: string
 ) {


### PR DESCRIPTION
Closes #6259.

Summary of What Has Been Done:
Added getPaceDistribution to count Fast/Balanced/Slow sections for pace breakdown bars.

Changes Made:
- frontend/src/utils/storyPaceHeatmap.ts

Impact it Made:
Small, isolated, independently mergeable improvement to the story-spark-ai frontend, verified locally with the commands listed in the issue.

Note: Please assign this PR to the `tmdeveloper007` account.