### PR TITLE
fix: return 0-100 from progress.percentage in useSpeechSynthesis — fraction 0-1 caused invisible progress bars in all consumers

### DIFF
--- a/frontend/src/hooks/useSpeechSynthesis.ts
+++ b/frontend/src/hooks/useSpeechSynthesis.ts
@@ -476,7 +476,11 @@ export const useSpeechSynthesis = (
     return {
       currentWordIndex: boundedCurrentWordIndex,
       totalWords,
-      percentage: Math.min(1, (boundedCurrentWordIndex + 1) / totalWords),
+      // percentage is 0-100 (per-centum), not 0-1 (ratio).
+      // Consumers using this for progress bars expect width: `${percentage}%`.
+      percentage: Math.round(
+        Math.min(100, ((boundedCurrentWordIndex + 1) / totalWords) * 100)
+      ),
     };
   }, [currentWordIndex]);
 


### PR DESCRIPTION
### Description
Multiplies the ratio by 100 and wraps with `Math.round()` to return
an integer percentage (0-100). The cap changes from `Math.min(1, ...)` 
to `Math.min(100, ...)`. Matches the semantic meaning of the field
name as declared in the exported `SpeechProgress` interface.

### Related Issues
Closes #6596 