### PR TITLE
fix(#2274): remove duplicate middleware registration in backend/src/app.ts

### DIFF
--- a/backend/src/__tests__/app.middleware.duplicate.test.ts
+++ b/backend/src/__tests__/app.middleware.duplicate.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Regression test for issue #2274 — duplicate middleware registration in app.ts.
+ *
+ * body-parsing (json, urlencoded), cookieParser, and sanitizeAllMiddleware
+ * were each registered more than once, so every request ran them multiple
+ * times. This test asserts each is registered exactly once by inspecting the
+ * real Express application's router stack.
+ */
+import app from "../app";
+
+type Layer = { name?: string; handle?: { name?: string } };
+
+const stack: Layer[] = (app as unknown as { _router: { stack: Layer[] } })._router.stack;
+
+const countNamed = (predicate: (layer: Layer) => boolean): number =>
+  stack.filter(predicate).length;
+
+describe("app middleware registration (issue #2274)", () => {
+  it("registers express.json exactly once", () => {
+    const n = countNamed((l) => l.name === "jsonParser");
+    expect(n).toBe(1);
+  });
+
+  it("registers express.urlencoded exactly once", () => {
+    const n = countNamed((l) => l.name === "urlencodedParser");
+    expect(n).toBe(1);
+  });
+
+  it("registers cookieParser exactly once", () => {
+    const n = countNamed((l) => l.name === "cookieParser");
+    expect(n).toBe(1);
+  });
+
+  it("registers sanitizeAllMiddleware exactly once", () => {
+    // sanitizeAllMiddleware is an array of [sanitizeQueryMiddleware, sanitizeBodyMiddleware];
+    // Express flattens app.use(array) so each inner middleware appears once.
+    const queries = countNamed((l) => l.name === "sanitizeQueryMiddleware");
+    const bodies = countNamed((l) => l.name === "sanitizeBodyMiddleware");
+    expect(queries).toBe(1);
+    expect(bodies).toBe(1);
+  });
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -78,10 +78,8 @@ app.use(globalRateLimiter);
 app.use(express.json({ limit: "10mb" }));
 app.use(express.urlencoded({ extended: true, limit: "10mb" }));
 app.use(cookieParser() as unknown as RequestHandler);
-app.use(sanitizeAllMiddleware);
 
-
-// Global XSS sanitization for all incoming request bodies and query parameters
+// Global XSS sanitization for all incoming request bodies and query parameters.
 app.use(sanitizeAllMiddleware);
 
 
@@ -94,14 +92,6 @@ app.use((req, res, next) => {
   }
   next();
 });
-
-
-// Payload limit set to 10mb to support large story content and
-// character network data without triggering 413 errors.
-// Previously used Express default (100kb) which was too restrictive.
-app.use(express.json({ limit: "10mb" }));
-app.use(express.urlencoded({ extended: true, limit: "10mb" }));
-app.use(cookieParser() as unknown as RequestHandler);
 
 
 app.use("/api/v1", Routers);


### PR DESCRIPTION
## Problem

Issue #2274 reports that `backend/src/app.ts` registers several core middlewares more than once, so every incoming request executes them multiple times. Concretely, the body-parsing stack, cookie parser, and XSS sanitizer were each wired in twice:

- `express.json({ limit: "10mb" })`
- `express.urlencoded({ extended: true, limit: "10mb" })`
- `cookieParser()`
- `sanitizeAllMiddleware`

The first registration sat just after `globalRateLimiter` (with the original 10mb payload-limit comment), and a second, near-identical block was re-registered a few lines further down, after the character-network URL rewrite rule. `sanitizeAllMiddleware` was likewise applied in two consecutive `app.use(...)` calls.

## Impact

For every single HTTP request the Express app was:

1. Parsing the JSON body twice — `express.json` reads and caches the stream, so the second parse is redundant work, and on large payloads (up to the 10mb limit this project allows for story content) that is non-trivial CPU/memory overhead.
2. Parsing URL-encoded bodies twice — same redundant streaming/parsing cost.
3. Parsing cookies twice — `cookieParser` re-walks the `Cookie` header and rebuilds `req.cookies`/`req.signedCookies`.
4. Running XSS sanitization (`sanitizeQueryMiddleware` + `sanitizeBodyMiddleware`) twice — string sanitization over the entire query and body, duplicated.

Beyond the wasted per-request work, duplicate middleware is a well-known source of subtle, hard-to-trace bugs: any future change to one of these handlers that is not idempotent (e.g. mutating `req.body`, appending to a header, or recording telemetry) would silently execute twice and produce doubled counts, doubled mutations, or unexpected side effects. It also pollutes the middleware stack trace and makes ordering bugs harder to reason about.

## Root Cause

This looks like the result of two earlier changes that each added the body-parsing + cookie stack independently (one with the original comment, one with the "Previously used Express default (100kb)" note) without removing the prior block, plus `sanitizeAllMiddleware` being registered once directly and once under a "Global XSS sanitization" comment. Two prior PRs (#2568, #2896) attempted to address this but the duplicates remain on `main`, so a focused fix plus a regression test is warranted.

## Fix

Removed the second registration block (the duplicate `express.json` / `express.urlencoded` / `cookieParser` trio after the rewrite rule) and collapsed the two `sanitizeAllMiddleware` registrations into a single one. The retained block keeps the explanatory 10mb-payload comment and sits in the correct position — after CORS and the global rate limiter, and before the route rewrite and `/api/v1` router mount — so request parsing/sanitization still happens exactly once per request, in the right order.

No behavioural change for valid requests; the only change is that each middleware now runs once instead of twice.

## Tests

Added `backend/src/__tests__/app.middleware.duplicate.test.ts` — a regression test that imports the **real** `app` (not a mock) and inspects Express's internal router stack (`app._router.stack`), asserting that:

- `jsonParser` is registered exactly once,
- `urlencodedParser` is registered exactly once,
- `cookieParser` is registered exactly once,
- `sanitizeQueryMiddleware` and `sanitizeBodyMiddleware` (the two members of the `sanitizeAllMiddleware` array, which Express flattens) are each registered exactly once.

All 4 tests pass. This test will fail if any of these middlewares are re-added in duplicate, guarding against regression.

## Files Changed

- `backend/src/app.ts` — removed the duplicate body-parser / cookie-parser / sanitizer registration block.
- `backend/src/__tests__/app.middleware.duplicate.test.ts` — new regression test asserting single registration.

Closes #2274