### PR TITLE
fix: exclude cover page from PDF footer page count in exportStoryToPDF

### DIFF
--- a/frontend/src/services/export.service.ts
+++ b/frontend/src/services/export.service.ts
@@ -260,10 +260,15 @@ export const exportStoryToPDF = async (
 
   // Running headers and footers (drawn over all pages except page 1)
   const totalPages = doc.getNumberOfPages();
+  // Content pages are numbered excluding the cover (page 1).
+  // i=2 → content page 1, i=3 → content page 2, etc.
+  const contentPageCount = totalPages - 1;
   for (let i = 1; i <= totalPages; i++) {
     doc.setPage(i);
     
     if (i === 1) continue; // Skip cover page
+
+    const contentPageNumber = i - 1; // Relative page number (1-based, cover excluded)
 
     // Running Header
     doc.setFont("helvetica", "normal");
@@ -279,7 +284,7 @@ export const exportStoryToPDF = async (
     // Running Footer
     doc.line(leftMargin, 280, 190, 280);
     doc.text("Generated with StorySparkAI", leftMargin, 285);
-    doc.text(`Page ${i} of ${totalPages}`, 190, 285, { align: "right" });
+    doc.text(`Page ${contentPageNumber} of ${contentPageCount}`, 190, 285, { align: "right" });
   }
 
   // Trigger file download


### PR DESCRIPTION
### Description
Adds `contentPageCount = totalPages - 1` and `contentPageNumber = i - 1`
inside the header/footer loop. Footer now shows `Page 1 of 2` on the
first content page, matching standard print publishing convention
where cover pages are not counted in the body page numbering.

### Related Issues
Closes #6503 