### PR TITLE
fix(#2746): accept OTPs containing internal whitespace during email verification

### DIFF
--- a/backend/src/__tests__/verify_email.test.ts
+++ b/backend/src/__tests__/verify_email.test.ts
@@ -93,4 +93,25 @@ describe("VerifyEmailService.VerifyOtp", () => {
       VerifyEmailService.VerifyOtp({ email: "user@example.com", otp: "123456" })
     ).rejects.toMatchObject({ status: httpStatus.TOO_MANY_REQUESTS });
   });
+
+  // Regression tests for issue #2746 — the OTP email renders each digit in its
+  // own box with 10px gaps, so users frequently type/paste the code with
+  // internal whitespace. Previously otp.trim() only stripped ends, so a valid
+  // but space-separated OTP was rejected as "Invalid OTP".
+  it("should accept a correct OTP with internal spaces (issue #2746)", async () => {
+    const response = await VerifyEmailService.VerifyOtp({ email: "user@example.com", otp: "123 456" });
+    expect(response).toMatchObject({ verified: true });
+    expect(mockOtpRecord.save).toHaveBeenCalled();
+  });
+
+  it("should accept a correct OTP with leading/trailing/internal whitespace (issue #2746)", async () => {
+    const response = await VerifyEmailService.VerifyOtp({ email: "user@example.com", otp: "  123 456  " });
+    expect(response).toMatchObject({ verified: true });
+  });
+
+  it("should still reject a genuinely wrong OTP even after whitespace normalization", async () => {
+    await expect(
+      VerifyEmailService.VerifyOtp({ email: "user@example.com", otp: "999 999" })
+    ).rejects.toThrow(ApiError);
+  });
 });

--- a/backend/src/app/modules/verify_email/verify_email.service.ts
+++ b/backend/src/app/modules/verify_email/verify_email.service.ts
@@ -125,6 +125,13 @@ const VerifyOtp = async (payload: IVerifyOtpBody) => {
     );
   }
   
+  // The OTP email renders each digit in its own box with 10px gaps, so users
+  // frequently type or paste the code with internal whitespace (e.g. "123 456").
+  // otp.trim() only strips leading/trailing whitespace, so a correctly-typed but
+  // space-separated OTP compared "123456" !== "123 456" and was rejected as
+  // invalid (issue #2746). Strip ALL whitespace before comparing.
+  const normalizedOtp = otp.replace(/\s+/g, "");
+
   const storedOtpRecord = await OTPModel.findOne({ email });
 
   if (!storedOtpRecord) {
@@ -161,7 +168,7 @@ const VerifyOtp = async (payload: IVerifyOtpBody) => {
   }
 
   // Verify OTP
-  if (storedOtpRecord.otp !== otp.trim()) {
+  if (storedOtpRecord.otp !== normalizedOtp) {
     // Increment failed attempts
     storedOtpRecord.failedAttempts += 1;
     await storedOtpRecord.save();


### PR DESCRIPTION
## Problem

Issue #2746 reports that email verification is broken during account registration: after signing up, the user receives a valid OTP via email, but when they enter it the application rejects it as **"Invalid OTP"**, preventing verification and login entirely.

## Root Cause

The verification email template in `verify_email.service.ts` renders the OTP not as a plain string, but as **each digit inside its own bordered box with a 10px right margin between digits**:

```js
${otp.split("").map((digit, index, arr) => `
  <span style="... width: 40px; height: 40px; ... ${index !== arr.length - 1 ? "margin-right: 10px;" : ""}">
    ${digit}
  </span>`).join("")}
```

So a user reading `1 2 3 4 5 6` (visually grouped into digit boxes) very naturally types — or copy-pastes — the code **with internal whitespace**, e.g. `"123 456"` or `"123  456"`.

The verification logic compared the stored OTP against the input using `otp.trim()`:

```ts
if (storedOtpRecord.otp !== otp.trim()) { /* reject as Invalid OTP */ }
```

`String.prototype.trim()` only removes **leading and trailing** whitespace — it does **not** remove whitespace *between* digits. So for an input of `"123 456"`:

- `"123 456".trim()` → `"123 456"` (unchanged, internal space preserved)
- comparison: `"123456" !== "123 456"` → **true** → "Invalid OTP"

A correctly-typed, valid OTP was therefore rejected whenever the user included any internal spacing — which the email's own visual design actively encourages. Each such rejection also incremented `failedAttempts`, and after 5 the user was locked out and forced to request a new OTP, only to hit the same wall.

## Fix

Normalize the submitted OTP by stripping **all** whitespace before comparison, not just the ends:

```ts
const normalizedOtp = otp.replace(/\s+/g, "");
// ...
if (storedOtpRecord.otp !== normalizedOtp) { /* reject */ }
```

This makes `"123 456"`, `"  123 456  "`, `"123\t456"`, and `"123456"` all compare equal to the stored `"123456"`. A genuinely incorrect code (e.g. `"999 999"` → normalized `"999999"`) is still rejected and still increments `failedAttempts`, so brute-force protection is unaffected.

Normalization is done once, after the type/emptiness guard and before the DB lookup, so all downstream logic (expiry check, reuse check, attempt limiting, comparison) operates on the cleaned value.

## Tests

Added regression tests to the existing `backend/src/__tests__/verify_email.test.ts`:

1. **Accepts a correct OTP with internal spaces** (`"123 456"`) — previously rejected; now verifies successfully.
2. **Accepts a correct OTP with leading/trailing/internal whitespace** (`"  123 456  "`) — now verifies successfully.
3. **Still rejects a genuinely wrong OTP even after normalization** (`"999 999"` → `"999999"` ≠ `"123456"`) — confirms the fix doesn't weaken validation.

All 3 new tests pass. (Note: 4 pre-existing tests in the same file already fail on `main` — e.g. `should enforce max failed attempts` expects `toMatchObject({ status: 429 })` but the thrown `ApiError` doesn't serialize that way under the mock. These are unrelated to this change and were verified failing on `main` before the patch.)

## Files Changed

- `backend/src/app/modules/verify_email/verify_email.service.ts` — strip all whitespace from the submitted OTP before comparison.
- `backend/src/__tests__/verify_email.test.ts` — 3 regression tests for whitespace normalization.

## Impact

Resolves the registration-blocking verification failure for any user whose OTP input contained internal whitespace — a scenario the email template's per-digit-box layout actively invites. No change to security posture: wrong codes are still rejected and rate-limited exactly as before.

Closes #2746