### PR TITLE
fix : removed duplicate slugify function declarations

### DIFF
--- a/backend/src/app/utils/slugify.ts
+++ b/backend/src/app/utils/slugify.ts
@@ -1,39 +1,4 @@
 /**
- * Converts a string into a URL-safe slug.
- * - Converts to lowercase
- * - Replaces spaces with hyphens
- * - Removes non-alphanumeric characters (except hyphens)
- * - Collapses multiple consecutive hyphens into one
- * - Trims leading and trailing hyphens
- */
-export const slugify = (input: string): string => {
-  if (!input || typeof input !== "string") {
-    return "";
-  }
-
-  return input
-    .toLowerCase()
-    .trim()
-    .replace(/\s+/g, "-")       // Replace spaces with hyphens
-    .replace(/[^a-z0-9-]/g, "") // Remove non-alphanumeric (keep hyphens)
-    .replace(/-+/g, "-")        // Collapse multiple hyphens
-    .replace(/^-+|-+$/g, "");   // Trim leading/trailing hyphens
-};
-
-
-export function slugify(input: string): string {
-  if (!input) return "";
-
-  return input
-    .toLowerCase()
-    .trim()
-    .replace(/\s+/g, "-")      // Replace one or more spaces with a hyphen
-    .replace(/[^a-z0-9-]/g, "") // Remove special characters
-    .replace(/-+/g, "-")        // Collapse multiple hyphens
-    .replace(/^-|-$/g, "");     // Remove leading/trailing hyphens
-}
-
-/**
  * Converts a string to a URL-safe slug.
  * - Lowercases the string
  * - Replaces spaces with hyphens


### PR DESCRIPTION
Closes #6398.

Summary of What Has Been Done:
Removed the two duplicate export declarations of the slugify function from backend/src/app/utils/slugify.ts. TypeScript was reporting duplicate-identifier errors for the three declarations. Kept only the final valid implementation which includes a proper typeof string guard.

Changes Made:
- backend/src/app/utils/slugify.ts: Removed the first export const slugify (lines 9-21) and the second export function slugify (lines 24-34). Kept only the third export const slugify with the text parameter name and typeof guard.

Impact it Made:
- Resolves TypeScript duplicate-identifier compilation errors
- Cleans up dead code
- Ensures the backend build passes cleanly

Note: Please assign this PR to the tmdeveloper007 account.