### PR TITLE
perf : hoist resolution constants in storyConflictResolutionEvaluator utility

### DIFF
--- a/frontend/src/utils/storyConflictResolutionEvaluator.ts
+++ b/frontend/src/utils/storyConflictResolutionEvaluator.ts
@@ -7,43 +7,45 @@ export interface StoryConflict {
   suggestion: string;
 }
 
+const DEFAULT_CONFLICTS: StoryConflict[] = [
+  {
+    id: 1,
+    title: "Hero vs Main Villain",
+    type: "Primary",
+    resolution: "Resolved",
+    description:
+      "The protagonist defeats the antagonist and restores peace.",
+    suggestion:
+      "The resolution feels complete and provides a satisfying ending.",
+  },
+  {
+    id: 2,
+    title: "Sibling Relationship",
+    type: "Secondary",
+    resolution: "Partially Resolved",
+    description:
+      "The siblings reconcile, but lingering tension remains.",
+    suggestion:
+      "Add a final conversation to strengthen emotional closure.",
+  },
+  {
+    id: 3,
+    title: "Ancient Artifact Mystery",
+    type: "Secondary",
+    resolution: "Unresolved",
+    description:
+      "The origin of the artifact is never explained.",
+    suggestion:
+      "Include a short reveal or epilogue to resolve this plot thread.",
+  },
+];
+
 export function analyzeConflictResolution(
   story: string
 ): StoryConflict[] {
   if (!story.trim()) return [];
 
-  return [
-    {
-      id: 1,
-      title: "Hero vs Main Villain",
-      type: "Primary",
-      resolution: "Resolved",
-      description:
-        "The protagonist defeats the antagonist and restores peace.",
-      suggestion:
-        "The resolution feels complete and provides a satisfying ending.",
-    },
-    {
-      id: 2,
-      title: "Sibling Relationship",
-      type: "Secondary",
-      resolution: "Partially Resolved",
-      description:
-        "The siblings reconcile, but lingering tension remains.",
-      suggestion:
-        "Add a final conversation to strengthen emotional closure.",
-    },
-    {
-      id: 3,
-      title: "Ancient Artifact Mystery",
-      type: "Secondary",
-      resolution: "Unresolved",
-      description:
-        "The origin of the artifact is never explained.",
-      suggestion:
-        "Include a short reveal or epilogue to resolve this plot thread.",
-    },
-  ];
+  return DEFAULT_CONFLICTS;
 }
 
 export function refreshConflictAnalysis(


### PR DESCRIPTION
Closes #6288.

Summary of What Has Been Done:
Hoisted the static conflict list into a module constant so analyzeConflictResolution does not rebuild it on every call.

Changes Made:
- frontend/src/utils/storyConflictResolutionEvaluator.ts

Impact it Made:
Small, isolated, independently mergeable improvement to the story-spark-ai frontend, verified locally with the commands listed in the issue.

Note: Please assign this PR to the `tmdeveloper007` account.