### PR TITLE
perf : hoist storage key helper in readingProgress utility

### DIFF
--- a/frontend/src/utils/readingProgress.ts
+++ b/frontend/src/utils/readingProgress.ts
@@ -1,9 +1,14 @@
+const READING_POSITION_PREFIX = "reading-";
+
+const positionKey = (storyId: string): string =>
+  `${READING_POSITION_PREFIX}${storyId}`;
+
 export const saveReadingPosition = (
   storyId: string,
   position: number
 ) => {
   localStorage.setItem(
-    `reading-${storyId}`,
+    positionKey(storyId),
     position.toString()
   );
 };
@@ -11,12 +16,12 @@ export const saveReadingPosition = (
 export const getReadingPosition = (
   storyId: string
 ): number => {
-  const value = localStorage.getItem(`reading-${storyId}`);
+  const value = localStorage.getItem(positionKey(storyId));
   return value ? Number(value) : 0;
 };
 
 export const resetReadingPosition = (
   storyId: string
 ) => {
-  localStorage.removeItem(`reading-${storyId}`);
+  localStorage.removeItem(positionKey(storyId));
 };


### PR DESCRIPTION
Closes #6290.

Summary of What Has Been Done:
Hoisted the reading-position storage key construction into a shared positionKey helper to avoid repeating the prefix literal.

Changes Made:
- frontend/src/utils/readingProgress.ts

Impact it Made:
Small, isolated, independently mergeable improvement to the story-spark-ai frontend, verified locally with the commands listed in the issue.

Note: Please assign this PR to the `tmdeveloper007` account.