### PR TITLE
refactor : extract paragraph splitter in previewFormatter utility

### DIFF
--- a/frontend/src/utils/previewFormatter.ts
+++ b/frontend/src/utils/previewFormatter.ts
@@ -4,10 +4,16 @@ export interface StoryData {
   content: string;
 }
 
-export function formatPreview(story: StoryData) {
-  const paragraphs = story.content
+export function splitParagraphs(
+  content: string
+): string[] {
+  return content
     .split("\n")
     .filter((p) => p.trim() !== "");
+}
+
+export function formatPreview(story: StoryData) {
+  const paragraphs = splitParagraphs(story.content);
 
   return {
     ...story,


### PR DESCRIPTION
Closes #6284.

Summary of What Has Been Done:
Extracted splitParagraphs so paragraph splitting is reusable and independently testable.

Changes Made:
- frontend/src/utils/previewFormatter.ts

Impact it Made:
Small, isolated, independently mergeable improvement to the story-spark-ai frontend, verified locally with the commands listed in the issue.

Note: Please assign this PR to the `tmdeveloper007` account.