### PR TITLE
fix(verify_email): wire real clearOtpAttempts so successes don't burn OTP budget (#6534)

### DIFF
--- a/backend/src/app/modules/verify_email/__tests__/otp.rate-limiter.middleware.test.ts
+++ b/backend/src/app/modules/verify_email/__tests__/otp.rate-limiter.middleware.test.ts
@@ -1,0 +1,44 @@
+import { otpRateLimiter, clearOtpAttempts } from "../otp.rate-limiter.middleware";
+
+function buildReq(email: string) {
+  return { body: { email } } as any;
+}
+
+function runMiddleware(email: string): { nextOk: boolean } {
+  let nextOk = true;
+  otpRateLimiter(
+    buildReq(email),
+    {} as any,
+    (err?: unknown) => {
+      if (err) nextOk = false;
+    }
+  );
+  return { nextOk };
+}
+
+describe("otp.rate-limiter.middleware (#6534)", () => {
+  it("clearOtpAttempts actually clears the store so successes do not accumulate", () => {
+    const email = "user@example.com";
+    // Burn 4 attempts (all allowed), clearing after each to simulate successful verifies.
+    for (let i = 0; i < 10; i += 1) {
+      const { nextOk } = runMiddleware(email);
+      expect(nextOk).toBe(true); // never blocked because we clear on success
+      clearOtpAttempts(email);
+    }
+  });
+
+  it("without clearOtpAttempts, repeated attempts eventually get blocked (sanity)", () => {
+    const email = "blocked@example.com";
+    let blockedAtLeastOnce = false;
+    for (let i = 0; i < 9; i += 1) {
+      const { nextOk } = runMiddleware(email);
+      if (!nextOk) blockedAtLeastOnce = true;
+    }
+    expect(blockedAtLeastOnce).toBe(true);
+    clearOtpAttempts(email);
+  });
+
+  it("clearOtpAttempts is idempotent for unknown emails", () => {
+    expect(() => clearOtpAttempts("never-seen@example.com")).not.toThrow();
+  });
+});

