### PR TITLE
fix: clone Response before consuming body in fetchImageAsBlob — image cache was silently broken by post-consumption clone

### DIFF
--- a/frontend/src/services/export.service.ts
+++ b/frontend/src/services/export.service.ts
@@ -40,12 +40,16 @@ export const fetchImageAsBlob = async (url: string): Promise<Blob> => {
     if (!response.ok) {
       throw new Error(`Direct fetch failed with status ${response.status}`);
     }
+
+    // Clone BEFORE reading the body — response body is a one-time readable stream.
+    // Calling .blob() exhausts it; .clone() after that throws "body already used".
+    const responseToCache = response.clone();
     const blob = await response.blob();
 
     if ("caches" in window) {
       try {
         const cache = await caches.open(CACHE_NAME);
-        await cache.put(url, response.clone());
+        await cache.put(url, responseToCache);
       } catch (cacheError) {
         console.warn("[ExportService] Failed to cache image:", cacheError);
       }


### PR DESCRIPTION
### Description
Moves `const responseToCache = response.clone()` to immediately after
the fetch response is received and validated, before `response.blob()`
is called. The clone has its own independent body stream for caching
while the original is read into a Blob. Fixes the silent TypeError
that prevented Cache Storage from ever storing an image entry.

### Related Issues
Closes #6501 