### PR TITLE
fix: validate type and sortBy URL params with includes() check in SearchPage — unsafe as cast bypassed TypeScript types at runtime

### DIFF
--- a/frontend/src/pages/analytics/SearchPage.tsx
+++ b/frontend/src/pages/analytics/SearchPage.tsx
@@ -11,12 +11,18 @@ const SearchPage: React.FC = () => {
   const navigate = useNavigate();
 
   const [query, setQuery] = useState(searchParams.get("q") ?? "");
+  const VALID_TYPES = ["all", "story", "user", "tag"] as const;
+  const VALID_SORTS = ["relevance", "date", "popularity"] as const;
+
+  const rawType = searchParams.get("type");
+  const rawSort = searchParams.get("sortBy");
+
   const [type, setType] = useState<"all" | "story" | "user" | "tag">(
-    (searchParams.get("type") as "all") ?? "all"
+    VALID_TYPES.includes(rawType as "all") ? (rawType as "all") : "all"
   );
   const [genre, setGenre] = useState(searchParams.get("genre") ?? "");
   const [sortBy, setSortBy] = useState<"relevance" | "date" | "popularity">(
-    (searchParams.get("sortBy") as "relevance") ?? "relevance"
+    VALID_SORTS.includes(rawSort as "relevance") ? (rawSort as "relevance") : "relevance"
   );
   const [page, setPage] = useState(Number(searchParams.get("page") ?? 1));
   const [results, setResults] = useState<SearchResults | null>(null);


### PR DESCRIPTION
### Description
Defines `VALID_TYPES` and `VALID_SORTS` const arrays. Uses
`.includes()` to check if the raw URL param value is a member of
the allowed set before using it as state. Falls back to `"all"` and
`"relevance"` respectively for any absent or invalid value. This is
runtime validation — unlike `as` which is compile-time only.

### Related Issues
Closes #6420 