### PR TITLE
fix: change data to body in createBranchVersion RTK Query mutation — branchName was silently dropped from POST request

### DIFF
--- a/frontend/src/redux/apis/storyVersion.api.ts
+++ b/frontend/src/redux/apis/storyVersion.api.ts
@@ -68,7 +68,7 @@ const storyVersionApi = baseApi.injectEndpoints({
       }) => ({
         url: `/story/version/${versionId}/branch`,
         method: "POST",
-        data: {
+        body: {          // ← fetchBaseQuery uses 'body', not 'data'
           branchName,
         },
       }),


### PR DESCRIPTION
### Description
Single-word change: `data` → `body` in the `createBranchVersion`
query object. RTK Query's `fetchBaseQuery` follows the Fetch API
spec which uses `body` for request payloads. The `data` key (an
axios convention) is ignored by `fetchBaseQuery`, causing the
POST body to be empty and the branch name to never reach the backend.

### Related Issues
Closes #6493