### PR TITLE
perf : avoid repeated regex compilation in readingStats utility

### DIFF
--- a/frontend/src/utils/readingStats.ts
+++ b/frontend/src/utils/readingStats.ts
@@ -7,6 +7,9 @@ export interface ReadingStats {
   readingTime: number;
 }
 
+const CHAPTER_REGEX = /chapter/gi;
+const SENTENCE_REGEX = /[.!?]+/;
+
 export function calculateReadingStats(text: string): ReadingStats {
   const words = text.trim().split(/\s+/).filter(Boolean).length;
 
@@ -16,11 +19,11 @@ export function calculateReadingStats(text: string): ReadingStats {
 
   const chapters = Math.max(
     1,
-    (text.match(/chapter/gi) || []).length
+    (text.match(CHAPTER_REGEX) || []).length
   );
 
   const sentences = text
-    .split(/[.!?]+/)
+    .split(SENTENCE_REGEX)
     .filter((s) => s.trim()).length;
 
   const averageSentenceLength =


### PR DESCRIPTION
Closes #6287.

Summary of What Has Been Done:
Hoisted the chapter and sentence regexes to module constants so calculateReadingStats does not recompile them on every call.

Changes Made:
- frontend/src/utils/readingStats.ts

Impact it Made:
Small, isolated, independently mergeable improvement to the story-spark-ai frontend, verified locally with the commands listed in the issue.

Note: Please assign this PR to the `tmdeveloper007` account.