### PR TITLE
fix: bind guest free-generation quota to client IP

### DIFF
--- a/backend/src/__tests__/cookie.util.test.ts
+++ b/backend/src/__tests__/cookie.util.test.ts
@@ -4,11 +4,23 @@ import {
   setRefreshTokenCookie,
   clearRefreshTokenCookie,
   setGuestUserIdCookie,
+  signGuestUserId,
+  verifySignedGuestUserId,
+  guestQuotaKeyForIp,
+  getRequestClientIp,
 } from "../utils/cookie.util";
 
 jest.mock("../config", () => ({
   __esModule: true,
-  default: { env: "development" },
+  default: {
+    env: "development",
+    jwt: {
+      secret: "test-jwt-secret",
+      refresh_secret: "test-refresh-secret",
+      expires_in: "15m",
+      refresh_expires_in: "7d",
+    },
+  },
 }));
 
 function buildMockRes(): {
@@ -98,7 +110,8 @@ describe("setGuestUserIdCookie", () => {
     expect(cookieMock).toHaveBeenCalledTimes(1);
     const [name, value] = cookieMock.mock.calls[0];
     expect(name).toBe("userId");
-    expect(value).toBe("guest-uuid-123");
+    expect(typeof value).toBe("string");
+    expect(value.startsWith("s:guest-uuid-123.")).toBe(true);
   });
 
   it("passes httpOnly, secure, sameSite, path from cookieOptions", () => {
@@ -116,5 +129,26 @@ describe("setGuestUserIdCookie", () => {
     setGuestUserIdCookie(res, "guest-uuid");
     const [, , options] = cookieMock.mock.calls[0];
     expect(options.maxAge).toBe(30 * 24 * 60 * 60 * 1000);
+  });
+});
+
+
+describe("signed guest cookie + IP quota key", () => {
+  it("round-trips a signed guest user id", () => {
+    const signed = signGuestUserId("guest-uuid-123");
+    expect(verifySignedGuestUserId(signed)).toBe("guest-uuid-123");
+    expect(verifySignedGuestUserId("s:guest-uuid-123.deadbeef")).toBeNull();
+  });
+
+  it("builds a stable IP-bound guest quota key", () => {
+    expect(guestQuotaKeyForIp("203.0.113.10")).toBe("ip:203.0.113.10");
+  });
+
+  it("reads client IP from x-forwarded-for when present", () => {
+    const req = {
+      headers: { "x-forwarded-for": "198.51.100.4, 10.0.0.1" },
+      ip: "10.0.0.1",
+    } as any;
+    expect(getRequestClientIp(req)).toBe("198.51.100.4");
   });
 });

--- a/backend/src/app/modules/ai_model/__tests__/quota.service.test.ts
+++ b/backend/src/app/modules/ai_model/__tests__/quota.service.test.ts
@@ -12,6 +12,7 @@ import {
   refundUserQuota,
   reserveGuestQuota,
   reserveUserQuota,
+  resolveGuestQuotaIdentity,
   subscriptionLimitExpression,
 } from "../quota.service";
 
@@ -160,5 +161,47 @@ describe("concurrency semantics", () => {
     const updateCall = mockedUser.findOneAndUpdate.mock.calls[0];
     expect(updateCall[0]).toHaveProperty("$expr");
     expect(Array.isArray(updateCall[1])).toBe(true);
+  });
+});
+
+
+describe("resolveGuestQuotaIdentity", () => {
+  it("binds quota to IP even when the userId cookie is missing", () => {
+    const req = {
+      headers: { "x-forwarded-for": "203.0.113.50" },
+      cookies: {},
+      ip: "203.0.113.50",
+    } as any;
+    const cookie = jest.fn();
+    const res = { cookie } as any;
+
+    const identity = resolveGuestQuotaIdentity(req, res);
+    expect(identity.quotaKey).toBe("ip:203.0.113.50");
+    expect(identity.cookieUserId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    );
+    expect(cookie).toHaveBeenCalled();
+  });
+
+  it("fails closed when client IP cannot be determined", () => {
+    const req = { headers: {}, cookies: {}, ip: "", socket: {} } as any;
+    const res = { cookie: jest.fn() } as any;
+    expect(() => resolveGuestQuotaIdentity(req, res)).toThrow(ApiError);
+  });
+
+  it("keeps the same IP quota key after cookie clear / new UUID", () => {
+    const req = {
+      headers: {},
+      cookies: {},
+      ip: "198.51.100.9",
+    } as any;
+    const res = { cookie: jest.fn() } as any;
+    const first = resolveGuestQuotaIdentity(req, res);
+    const second = resolveGuestQuotaIdentity(
+      { ...req, cookies: {} } as any,
+      { cookie: jest.fn() } as any
+    );
+    expect(first.quotaKey).toBe(second.quotaKey);
+    expect(first.cookieUserId).not.toBe(second.cookieUserId);
   });
 });

