### PR TITLE
fix: change MIME type from DOCX to text/html in createDocxBlob and createWorkspaceDocxBlob — HTML content declared as DOCX broke Word

### DIFF
--- a/frontend/src/utils/story-export.utils.ts
+++ b/frontend/src/utils/story-export.utils.ts
@@ -1,6 +1,6 @@
 import jsPDF from "jspdf";
 
-export type StoryExportExtension = "md" | "docx" | "pdf";
+export type StoryExportExtension = "md" | "docx" | "pdf" | "html";
 
 export const getSafeFileName = (
   title: string,
@@ -71,8 +71,11 @@ export const createDocxBlob = ({
 </body>
 </html>`;
 
+  // This blob contains HTML, not a real DOCX (Office Open XML ZIP).
+  // Using text/html so the file opens correctly instead of corrupting Word.
+  // To generate a real .docx, use the 'docx' npm package.
   return new Blob([html], {
-    type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document;charset=utf-8",
+    type: "text/html;charset=utf-8",
   });
 };
 
@@ -120,8 +123,9 @@ export const createWorkspaceDocxBlob = ({
 </body>
 </html>`;
 
+  // Same as createDocxBlob — content is HTML, not Office Open XML.
   return new Blob([html], {
-    type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document;charset=utf-8",
+    type: "text/html;charset=utf-8",
   });
 };
 


### PR DESCRIPTION
### Description
Changes `type` in both blob constructors from
`application/vnd.openxmlformats-officedocument.wordprocessingml.document`
to `text/html;charset=utf-8`. Adds `"html"` to `StoryExportExtension`
type. The generated content is HTML — the MIME type now honestly
reflects this. Files open correctly in browsers and are importable
into Word. Adds inline comment noting that a real `.docx` requires
the `docx` npm package for future implementation.

### Related Issues
Closes #6589 