### PR TITLE
test : added unit tests for useReadingStats hook

### DIFF
--- a/frontend/src/hooks/__tests__/useReadingStats.test.ts
+++ b/frontend/src/hooks/__tests__/useReadingStats.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { renderHook } from "@testing-library/react";
+import useReadingStats from "../useReadingStats";
+
+describe("useReadingStats", () => {
+  it("returns reading stats for a given text", () => {
+    const { result } = renderHook(() =>
+      useReadingStats("This is a test story with several words.")
+    );
+    expect(result.current).toHaveProperty("words");
+    expect(result.current).toHaveProperty("paragraphs");
+    expect(result.current).toHaveProperty("chapters");
+    expect(result.current).toHaveProperty("sentences");
+    expect(result.current).toHaveProperty("averageSentenceLength");
+    expect(result.current).toHaveProperty("readingTime");
+  });
+
+  it("memoizes results: same text does not recompute", () => {
+    const { result, rerender } = renderHook(
+      ({ text }) => useReadingStats(text),
+      { initialProps: { text: "This is a test story." } }
+    );
+    const firstResult = result.current;
+    rerender({ text: "This is a test story." });
+    expect(result.current).toBe(firstResult);
+  });
+
+  it("recomputes when text changes", () => {
+    const { result, rerender } = renderHook(
+      ({ text }) => useReadingStats(text),
+      { initialProps: { text: "Short text." } }
+    );
+    const wordsFirst = result.current.words;
+    rerender({ text: "A much longer text with many more words in it." });
+    expect(result.current.words).not.toBe(wordsFirst);
+  });
+
+  it("handles empty string", () => {
+    const { result } = renderHook(() => useReadingStats(""));
+    expect(result.current.words).toBe(0);
+    expect(result.current.sentences).toBe(0);
+  });
+
+  it("returns numeric values for all stat fields", () => {
+    const { result } = renderHook(() =>
+      useReadingStats("Hello world. This is a sentence.")
+    );
+    expect(typeof result.current.words).toBe("number");
+    expect(typeof result.current.paragraphs).toBe("number");
+    expect(typeof result.current.chapters).toBe("number");
+    expect(typeof result.current.sentences).toBe("number");
+    expect(typeof result.current.averageSentenceLength).toBe("number");
+    expect(typeof result.current.readingTime).toBe("number");
+  });
+});


### PR DESCRIPTION
Closes #6581.

Summary of What Has Been Done:
Added vitest unit tests for the useReadingStats React hook. Tests cover: correct return structure with all ReadingStats fields, memoization behavior (stable reference on same text), recomputation when text changes, correct handling of empty string (0 words, 0 sentences), and verification that all returned values are numeric.

Changes Made:
- frontend/src/hooks/__tests__/useReadingStats.test.ts: created new test file with 5 test cases

Impact it Made:
- Test coverage for a previously untested hook
- Verified via: pnpm exec vitest run src/hooks/__tests__/useReadingStats.test.ts (5 tests passing)

Note: Please assign this PR to the `tmdeveloper007` account.