### PR TITLE
fix : added SSR guard to announceToScreenReader in accessibility utility

### DIFF
--- a/frontend/src/utils/accessibility.js
+++ b/frontend/src/utils/accessibility.js
@@ -21,6 +21,7 @@ export const handleKeyboardNavigation = (event, handlers) => {
 };
 
 export const announceToScreenReader = (message, priority = 'polite') => {
+  if (typeof document === 'undefined') return;
   const announcement = document.createElement('div');
   announcement.setAttribute('role', 'status');
   announcement.setAttribute('aria-live', priority);


### PR DESCRIPTION
Closes #6580.

Summary of What Has Been Done:
Added a typeof document guard to the announceToScreenReader function in frontend/src/utils/accessibility.js. The function now returns early if document is undefined, preventing SSR crashes when the function is called or imported in a server-side context.

Changes Made:
- frontend/src/utils/accessibility.js: added if (typeof document === 'undefined') return; before document.createElement call

Impact it Made:
- Fixes SSR crash in accessibility utility
- Makes the utility safe for both client and server environments
- Verified via: pnpm exec eslint src/utils/accessibility.js (no errors)

Note: Please assign this PR to the `tmdeveloper007` account.