### PR TITLE
fix: use e.key === "?" instead of e.shiftKey && e.code === "Slash" — help shortcut was layout-dependent, broken on non-US keyboards

### DIFF
--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -44,7 +44,9 @@ const useKeyboardShortcuts = ({
         active !== null &&
         ["INPUT", "TEXTAREA", "SELECT"].includes(active.tagName);
 
-      if (e.shiftKey && e.code === "Slash") {
+      // e.key === "?" is layout-independent — works on all keyboard layouts.
+      // e.code === "Slash" only works on US QWERTY (physical key position).
+      if (e.key === "?") {
         e.preventDefault();
         handlersRef.current.onOpenHelp();
         return;


### PR DESCRIPTION
### Description
Replaces `e.shiftKey && e.code === "Slash"` with `e.key === "?"`.
`e.key` is the logical key value — the actual character produced
after applying the user's keyboard layout. This works correctly on
all keyboard layouts (US, UK, QWERTZ, AZERTY, etc.) without any
modifier key checks. Adds an inline comment explaining why `e.key`
is preferred over `e.code` for character-based shortcuts.

### Related Issues
Closes #6598 