### PR TITLE
fix: validate response.data.data in all 3 prompt analysis service functions — prevents null/undefined from being returned as typed IPromptAnalysisResponse

### DIFF
--- a/frontend/src/services/prompt_analysis.service.ts
+++ b/frontend/src/services/prompt_analysis.service.ts
@@ -42,7 +42,11 @@ export const analyzePrompt = async (
     request,
     { withCredentials: true }
   );
-  return response.data.data;
+  const data = response.data?.data;
+  if (!data || typeof data !== "object") {
+    throw new Error("analyzePrompt: invalid response shape from backend.");
+  }
+  return data as IPromptAnalysisResponse;
 };
 
 /**
@@ -61,7 +65,11 @@ export const enhancePrompt = async (
     request,
     { withCredentials: true }
   );
-  return response.data.data;
+  const data = response.data?.data;
+  if (!data || typeof data !== "object") {
+    throw new Error("enhancePrompt: invalid response shape from backend.");
+  }
+  return data;
 };
 
 /**
@@ -75,5 +83,9 @@ export const batchAnalyzePrompts = async (
     { prompts },
     { withCredentials: true }
   );
-  return response.data.data;
+  const data = response.data?.data;
+  if (!Array.isArray(data)) {
+    throw new Error("batchAnalyzePrompts: expected array from backend.");
+  }
+  return data as IPromptAnalysisResponse[];
 };


### PR DESCRIPTION
### Description
Adds `const data = response.data?.data` with null/object guard
(`!data || typeof data !== "object"`) in `analyzePrompt` and
`enhancePrompt`. Uses `Array.isArray` guard in `batchAnalyzePrompts`.
All three throw a descriptive `Error` on invalid shapes — caught by
callers' existing try/catch blocks with actionable messages rather
than silent null reference crashes.

### Related Issues
Closes #6499 