### PR TITLE
fix(user): exclude password hash from profile & writer-application responses (#6525)

### DIFF
--- a/backend/src/app/modules/user/__tests__/user.service.password-leak.test.ts
+++ b/backend/src/app/modules/user/__tests__/user.service.password-leak.test.ts
@@ -1,0 +1,100 @@
+jest.mock("bcryptjs", () => ({ hash: jest.fn() }), { virtual: true });
+
+jest.mock("../../../../config", () => ({
+  __esModule: true,
+  default: { bcrypt_salt_rounds: 10 },
+}));
+
+// Heavy modules the service imports but these tests don't exercise.
+jest.mock("nodemailer", () => ({ createTransport: jest.fn(() => ({ sendMail: jest.fn() })) }));
+
+const postFindMock = jest.fn();
+const followMock = { populate: jest.fn().mockReturnThis(), lean: jest.fn().mockResolvedValue([]) };
+
+jest.mock("../../post/post.model", () => ({
+  __esModule: true,
+  Post: { find: postFindMock },
+}));
+
+jest.mock("../../follow/follow.model", () => ({
+  __esModule: true,
+  Follow: {},
+}));
+
+jest.mock("../../comment/comment.model", () => ({ __esModule: true, Comment: {} }));
+jest.mock("../../reaction/reaction.model", () => ({ __esModule: true, Reaction: {} }));
+jest.mock("../../bookmark/bookmark.model", () => ({ __esModule: true, Bookmark: {} }));
+jest.mock("../../notification/notification.model", () => ({ __esModule: true, Notification: {} }));
+jest.mock("../../story_version/story_version.model", () => ({ __esModule: true, StoryVersion: {} }));
+jest.mock("../../report/report.model", () => ({ __esModule: true, Report: {} }));
+
+// Chainable query mock that records whether select("-password") was invoked.
+function chainable(finalValue: unknown) {
+  const state = { selectCalled: false, populateCalls: 0 };
+  const self: any = {
+    select(arg: string) {
+      if (arg === "-password") state.selectCalled = true;
+      return self;
+    },
+    populate(..._args: unknown[]) {
+      state.populateCalls += 1;
+      return self;
+    },
+    sort() {
+      return self;
+    },
+    then(resolve: (v: unknown) => unknown) {
+      return Promise.resolve(finalValue).then(resolve);
+    },
+    catch() {
+      return self;
+    },
+    __state: state,
+  };
+  return self;
+}
+
+const userDoc = {
+  _id: "u1",
+  email: "me@example.com",
+  name: "Me",
+  password: "$2a$10$LEAKEDHASH",
+  followers: [],
+  following: [],
+};
+
+const findOneMock = jest.fn(() => chainable(userDoc));
+const findMock = jest.fn(() => chainable([userDoc]));
+
+jest.mock("../user.model", () => ({
+  __esModule: true,
+  User: { findOne: findOneMock, find: findMock },
+}));
+
+import { UserService } from "../user.service";
+
+describe("user.service password-hash leak (#6525)", () => {
+  beforeEach(() => {
+    findOneMock.mockImplementation(() => chainable(userDoc));
+    findMock.mockImplementation(() => chainable([userDoc]));
+  });
+
+  it("getProfileInfo excludes the password field from the query", async () => {
+    const token = { email: "me@example.com" } as any;
+    const result = (await UserService.getProfileInfo(token)) as any;
+
+    expect(result).toBeTruthy();
+    expect(findOneMock).toHaveBeenCalledWith({ email: "me@example.com" });
+    const chain = findOneMock.mock.results[0].value;
+    expect(chain.__state.selectCalled).toBe(true);
+  });
+
+  it("getAllWriterApplicationUsers excludes the password field from the query", async () => {
+    const result = (await UserService.getAllWriterApplicationUsers()) as any;
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(findMock).toHaveBeenCalledWith({ isApplyForWriter: true });
+    const chain = findMock.mock.results[0].value;
+    expect(chain.__state.selectCalled).toBe(true);
+  });
+});

--- a/backend/src/app/modules/user/user.service.ts
+++ b/backend/src/app/modules/user/user.service.ts
@@ -224,13 +224,14 @@ const approveWriterApplication = async (email: string) => {
 };
 
 const getAllWriterApplicationUsers = async (): Promise<IUser[]> => {
-  const result = await User.find({ isApplyForWriter: true });
+  const result = await User.find({ isApplyForWriter: true }).select("-password");
   return result;
 };
 
 const getProfileInfo = async (token: ITokenPayload) => {
   const { email } = token;
   const user = await User.findOne({ email: email })
+    .select("-password")
     .populate("followers", "name profile")
     .populate("following", "name profile");
   if (!user) {

--- a/backend/src/app/modules/writer_application/__tests__/writer_application.service.password-leak.test.ts
+++ b/backend/src/app/modules/writer_application/__tests__/writer_application.service.password-leak.test.ts
@@ -1,0 +1,37 @@
+jest.mock("../../user/user.model", () => ({
+  __esModule: true,
+  User: { findByIdAndUpdate: jest.fn() },
+}));
+
+const populateMock = jest.fn();
+const sortMock = jest.fn();
+
+jest.mock("../writer_application.model", () => ({
+  __esModule: true,
+  WriterApplication: { find: jest.fn(), findOne: jest.fn(), findById: jest.fn() },
+}));
+
+import { WriterApplication } from "../writer_application.model";
+import { WriterApplicationService } from "../writer_application.service";
+
+describe("writer_application.service password-hash leak (#6525)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const findChain: any = {
+      populate: populateMock.mockReturnThis(),
+      sort: sortMock.mockReturnThis(),
+      then: (resolve: (v: unknown) => unknown) =>
+        Promise.resolve([{ _id: "app1", user: { email: "u@x.com" } }]).then(resolve),
+    };
+    (WriterApplication.find as jest.Mock).mockReturnValue(findChain);
+  });
+
+  it("getAllApplications populates the user with -password so hashes are not leaked", async () => {
+    const result = (await WriterApplicationService.getAllApplications()) as any;
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(WriterApplication.find).toHaveBeenCalledTimes(1);
+    // populate must be called with ("user", "-password") — not just ("user").
+    expect(populateMock).toHaveBeenCalledWith("user", "-password");
+  });
+});

