### PR TITLE
fix: detect image format from data URL prefix in exportStoryToPDF — JPEG covers were silently failing with hardcoded "PNG" format

### DIFF
--- a/frontend/src/services/export.service.ts
+++ b/frontend/src/services/export.service.ts
@@ -107,6 +107,19 @@ export const blobToBase64 = (blob: Blob): Promise<string> => {
 };
 
 /**
+ * Detects the jsPDF image format string from a base64 data URL.
+ */
+function detectImageFormat(base64DataUrl: string): string {
+  if (base64DataUrl.startsWith("data:image/jpeg") || base64DataUrl.startsWith("data:image/jpg")) {
+    return "JPEG";
+  }
+  if (base64DataUrl.startsWith("data:image/webp")) {
+    return "WEBP";
+  }
+  return "PNG"; // default
+}
+
+/**
  * Compiles and exports the story to a beautifully structured PDF.
  */
 export const exportStoryToPDF = async (
@@ -159,7 +172,7 @@ export const exportStoryToPDF = async (
   // Cover Page Illustration (Centered Frame)
   if (base64Image) {
     try {
-      doc.addImage(base64Image, "PNG", 35, coverY, 140, 105);
+      doc.addImage(base64Image, detectImageFormat(base64Image), 35, coverY, 140, 105);
       coverY += 115;
     } catch (e) {
       console.error("Failed to add image to PDF cover:", e);
@@ -200,7 +213,7 @@ export const exportStoryToPDF = async (
   // Add the illustration at the top of content page
   if (base64Image) {
     try {
-      doc.addImage(base64Image, "PNG", 45, yCursor, 120, 90);
+      doc.addImage(base64Image, detectImageFormat(base64Image), 45, yCursor, 120, 90);
       yCursor += 100;
     } catch (e) {
       console.error("Failed to add image to PDF content:", e);


### PR DESCRIPTION
### Description
Adds `detectImageFormat(base64DataUrl)` helper that reads the MIME
type from the data URL prefix and returns the jsPDF format string
("JPEG", "WEBP", or "PNG"). Replaces both hardcoded `"PNG"` arguments
in `doc.addImage()` — cover page and content page — with
`detectImageFormat(base64Image)`. JPEG story covers now render
correctly in exported PDFs.

### Related Issues
Closes #6505 