### PR TITLE
fix: defer URL.revokeObjectURL in downloadBlob — synchronous revocation silently failed downloads in Firefox and Safari

### DIFF
--- a/frontend/src/utils/story-export.utils.ts
+++ b/frontend/src/utils/story-export.utils.ts
@@ -25,7 +25,11 @@ export const downloadBlob = (blob: Blob, fileName: string): void => {
   link.click();
   link.remove();
 
-  URL.revokeObjectURL(url);
+  // Defer revocation to the next event loop tick — the browser's download
+  // initiation is asynchronous. Revoking synchronously after click() causes
+  // the URL to be invalidated before the browser fetches it, silently
+  // failing the download in Firefox and Safari.
+  setTimeout(() => URL.revokeObjectURL(url), 100);
 };
 
 const escapeHtml = (value: string): string =>


### PR DESCRIPTION
### Description
Wraps `URL.revokeObjectURL(url)` in `setTimeout(() => ..., 100)`.
The 100ms delay ensures the browser has time to initiate the download
before the URL is invalidated. This is the standard recommended
approach per MDN for programmatic blob downloads. Fixes silent
download failures in Firefox and Safari.

### Related Issues
Closes #6587 