### PR TITLE
fix: stack subscriptionExpiry on plan renewals

### DIFF
--- a/backend/src/controllers/payment.controller.ts
+++ b/backend/src/controllers/payment.controller.ts
@@ -111,18 +111,40 @@ async function grantEntitlementAndRespond(
   { respond }: { respond: boolean }
 ): Promise<void> {
   const selectedPlan = PLANS[order.plan];
-  const subscriptionExpiry = new Date(
-    Date.now() + selectedPlan.durationDays * 24 * 60 * 60 * 1000
-  );
+  const durationMs = selectedPlan.durationDays * 24 * 60 * 60 * 1000;
+  const now = new Date();
 
+  // Stack remaining premium time: expiry = max(now, currentExpiry) + duration.
+  // Use an aggregation update so concurrent renewals cannot clobber each other
+  // by reading a stale expiry and writing Date.now() + duration.
   const updatedUser = await User.findByIdAndUpdate(
     order.userId,
-    {
-      subscriptionType: "premium",
-      subscriptionExpiry,
-      lastPaymentId: order.razorpayPaymentId,
-      lastOrderId: order.razorpayOrderId,
-    },
+    [
+      {
+        $set: {
+          subscriptionType: "premium",
+          lastPaymentId: order.razorpayPaymentId,
+          lastOrderId: order.razorpayOrderId,
+          subscriptionExpiry: {
+            $add: [
+              {
+                $cond: [
+                  {
+                    $and: [
+                      { $ne: [{ $ifNull: ["$subscriptionExpiry", null] }, null] },
+                      { $gt: ["$subscriptionExpiry", now] },
+                    ],
+                  },
+                  "$subscriptionExpiry",
+                  now,
+                ],
+              },
+              durationMs,
+            ],
+          },
+        },
+      },
+    ],
     { new: true, select: "email subscriptionType subscriptionExpiry" }
   );
 

--- a/backend/src/jobs/reconcilePendingOrders.job.ts
+++ b/backend/src/jobs/reconcilePendingOrders.job.ts
@@ -35,16 +35,38 @@ export async function reconcilePendingOrders(): Promise<void> {
         continue;
       }
 
-      const subscriptionExpiry = new Date(Date.now() + plan.durationDays * 24 * 60 * 60 * 1000);
+      const durationMs = plan.durationDays * 24 * 60 * 60 * 1000;
+      const now = new Date();
 
+      // Stack remaining premium: max(now, currentExpiry) + plan duration.
       const updatedUser = await User.findByIdAndUpdate(
         order.userId,
-        {
-          subscriptionType: "premium",
-          subscriptionExpiry,
-          lastPaymentId: order.razorpayPaymentId,
-          lastOrderId: order.razorpayOrderId,
-        },
+        [
+          {
+            $set: {
+              subscriptionType: "premium",
+              lastPaymentId: order.razorpayPaymentId,
+              lastOrderId: order.razorpayOrderId,
+              subscriptionExpiry: {
+                $add: [
+                  {
+                    $cond: [
+                      {
+                        $and: [
+                          { $ne: [{ $ifNull: ["$subscriptionExpiry", null] }, null] },
+                          { $gt: ["$subscriptionExpiry", now] },
+                        ],
+                      },
+                      "$subscriptionExpiry",
+                      now,
+                    ],
+                  },
+                  durationMs,
+                ],
+              },
+            },
+          },
+        ],
         { new: true }
       );
 
@@ -82,5 +104,5 @@ export function startOrderReconciliationJob(): void {
       logger.error("[reconcile] Unhandled error in scheduled sweep:", err)
     );
   });
-  logger.info("🔁 Order reconciliation job scheduled (every 5 minutes).");
+  logger.info("Order reconciliation job scheduled (every 5 minutes).");
 }


### PR DESCRIPTION
## Summary
- Premium renewals now set `subscriptionExpiry = max(now, currentExpiry) + plan duration` so buying another plan extends remaining time instead of resetting from now.
- Applied in both `grantEntitlementAndRespond` (verify path) and the reconcile job via atomic aggregation updates.

Fixes #6532

## Test plan
- [ ] Grant a user premium with `subscriptionExpiry` far in the future
- [ ] Complete another paid plan purchase that grants entitlement
- [ ] Confirm expiry is roughly previousExpiry + new plan days (not now + plan days)
- [ ] Confirm a lapsed/expired user still gets now + plan duration

Made with [Cursor](https://cursor.com)