### PR TITLE
fix(auth): use DB role for authorization checks

### DIFF
--- a/backend/src/app/middleware/auth.middleware.ts
+++ b/backend/src/app/middleware/auth.middleware.ts
@@ -148,12 +148,9 @@ const auth =
         );
       }
 
-      // Role authorization
+      // Role authorization — use DB role so JWT claim drift cannot escalate privileges
       if (requiredRole.length) {
-        if (
-          !verifiedUser.role ||
-          !requiredRole.includes(verifiedUser.role)
-        ) {
+        if (!user.role || !requiredRole.includes(user.role)) {
           throw new ApiError(
             httpStatus.FORBIDDEN,
             "Forbidden"

--- a/backend/src/app/modules/user/user.service.ts
+++ b/backend/src/app/modules/user/user.service.ts
@@ -204,7 +204,7 @@ const approveWriterApplication = async (email: string) => {
     }
     const result = await User.findOneAndUpdate(
       { email: email },
-      { role: ENUM_USER_ROLE.WRITER },
+      { $set: { role: ENUM_USER_ROLE.WRITER }, $inc: { tokenVersion: 1 } },
       {
         new: true,
         runValidators: true,

--- a/backend/src/app/modules/writer_application/writer_application.service.ts
+++ b/backend/src/app/modules/writer_application/writer_application.service.ts
@@ -49,7 +49,8 @@ const updateApplicationStatus = async (
   
   if (status === "approved") {
     await User.findByIdAndUpdate(application.user, {
-      role: ENUM_USER_ROLE.WRITER,
+      $set: { role: ENUM_USER_ROLE.WRITER },
+      $inc: { tokenVersion: 1 },
     });
   } else {
     // If rejected, we might want to let them apply again by setting isApplyForWriter to false


### PR DESCRIPTION
## Summary
- Authorize `requiredRole` against `user.role` from the database instead of the JWT `verifiedUser.role` claim.
- Increment `tokenVersion` when a user is promoted to writer so stale elevated/downgraded tokens are rejected.

## Test plan
- [ ] Authenticate with a JWT whose role claim differs from the DB role and confirm access follows the DB role.
- [ ] Approve a writer application and confirm subsequent requests with the old access token are rejected until re-login.
- [ ] Existing auth middleware tests still pass.

Fixes #6539

Made with [Cursor](https://cursor.com)