### PR TITLE
fix: suppress canceled/interrupted events in utterance.onerror — stop button was triggering error message

### DIFF
--- a/frontend/src/hooks/useSpeechSynthesis.ts
+++ b/frontend/src/hooks/useSpeechSynthesis.ts
@@ -388,9 +388,15 @@ export const useSpeechSynthesis = (
         );
       };
 
-      utterance.onerror = () => {
+      utterance.onerror = (event: SpeechSynthesisErrorEvent) => {
         setIsSpeaking(false);
         setIsPaused(false);
+        // "canceled" fires when cancel() is called intentionally (stop button).
+        // "interrupted" fires when speak() replaces an ongoing utterance.
+        // Neither is a real error — suppress them to avoid false error messages.
+        if (event.error === "canceled" || event.error === "interrupted") {
+          return;
+        }
         setError("Unable to play narration. Please try again.");
       };
 


### PR DESCRIPTION
### Description
Adds `event: SpeechSynthesisErrorEvent` parameter to `utterance.onerror`.
Returns early without calling `setError` when `event.error` is
`"canceled"` (fired by `cancel()` on intentional stop) or
`"interrupted"` (fired when a new utterance replaces a playing one).
Real errors (network, not-allowed, audio-busy, etc.) still show the
user-facing error message.

### Related Issues
Closes #6592 