### PR TITLE
fix : added uppercase I to FIRST_PERSON pronoun list in povAnalyzer

### DIFF
--- a/frontend/src/utils/povAnalyzer.ts
+++ b/frontend/src/utils/povAnalyzer.ts
@@ -7,6 +7,7 @@ export interface POVIssue {
 
 const FIRST_PERSON = [
   " i ",
+  " I ",
   " me ",
   " my ",
   " mine ",


### PR DESCRIPTION
Closes #6473.

Summary of What Has Been Done:
Added uppercase ' I ' to the FIRST_PERSON pronoun array in frontend/src/utils/povAnalyzer.ts. The array previously only included lowercase ' i ' which would not match capitalised 'I' at the start of sentences.

Changes Made:
- frontend/src/utils/povAnalyzer.ts: Added ' I ' to FIRST_PERSON array

Impact it Made:
- Fixes POV detection for first-person narration starting with capitalised 'I'
- Prevents false negatives where first-person narration is not detected
- Improves accuracy of POV analysis for real story text

Note: Please assign this PR to the `tmdeveloper007` account.