### PR TITLE
refactor : extract genre tags helper in promptLibrary utility

### DIFF
--- a/frontend/src/utils/promptLibrary.ts
+++ b/frontend/src/utils/promptLibrary.ts
@@ -57,3 +57,9 @@ export function filterByGenre(
   if (!genre) return prompts;
   return prompts.filter((item) => item.genre === genre);
 }
+
+export function genreTags(
+  prompts: StoryPrompt[]
+): string[] {
+  return [...new Set(prompts.map((item) => item.genre))];
+}


### PR DESCRIPTION
Closes #6285.

Summary of What Has Been Done:
Extracted genreTags to derive a deduplicated genre list for filter chips.

Changes Made:
- frontend/src/utils/promptLibrary.ts

Impact it Made:
Small, isolated, independently mergeable improvement to the story-spark-ai frontend, verified locally with the commands listed in the issue.

Note: Please assign this PR to the `tmdeveloper007` account.