### PR TITLE
docs(#1240): clarify AI Layer section in ARCHITECTURE.md (Unsplash is not an AI model)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -223,9 +223,16 @@ StorySparkAI supports two AI providers — switchable via environment variables:
 |---|---|---|
 | OpenAI | `OPEN_AI_KEY` | Story generation + analysis |
 | Google Gemini | `GEMINI_API_KEY` | Story generation + analysis |
+
+**Image assets** (not an AI model — listed here because it is consumed during story cover generation):
+
+| Service | Env var | Used for |
+|---|---|---|
 | Unsplash | `UNSPLASH_KEY_API` | Story cover image fetching |
 
-AI is used **only** for generation and analysis — all story data, user data, and bookmarks are stored in MongoDB.
+AI is used **only** for generation and analysis; Unsplash is an image-asset API
+(not an AI model) used solely to fetch cover images. All story data, user data,
+and bookmarks are stored in MongoDB.
 
 ---
 


### PR DESCRIPTION
## Problem

Issue #1240 points out two documentation inconsistencies in the **AI Layer** section (Section 4) of `ARCHITECTURE.md`:

1. The providers table lists **Unsplash** alongside OpenAI and Google Gemini, but Unsplash is an image-asset API, not an AI model. This directly contradicts the section's own opening line — _"StorySparkAI supports two AI providers"_ — because the table then shows three rows, one of which is not an AI provider at all.
2. The closing line — _"AI is used **only** for generation and analysis"_ — is misleading because Unsplash (image fetching, not generation/analysis) is grouped under the same heading, so a reader cannot tell whether image fetching counts as an "AI" use or not.

The issue also suggests renaming the environment variable `UNSPLASH_KEY_API` to `UNSPLASH_API_KEY` on the grounds of naming convention. After checking the actual codebase, I did **not** make that rename: `UNSPLASH_KEY_API` is the name genuinely consumed by `backend/src/config/index.ts` (`process.env.UNSPLASH_KEY_API`) and declared in `backend/.env.example`. Renaming it only in the documentation would make the docs actively wrong — a contributor copying `UNSPLASH_API_KEY` into their `.env` would find Unsplash cover fetching silently broken. So the doc is left matching the code, and the fix focuses on the real accuracy problem (the Unsplash mislabeling).

## Fix

Restructured Section 4 so the AI providers and the image-asset service are no longer conflated:

- The **AI providers table** now contains only the two actual AI providers — OpenAI (`OPEN_AI_KEY`) and Google Gemini (`GEMINI_API_KEY`) — matching the _"two AI providers"_ intro.
- Unsplash is moved into a separate, clearly-labelled **"Image assets"** sub-table, explicitly noted as _"not an AI model — listed here because it is consumed during story cover generation"_. The env var name `UNSPLASH_KEY_API` is preserved exactly as it appears in the code.
- The closing sentence is reworded to remove the contradiction: _"AI is used **only** for generation and analysis; Unsplash is an image-asset API (not an AI model) used solely to fetch cover images. All story data, user data, and bookmarks are stored in MongoDB."_

This makes the section internally consistent: the intro claims two AI providers, the table shows two AI providers, and the summary correctly distinguishes AI generation/analysis from image-asset fetching.

## Why not rename the env var?

A documentation-only rename of `UNSPLASH_KEY_API` → `UNSPLASH_API_KEY` would desynchronize the docs from `backend/src/config/index.ts` and `backend/.env.example`, both of which use `UNSPLASH_KEY_API`. The downstream cost of that (broken Unsplash integration for anyone following the docs) is worse than the stylistic naming concern. A proper rename would need to touch the config loader, the `.env.example`, and any deployment/CI secrets — out of scope for a documentation issue and better handled as a dedicated refactor if desired.

## Files Changed

- `ARCHITECTURE.md` — Section 4 (AI Layer): split Unsplash into a separate "Image assets" sub-table and reworded the summary line; env var name left unchanged to match the code.

This is a documentation-only change, so no tests are added.

Closes #1240