--- a/backend/src/app/modules/writer_application/writer_application.service.ts
+++ b/backend/src/app/modules/writer_application/writer_application.service.ts
@@ -25,7 +25,9 @@ const submitApplication = async (
 };
 
 const getAllApplications = async () => {
-  return await WriterApplication.find().populate("user").sort({ createdAt: -1 });
+  return await WriterApplication.find()
+    .populate("user", "-password")
+    .sort({ createdAt: -1 });
 };
 
 const updateApplicationStatus = async (


### PR DESCRIPTION
## Summary

`getProfileInfo` (the dashboard profile endpoint) and `getAllWriterApplicationUsers` (the admin writer-application list) queried the `User` document and returned it to authenticated callers **without excluding the `password` field**. The `User` schema does **not** set `select: false` on the `password` path, so Mongoose returns the bcrypt hash by default, and the controller serializes the raw document straight into the JSON response:

```typescript
// user.service.ts — BEFORE
const getProfileInfo = async (token) => {
  const user = await User.findOne({ email })
    .populate("followers", "name profile")
    .populate("following", "name profile");
  ...
  return user;            // includes user.password (bcrypt hash)
};

const getAllWriterApplicationUsers = async () => {
  const result = await User.find({ isApplyForWriter: true });   // includes password
  return result;
};
```

The writer-application list had the same leak via a populate path:

```typescript
// writer_application.service.ts — BEFORE
const getAllApplications = async () => {
  return await WriterApplication.find().populate("user").sort({ createdAt: -1 });
  //                                                  ^^^^^^^^^^^^^^ full user, hash included
};
```

So any authenticated user could read their own bcrypt hash from the profile response, and any admin viewing writer applications received the bcrypt hash of every applicant — a credential exposure that offline cracking could turn into account takeover, especially for users who reused passwords.

## Fix

Applied the existing, repo-established `.select("-password")` pattern (already used in `getAllUsers` at `user.service.ts:22`) to the two leaking read endpoints, and constrained the writer-application populate to exclude `password`:

- **`backend/src/app/modules/user/user.service.ts`**
  - `getProfileInfo`: `User.findOne({ email }).select("-password").populate(...)`
  - `getAllWriterApplicationUsers`: `User.find({ isApplyForWriter: true }).select("-password")`
- **`backend/src/app/modules/writer_application/writer_application.service.ts`**
  - `getAllApplications`: `.populate("user", "-password")` instead of `.populate("user")`

This is the minimal, targeted fix that matches the issue's named endpoints and the codebase's existing convention. I deliberately did **not** add `select: false` to the `password` schema field: the auth module's login and change-password flows (`auth.service.ts:97`, `:326`, `:392`) read `user.password` via plain `User.findOne({ email })` and would silently break (bcrypt comparing against `undefined`) if the field were hidden by default. The targeted `.select("-password")` approach leaves those flows untouched while closing the leak on the read endpoints.

## Verification

New regression tests, **3 tests, all passing**:

- `backend/src/app/modules/user/__tests__/user.service.password-leak.test.ts` (2 tests) — mocks the `User` model with a chainable query and asserts `.select("-password")` is invoked for both `getProfileInfo` and `getAllWriterApplicationUsers` (and that the correct filter is passed to `find`/`findOne`).
- `backend/src/app/modules/writer_application/__tests__/writer_application.service.password-leak.test.ts` (1 test) — mocks `WriterApplication` and asserts `populate` is called with `("user", "-password")` (not just `"user"`).

```
PASS src/app/modules/user/__tests__/user.service.password-leak.test.ts
PASS src/app/modules/writer_application/__tests__/writer_application.service.password-leak.test.ts
Tests: 3 passed
```

## Changes

- `backend/src/app/modules/user/user.service.ts` — `.select("-password")` on `getProfileInfo` and `getAllWriterApplicationUsers`.
- `backend/src/app/modules/writer_application/writer_application.service.ts` — `.populate("user", "-password")` on `getAllApplications`.
- `backend/src/app/modules/user/__tests__/user.service.password-leak.test.ts` — new (2 tests).
- `backend/src/app/modules/writer_application/__tests__/writer_application.service.password-leak.test.ts` — new (1 test).

Closes #6525
