### PR TITLE
fix: remove dead utterance property mutations in setPitch/setVolume — Web Speech API ignores post-speak changes, making sliders appear broken

### DIFF
--- a/frontend/src/hooks/useSpeechSynthesis.ts
+++ b/frontend/src/hooks/useSpeechSynthesis.ts
@@ -432,19 +432,15 @@ export const useSpeechSynthesis = (
     setRateState(clampRate(nextRate));
   }, []);
 
+  // Note: Web Speech API reads pitch/volume/rate from the utterance at
+  // speak() time — mutating the utterance after speech starts has no effect.
+  // New values apply on the next play() call, consistent with setRate.
   const setPitch = useCallback((nextPitch: number) => {
     setPitchState(nextPitch);
-
-    if (utteranceRef.current) {
-      utteranceRef.current.pitch = nextPitch;
-    }
   }, []);
 
   const setVolume = useCallback((nextVolume: number) => {
     setVolumeState(nextVolume);
-    if (utteranceRef.current) {
-      utteranceRef.current.volume = nextVolume;
-    }
   }, []);
 
   const setSelectedVoice = useCallback(


### PR DESCRIPTION
### Description
Removes `utteranceRef.current.pitch = nextPitch` from `setPitch` and
`utteranceRef.current.volume = nextVolume` from `setVolume`. Both
functions now only update their respective state variables, identical
to the `setRate` pattern already in the hook. New pitch/volume values
are applied via `utterance.pitch = pitchState` and
`utterance.volume = volumeState` at the top of `speakText` on the
next `play()` call.

### Related Issues
Closes #6594 