--- a/backend/src/app/modules/ai_model/ai_model.controller.ts
+++ b/backend/src/app/modules/ai_model/ai_model.controller.ts
@@ -1,13 +1,11 @@
 import { Request, Response } from "express";
-import { setGuestUserIdCookie } from "../../../utils/cookie.util";
-import { randomUUID } from "node:crypto";
 import httpStatus from "http-status";
 import ApiError from "../../../errors/api_error";
 import catchAsync from "../../../shared/catch_async";
 import sendResponse from "../../../shared/send_response";
 import { AiModelService } from "./ai_model.service";
 import { IRemixPayload, ITranslatePayload, IChatPayload } from "./ai_model.interface";
-import { reserveGuestQuota } from "./quota.service";
+import { reserveGuestQuota, resolveGuestQuotaIdentity } from "./quota.service";
 import {
   createGuestQuotaGuard,
   runWithQuotaCleanup,
@@ -43,18 +41,13 @@ const aiModelGenerate = catchAsync(async (req: Request, res: Response) => {
 
 const aiFreeModelGenerate = catchAsync(async (req: Request, res: Response) => {
   const prompt = req.body;
-  let userId = req.cookies.userId as string | undefined;
-
-  if (!userId) {
-    userId = randomUUID();
-    setGuestUserIdCookie(res, userId);
-  }
+  const { quotaKey } = resolveGuestQuotaIdentity(req, res);
 
   const controller = new AbortController();
   req.on("close", () => controller.abort());
 
-  await reserveGuestQuota(userId);
-  const guard = createGuestQuotaGuard(userId);
+  await reserveGuestQuota(quotaKey);
+  const guard = createGuestQuotaGuard(quotaKey);
   await runWithQuotaCleanup(guard, async () => {
     const result = await AiModelService.aiFreeModelGenerate(prompt, controller.signal);
     sendResponse(res, {
@@ -94,18 +87,13 @@ const aiModelAlternateEndings = catchAsync(async (req: Request, res: Response) =
 const aiFreeModelAlternateEndings = catchAsync(
   async (req: Request, res: Response) => {
     const payload = req.body;
-    let userId = req.cookies.userId as string | undefined;
-
-    if (!userId) {
-      userId = randomUUID();
-      setGuestUserIdCookie(res, userId);
-    }
+    const { quotaKey } = resolveGuestQuotaIdentity(req, res);
 
     const controller = new AbortController();
     req.on("close", () => controller.abort());
 
-    await reserveGuestQuota(userId);
-    const guard = createGuestQuotaGuard(userId);
+    await reserveGuestQuota(quotaKey);
+    const guard = createGuestQuotaGuard(quotaKey);
     await runWithQuotaCleanup(guard, async () => {
       const result = await AiModelService.aiFreeModelAlternateEndings(payload, controller.signal);
       sendResponse(res, {
@@ -195,18 +183,13 @@ const aiModelRemix = catchAsync(async (req: Request, res: Response) => {
 
 const aiFreeModelRemix = catchAsync(async (req: Request, res: Response) => {
   const payload = req.body as IRemixPayload;
-  let userId = req.cookies.userId as string | undefined;
-
-  if (!userId) {
-    userId = randomUUID();
-    setGuestUserIdCookie(res, userId);
-  }
+  const { quotaKey } = resolveGuestQuotaIdentity(req, res);
 
   const controller = new AbortController();
   req.on("close", () => controller.abort());
 
-  await reserveGuestQuota(userId);
-  const guard = createGuestQuotaGuard(userId);
+  await reserveGuestQuota(quotaKey);
+  const guard = createGuestQuotaGuard(quotaKey);
   await runWithQuotaCleanup(guard, async () => {
     const result = await AiModelService.aiFreeModelRemix(payload, controller.signal);
     sendResponse(res, {
@@ -245,18 +228,13 @@ const aiModelTranslate = catchAsync(async (req: Request, res: Response) => {
 
 const aiFreeModelTranslate = catchAsync(async (req: Request, res: Response) => {
   const payload = req.body as ITranslatePayload;
-  let userId = req.cookies.userId as string | undefined;
-
-  if (!userId) {
-    userId = randomUUID();
-    setGuestUserIdCookie(res, userId);
-  }
+  const { quotaKey } = resolveGuestQuotaIdentity(req, res);
 
   const controller = new AbortController();
   req.on("close", () => controller.abort());
 
-  await reserveGuestQuota(userId);
-  const guard = createGuestQuotaGuard(userId);
+  await reserveGuestQuota(quotaKey);
+  const guard = createGuestQuotaGuard(quotaKey);
   await runWithQuotaCleanup(guard, async () => {
     const result = await AiModelService.aiFreeModelTranslate(payload, controller.signal);
     sendResponse(res, {
@@ -295,18 +273,13 @@ const aiModelChat = catchAsync(async (req: Request, res: Response) => {
 
 const aiFreeModelChat = catchAsync(async (req: Request, res: Response) => {
   const payload = req.body as IChatPayload;
-  let userId = req.cookies.userId as string | undefined;
-
-  if (!userId) {
-    userId = randomUUID();
-    setGuestUserIdCookie(res, userId);
-  }
+  const { quotaKey } = resolveGuestQuotaIdentity(req, res);
 
   const controller = new AbortController();
   req.on("close", () => controller.abort());
 
-  await reserveGuestQuota(userId);
-  const guard = createGuestQuotaGuard(userId);
+  await reserveGuestQuota(quotaKey);
+  const guard = createGuestQuotaGuard(quotaKey);
   await runWithQuotaCleanup(guard, async () => {
     const result = await AiModelService.aiFreeModelChat(payload, controller.signal);
     sendResponse(res, {
@@ -345,18 +318,13 @@ const aiStoryContinuation = catchAsync(async (req: Request, res: Response) => {
 
 const aiFreeStoryContinuation = catchAsync(async (req: Request, res: Response) => {
   const payload = req.body as { prompt: string; language?: string };
-  let userId = req.cookies.userId as string | undefined;
-
-  if (!userId) {
-    userId = randomUUID();
-    setGuestUserIdCookie(res, userId);
-  }
+  const { quotaKey } = resolveGuestQuotaIdentity(req, res);
 
   const controller = new AbortController();
   req.on("close", () => controller.abort());
 
-  await reserveGuestQuota(userId);
-  const guard = createGuestQuotaGuard(userId);
+  await reserveGuestQuota(quotaKey);
+  const guard = createGuestQuotaGuard(quotaKey);
   await runWithQuotaCleanup(guard, async () => {
     const result = await AiModelService.aiFreeStoryContinuation(payload, controller.signal);
     sendResponse(res, {

--- a/backend/src/app/modules/ai_model/quota.service.ts
+++ b/backend/src/app/modules/ai_model/quota.service.ts
@@ -1,6 +1,14 @@
+import { Request, Response } from "express";
+import { randomUUID } from "node:crypto";
 import httpStatus from "http-status";
 import ApiError from "../../../errors/api_error";
 import { REQUEST_LIMITS } from "../../../interfaces/ai_model_request_limit";
+import {
+  getRequestClientIp,
+  guestQuotaKeyForIp,
+  readGuestUserIdCookie,
+  setGuestUserIdCookie,
+} from "../../../utils/cookie.util";
 import { User } from "../user/user.model";
 import { GuestUsage } from "./guest_usage.model";
 
@@ -108,8 +116,45 @@ export const refundUserQuota = async (email: string): Promise<void> => {
   );
 };
 
+
+/**
+ * Resolve the guest quota bucket for a free-generation request.
+ *
+ * Quota is bound to client IP so clearing/omitting the userId cookie cannot
+ * mint an unlimited fresh bucket. A signed guest cookie is still set for
+ * continuity, but reservation always uses the IP key and fails closed when
+ * the IP (or IP guest limit) cannot be satisfied.
+ */
+export const resolveGuestQuotaIdentity = (
+  req: Request,
+  res: Response
+): { quotaKey: string; cookieUserId: string } => {
+  const ip = getRequestClientIp(req);
+  if (!ip) {
+    throw new ApiError(
+      httpStatus.FORBIDDEN,
+      "Unable to identify guest client for quota enforcement."
+    );
+  }
+
+  let cookieUserId = readGuestUserIdCookie(req);
+  if (!cookieUserId) {
+    cookieUserId = randomUUID();
+    setGuestUserIdCookie(res, cookieUserId);
+  } else if (!String(req.cookies?.userId ?? "").startsWith("s:")) {
+    // Upgrade legacy unsigned cookies to signed ones.
+    setGuestUserIdCookie(res, cookieUserId);
+  }
+
+  return {
+    quotaKey: guestQuotaKeyForIp(ip),
+    cookieUserId,
+  };
+};
+
 /**
  * Atomically reserves one guest free-generation slot (persisted in MongoDB).
+ * `guestId` must be the IP-bound key from resolveGuestQuotaIdentity (not a raw cookie UUID).
  */
 export const reserveGuestQuota = async (guestId: string): Promise<void> => {
   try {

--- a/backend/src/utils/cookie.util.ts
+++ b/backend/src/utils/cookie.util.ts
@@ -1,6 +1,8 @@
-import { Response } from "express";
+import { Request, Response } from "express";
+import { createHmac, randomUUID, timingSafeEqual } from "node:crypto";
 import config from "../config";
 import { durationToMilliseconds } from "./duration.util";
+
 const isProd = config.env === "production";
 
 /**
@@ -14,6 +16,40 @@ export const cookieOptions = {
     secure: isProd,
     sameSite: (isProd ? "none" : "lax") as "none" | "lax" | "strict",
     path: "/",
+};
+
+const guestCookieSecret = (): string =>
+  process.env.COOKIE_SECRET?.trim() ||
+  config.jwt.refresh_secret ||
+  config.jwt.secret;
+
+/** HMAC-signed guest cookie value (s:<uuid>.<sig>) so clients cannot forge ids. */
+export const signGuestUserId = (userId: string): string => {
+  const sig = createHmac("sha256", guestCookieSecret())
+    .update(userId)
+    .digest("base64url");
+  return `s:${userId}.${sig}`;
+};
+
+export const verifySignedGuestUserId = (raw: string | undefined): string | null => {
+  if (!raw || !raw.startsWith("s:")) return null;
+  const payload = raw.slice(2);
+  const dot = payload.lastIndexOf(".");
+  if (dot <= 0) return null;
+  const userId = payload.slice(0, dot);
+  const sig = payload.slice(dot + 1);
+  if (!userId || !sig) return null;
+  const expected = createHmac("sha256", guestCookieSecret())
+    .update(userId)
+    .digest("base64url");
+  try {
+    const a = Buffer.from(sig);
+    const b = Buffer.from(expected);
+    if (a.length !== b.length || !timingSafeEqual(a, b)) return null;
+    return userId;
+  } catch {
+    return null;
+  }
 };
 
 /**
@@ -37,14 +73,48 @@ export const clearRefreshTokenCookie = (res: Response): void => {
 };
 
 /**
- * Sets the guest userId tracking cookie.
+ * Sets the guest userId tracking cookie (HMAC-signed).
+ * Quota is NOT keyed by this cookie alone — see resolveGuestQuotaKey.
  */
 export const setGuestUserIdCookie = (
     res: Response,
     userId: string
 ): void => {
-    res.cookie("userId", userId, {
+    res.cookie("userId", signGuestUserId(userId), {
         ...cookieOptions,
         maxAge: 30 * 24 * 60 * 60 * 1000, // 30 days
     });
 };
+
+/** Prefer signed guest cookie; fall back to legacy unsigned UUID cookies. */
+export const readGuestUserIdCookie = (req: Request): string | undefined => {
+  const raw = req.cookies?.userId as string | undefined;
+  const verified = verifySignedGuestUserId(raw);
+  if (verified) return verified;
+  // Legacy unsigned cookie (UUID-shaped) — still accepted for continuity, but
+  // quota binding uses IP so clearing/forging this cannot mint a fresh bucket.
+  if (raw && !raw.startsWith("s:") && /^[0-9a-f-]{36}$/i.test(raw)) {
+    return raw;
+  }
+  return undefined;
+};
+
+/**
+ * Client IP used for guest quota. Fail closed when the IP cannot be determined.
+ */
+export const getRequestClientIp = (req: Request): string | null => {
+  const forwarded = req.headers["x-forwarded-for"];
+  if (typeof forwarded === "string" && forwarded.trim()) {
+    const first = forwarded.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  if (Array.isArray(forwarded) && forwarded[0]?.trim()) {
+    return forwarded[0].trim();
+  }
+  const ip = (req.ip || req.socket?.remoteAddress || "").trim();
+  if (!ip) return null;
+  return ip;
+};
+
+/** Stable GuestUsage key bound to IP (not rotatable via cookie clear). */
+export const guestQuotaKeyForIp = (ip: string): string => `ip:${ip}`;


### PR DESCRIPTION
## Summary
- Guest free-generation quota is keyed by client IP (`ip:<addr>`), so clearing or omitting the `userId` cookie no longer mints a fresh quota bucket.
- Guest cookie is HMAC-signed when set; missing/unknown IP fails closed; over-limit still returns 403.

Fixes #6533

## Test plan
- [ ] Exhaust guest free generations from one IP
- [ ] Clear site cookies (or omit `userId`) and call again — should still be blocked
- [ ] Confirm a different IP still gets its own guest quota
- [ ] Confirm requests with no resolvable IP are rejected

Made with [Cursor](https://cursor.com)