### PR TITLE
refactor : extract top rated title helper in storyTitleABComparison utility

### DIFF
--- a/frontend/src/utils/storyTitleABComparison.ts
+++ b/frontend/src/utils/storyTitleABComparison.ts
@@ -47,6 +47,21 @@ export function generateStoryTitleOptions(
   ];
 }
 
+export function topRatedTitle(
+  options: StoryTitleOption[]
+): StoryTitleOption | undefined {
+  if (options.length === 0) return undefined;
+
+  return options.reduce((best, option) => {
+    const bestScore =
+      best.creativity + best.relevance + best.memorability + best.emotionalAppeal;
+    const optionScore =
+      option.creativity + option.relevance + option.memorability + option.emotionalAppeal;
+
+    return optionScore > bestScore ? option : best;
+  });
+}
+
 export function regenerateStoryTitles(
   story: string
 ) {


### PR DESCRIPTION
Closes #6283.

Summary of What Has Been Done:
Extracted topRatedTitle to return the highest-scoring title option for A/B comparison displays.

Changes Made:
- frontend/src/utils/storyTitleABComparison.ts

Impact it Made:
Small, isolated, independently mergeable improvement to the story-spark-ai frontend, verified locally with the commands listed in the issue.

Note: Please assign this PR to the `tmdeveloper007` account.