### PR TITLE
fix : removed duplicate sanitization function declarations

### DIFF
--- a/backend/src/app/utils/sanitization.ts
+++ b/backend/src/app/utils/sanitization.ts
@@ -4,47 +4,6 @@
  * to reduce the risk of HTML injection and ensure consistent string formatting.
  */
 
-// Dangerous URL protocols that can be used for XSS attacks
-const DANGEROUS_URL_PROTOCOLS = [
-  'javascript:',
-  'data:',
-  'vbscript:',
-  'mocha:',
-  'livescript:',
-  'about:',
-  'file:',
-  'view-source:',
-  'jar:',
-  'apt:',
-];
-
-/**
- * Checks whether a URL uses an allowed (safe) protocol.
- * URLs with dangerous protocols like javascript:, data:, vbscript:, etc.
- * can be used for XSS attacks and should be rejected.
- */
-export const isAllowedUrlProtocol = (url: string): boolean => {
-  if (!url || typeof url !== 'string') return false;
-  const lower = url.trim().toLowerCase();
-  for (const protocol of DANGEROUS_URL_PROTOCOLS) {
-    if (lower.startsWith(protocol)) return false;
-  }
-  return true;
-};
-
-/**
- * Sanitizes a URL by validating its protocol. Returns the URL unchanged
- * if the protocol is safe, otherwise returns the provided fallback value.
- * This prevents XSS via javascript:, data:, and other dangerous protocols.
- */
-export const sanitizeUrl = (
-  url: string,
-  fallback = '',
-): string => {
-  if (!url || typeof url !== 'string') return fallback;
-  return isAllowedUrlProtocol(url) ? url.trim() : fallback;
-};
-
 /**
  * Removes all HTML tags from a string using a regex that handles both
  * complete tags (<tag>) and incomplete openers (<script without >).
@@ -88,12 +47,14 @@ export const normalizeWhitespace = (input: string): string => {
 /**
  * Verifies if a URL protocol is safe (http, https, or mailto/tel if needed).
  * Rejects javascript:, data:, vbscript:, file:, about:, jar:, mocha:, livescript:, apt:, etc.
+ * Uses the URL constructor for thorough validation and falls back to regex for
+ * edge cases that the URL parser cannot handle.
  */
 export const isAllowedUrlProtocol = (url: string): boolean => {
   if (!url) return false;
-  
+
   const trimmed = url.trim().toLowerCase();
-  
+
   try {
     const parsed = new URL(trimmed);
     const allowed = ['http:', 'https:', 'mailto:', 'tel:'];


### PR DESCRIPTION
Closes #6399.

Summary of What Has Been Done:
Removed the duplicate declarations of isAllowedUrlProtocol and sanitizeUrl from backend/src/app/utils/sanitization.ts. The first simpler versions were removed, keeping the more robust second implementations that use the URL constructor for thorough validation and regex fallback for edge cases. Also removed the unused DANGEROUS_URL_PROTOCOLS constant.

Changes Made:
- backend/src/app/utils/sanitization.ts: Removed the first isAllowedUrlProtocol and first sanitizeUrl declarations along with the unused DANGEROUS_URL_PROTOCOLS constant. Kept the unique functions (stripHtmlTags, truncate, normalizeWhitespace) and the second, more robust isAllowedUrlProtocol and sanitizeUrl implementations.

Impact it Made:
- Resolves TypeScript duplicate-identifier compilation errors
- Keeps the more robust URL sanitization logic that properly validates protocols
- Cleans up dead code and unused constants

Note: Please assign this PR to the tmdeveloper007 account.