--- a/backend/src/app/modules/verify_email/__tests__/verify_email.service.clearOtpAttempts.test.ts
+++ b/backend/src/app/modules/verify_email/__tests__/verify_email.service.clearOtpAttempts.test.ts
@@ -1,0 +1,65 @@
+jest.mock("nodemailer", () => ({
+  createTransport: jest.fn(() => ({ sendMail: jest.fn() })),
+}));
+
+jest.mock("../../../../config", () => ({
+  __esModule: true,
+  default: { verify_email: "e", verify_password: "p" },
+}));
+
+jest.mock("../../../../utils/email.util", () => ({ escapeHtml: (s: string) => s }));
+
+const clearOtpAttemptsMock = jest.fn();
+jest.mock("../otp.rate-limiter.middleware", () => ({
+  __esModule: true,
+  clearOtpAttempts: clearOtpAttemptsMock,
+}));
+
+const otpDocMock: any = {
+  email: "user@example.com",
+  otp: "123456",
+  failedAttempts: 0,
+  isVerified: false,
+  expiresAt: new Date(Date.now() + 10 * 60 * 1000),
+  save: jest.fn(),
+};
+
+jest.mock("../otp.model", () => ({
+  __esModule: true,
+  OTPModel: { findOne: jest.fn(), deleteOne: jest.fn() },
+}));
+
+import { OTPModel } from "../otp.model";
+import { VerifyEmailService } from "../verify_email.service";
+
+describe("verify_email.service OTP success clears rate-limit (#6534)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    otpDocMock.failedAttempts = 0;
+    otpDocMock.isVerified = false;
+    otpDocMock.save.mockResolvedValue(otpDocMock);
+    (OTPModel.findOne as jest.Mock).mockResolvedValue(otpDocMock);
+  });
+
+  it("calls the real clearOtpAttempts (from the middleware) on successful verify", async () => {
+    const res = await VerifyEmailService.VerifyOtp({
+      email: "user@example.com",
+      otp: "123456",
+    } as any);
+
+    expect(res.verified).toBe(true);
+    expect(clearOtpAttemptsMock).toHaveBeenCalledTimes(1);
+    expect(clearOtpAttemptsMock).toHaveBeenCalledWith("user@example.com");
+  });
+
+  it("does NOT clear rate-limit attempts on a failed (wrong-OTP) verify", async () => {
+    await expect(
+      VerifyEmailService.VerifyOtp({
+        email: "user@example.com",
+        otp: "000000",
+      } as any)
+    ).rejects.toBeDefined();
+
+    expect(clearOtpAttemptsMock).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/app/modules/verify_email/verify_email.service.ts
+++ b/backend/src/app/modules/verify_email/verify_email.service.ts
@@ -6,6 +6,7 @@ import config from "../../../config";
 import httpStatus from "http-status";
 import { OTPModel } from "./otp.model";
 import crypto from "crypto";
+import { clearOtpAttempts } from "./otp.rate-limiter.middleware";
 
 const transporter = nodemailer.createTransport({
   service: "Gmail",
@@ -190,11 +191,6 @@ const VerifyOtp = async (payload: IVerifyOtpBody) => {
   };
 };
 
-// FIX #3: Converted to a standard function so it gets safely hoisted to the top 
-// of the scope during compilation, preventing potential initialization errors.
-function clearOtpAttempts(email: string) {
-  console.log('Clearing OTP attempts for:', email);
-}
 
 export const VerifyEmailService = {
   VerifyEmail,


### PR DESCRIPTION
## Summary

The OTP verification rate limiter never reset after a successful verify, so legitimate users eventually hit `429 Too Many Requests` despite only ever verifying **successfully**. Two compounding defects:

1. **`clearOtpAttempts` in the service was a no-op.** `verify_email.service.ts` defined a *local* function:
   ```typescript
   function clearOtpAttempts(email: string) {
     console.log('Clearing OTP attempts for:', email);   // logs only — never clears
   }
   ```
   This shadowed the real `clearOtpAttempts` exported by `otp.rate-limiter.middleware.ts` (which `delete`s the record from the in-memory `rateLimitStore` Map). The success path called this local no-op, so the attempt counter for the email was never removed.

2. **The middleware increments the attempt counter *before* the controller verifies.** `otpRateLimiter` does `record.attempts += 1` then calls `next()`, so every request — including the one that will succeed — consumes budget. Combined with defect #1, each successful verify permanently incremented the counter (it was never cleared), so after enough successful verifications the user crossed the `PHASE_1_MAX_ATTEMPTS` (5) / `PHASE_2_MAX_ATTEMPTS` (8) thresholds and got blocked, even though they never failed.

Net effect: a user who successfully verifies their email several times (e.g. across multiple registrations/resends, or a multi-instance deployment where the process-local Map is per-worker) gets rate-limited for behaving correctly.

## Fix

Wire the service to the real `clearOtpAttempts` and remove the no-op:

- **`backend/src/app/modules/verify_email/verify_email.service.ts`**
  - Add `import { clearOtpAttempts } from "./otp.rate-limiter.middleware";`
  - Remove the local `function clearOtpAttempts(email) { console.log(...) }` that shadowed it.

Now the existing success-path call (`clearOtpAttempts(email)` at the end of `VerifyOtp`) invokes the middleware's real implementation, which `delete`s the in-memory record. Because the record is wiped on success, the increment-before-verify no longer accumulates across successful verifies: a success consumes one increment then immediately clears the whole record, so the budget resets. Failed verifies (wrong OTP) increment `failedAttempts` on the OTP document and leave the limiter record in place, which is correct behavior — failures *should* count toward the limit.

This is the minimal change that resolves the reported symptom (eventual 429 despite successes) without restructuring the limiter's architecture. The process-local Map limitation (limits reset on restart / differ across instances) noted in the issue is a separate, larger concern requiring a shared store (Redis); it is out of scope for this fix, which targets the clear-no-op correctness bug.

## Verification

New regression tests, **5 tests, all passing**:

`backend/src/app/modules/verify_email/__tests__/otp.rate-limiter.middleware.test.ts` (3 tests):
- `clearOtpAttempts actually clears the store so successes do not accumulate` — runs the middleware 10 times for the same email, clearing after each (simulating successful verifies), and asserts it is **never** blocked. This is the exact regression: previously the counter would grow unbounded.
- `without clearOtpAttempts, repeated attempts eventually get blocked (sanity)` — confirms the limiter *does* still block when `clearOtpAttempts` is not called (9 attempts → blocked), proving the fix doesn't disable rate limiting.
- `clearOtpAttempts is idempotent for unknown emails` — clearing a never-seen email does not throw.

`backend/src/app/modules/verify_email/__tests__/verify_email.service.clearOtpAttempts.test.ts` (2 tests):
- `calls the real clearOtpAttempts (from the middleware) on successful verify` — mocks the middleware module and asserts `clearOtpAttempts` is called once with the email after a successful OTP verify.
- `does NOT clear rate-limit attempts on a failed (wrong-OTP) verify` — asserts `clearOtpAttempts` is **not** called when the OTP is wrong (failures must still count).

```
PASS src/app/modules/verify_email/__tests__/otp.rate-limiter.middleware.test.ts
PASS src/app/modules/verify_email/__tests__/verify_email.service.clearOtpAttempts.test.ts
Tests: 5 passed
```

## Changes

- `backend/src/app/modules/verify_email/verify_email.service.ts` — import real `clearOtpAttempts` from the middleware; remove the local no-op.
- `backend/src/app/modules/verify_email/__tests__/otp.rate-limiter.middleware.test.ts` — new (3 tests).
- `backend/src/app/modules/verify_email/__tests__/verify_email.service.clearOtpAttempts.test.ts` — new (2 tests).

Closes #6534
