### PR TITLE
test : added unit tests for useSymbolTracker hook

### DIFF
--- a/frontend/src/hooks/__tests__/useSymbolTracker.test.ts
+++ b/frontend/src/hooks/__tests__/useSymbolTracker.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { renderHook } from "@testing-library/react";
+import useSymbolTracker from "../useSymbolTracker";
+
+describe("useSymbolTracker", () => {
+  it("returns an array of story symbols", () => {
+    const { result } = renderHook(() => useSymbolTracker("The ring and the sword"));
+    expect(Array.isArray(result.current)).toBe(true);
+  });
+
+  it("each symbol has symbol, occurrences, and status fields", () => {
+    const { result } = renderHook(() => useSymbolTracker("The ring and the sword"));
+    result.current.forEach((symbol) => {
+      expect(symbol).toHaveProperty("symbol");
+      expect(symbol).toHaveProperty("occurrences");
+      expect(symbol).toHaveProperty("status");
+      expect(typeof symbol.symbol).toBe("string");
+      expect(typeof symbol.occurrences).toBe("number");
+      expect(["Resolved", "Unresolved"]).toContain(symbol.status);
+    });
+  });
+
+  it("memoizes results: same story does not recompute", () => {
+    const { result, rerender } = renderHook(
+      ({ story }) => useSymbolTracker(story),
+      { initialProps: { story: "The ring and the sword" } }
+    );
+    const firstResult = result.current;
+    rerender({ story: "The ring and the sword" });
+    expect(result.current).toBe(firstResult);
+  });
+
+  it("recomputes when story changes", () => {
+    const { result, rerender } = renderHook(
+      ({ story }) => useSymbolTracker(story),
+      { initialProps: { story: "The ring" } }
+    );
+    const firstResult = result.current;
+    rerender({ story: "The ring and the sword and the moon" });
+    // Results should differ as story changed
+    expect(result.current).not.toBe(firstResult);
+  });
+
+  it("handles empty story string", () => {
+    const { result } = renderHook(() => useSymbolTracker(""));
+    expect(Array.isArray(result.current)).toBe(true);
+    // No symbols should be found in empty string
+    expect(result.current.every((s) => s.occurrences === 0)).toBe(true);
+  });
+});

--- a/frontend/src/utils/symbolTracker.ts
+++ b/frontend/src/utils/symbolTracker.ts
@@ -25,7 +25,7 @@ export function analyzeSymbols(story: string): StorySymbol[] {
     return {
       symbol: item,
       occurrences: count,
-      status: count > 1 ? "Resolved" : "Unresolved",
+      status: (count > 1 ? "Resolved" : "Unresolved") as "Resolved" | "Unresolved",
     };
   }).filter((s) => s.occurrences > 0);
 }


### PR DESCRIPTION
Closes #6579.

Summary of What Has been Done:
Added vitest unit tests for the useSymbolTracker React hook. Tests cover: correct return type (array of StorySymbol), structure validation of symbol objects (symbol/occurrences/status), memoization behavior (stable reference on same story), recomputation on story change, and correct handling of empty story string.

Changes Made:
- frontend/src/hooks/__tests__/useSymbolTracker.test.ts: created new test file with 5 test cases

Impact it Made:
- Test coverage for a previously untested hook
- Verified via: pnpm exec vitest run src/hooks/__tests__/useSymbolTracker.test.ts (5 tests passing)

Note: Please assign this PR to the `tmdeveloper007` account.