### PR TITLE
refactor : extract style label helper in storyEndingAlternatives utility

### DIFF
--- a/frontend/src/utils/storyEndingAlternatives.ts
+++ b/frontend/src/utils/storyEndingAlternatives.ts
@@ -39,6 +39,21 @@ export function generateEndingAlternatives(
   ];
 }
 
+export function styleLabel(
+  style: string
+): string {
+  switch (style.toLowerCase()) {
+    case "inspirational":
+      return "Motivating";
+    case "drama":
+      return "Dramatic";
+    case "mystery":
+      return "Intriguing";
+    default:
+      return style;
+  }
+}
+
 export function regenerateEndingAlternatives(
   story: string
 ) {


### PR DESCRIPTION
Closes #6280.

Summary of What Has Been Done:
Extracted styleLabel to centralize the ending-style display labels for reuse in list rendering.

Changes Made:
- frontend/src/utils/storyEndingAlternatives.ts

Impact it Made:
Small, isolated, independently mergeable improvement to the story-spark-ai frontend, verified locally with the commands listed in the issue.

Note: Please assign this PR to the `tmdeveloper007` account.