### PR TITLE
test : added unit tests for useChapterTitleGenerator hook

### DIFF
--- a/frontend/src/hooks/__tests__/useChapterTitleGenerator.test.ts
+++ b/frontend/src/hooks/__tests__/useChapterTitleGenerator.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import useChapterTitleGenerator from "../useChapterTitleGenerator";
+
+describe("useChapterTitleGenerator", () => {
+  beforeEach(() => {
+    vi.spyOn(window, "alert").mockImplementation(vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns chapters from generateChapterTitles", () => {
+    const { result } = renderHook(() => useChapterTitleGenerator());
+    expect(result.current.chapters).toBeDefined();
+    expect(Array.isArray(result.current.chapters)).toBe(true);
+    expect(result.current.chapters.length).toBeGreaterThan(0);
+  });
+
+  it("chapters have chapter and suggestions fields", () => {
+    const { result } = renderHook(() => useChapterTitleGenerator());
+    const firstChapter = result.current.chapters[0];
+    expect(firstChapter).toHaveProperty("chapter");
+    expect(firstChapter).toHaveProperty("suggestions");
+    expect(Array.isArray(firstChapter.suggestions)).toBe(true);
+  });
+
+  it("regenerateTitles is a function", () => {
+    const { result } = renderHook(() => useChapterTitleGenerator());
+    expect(typeof result.current.regenerateTitles).toBe("function");
+  });
+
+  it("regenerateTitles calls alert", () => {
+    const { result } = renderHook(() => useChapterTitleGenerator());
+    result.current.regenerateTitles();
+    expect(window.alert).toHaveBeenCalled();
+  });
+
+  it("chapters are memoized and stable across re-renders", () => {
+    const { result, rerender } = renderHook(() => useChapterTitleGenerator());
+    const chaptersFirst = result.current.chapters;
+    rerender();
+    expect(result.current.chapters).toBe(chaptersFirst);
+  });
+});


### PR DESCRIPTION
Closes #6577.

Summary of What Has Been Done:
Added vitest unit tests for the useChapterTitleGenerator React hook. The tests verify that chapters are memoized and returned correctly, that chapter objects have the expected chapter and suggestions fields, that regenerateTitles is a callable function that triggers an alert, and that chapters are stable across re-renders due to memoization.

Changes Made:
- frontend/src/hooks/__tests__/useChapterTitleGenerator.test.ts: created new test file with 5 test cases covering hook behavior

Impact it Made:
- Test coverage for a previously untested hook
- Verified via: pnpm exec vitest run __tests__/useChapterTitleGenerator.test.ts (5 tests passing)

Note: Please assign this PR to the `tmdeveloper007` account.