### PR TITLE
fix(newsletter): strip secret tokens from subscribe/verify responses (#6535)

### DIFF
--- a/backend/src/app/modules/newsletter/__tests__/newsletter.service.token-leak.test.ts
+++ b/backend/src/app/modules/newsletter/__tests__/newsletter.service.token-leak.test.ts
@@ -1,0 +1,109 @@
+jest.mock("../../../../utils/email.util", () => ({
+  sendVerificationEmail: jest.fn(),
+}));
+
+const SECRET_FIELDS = ["unsubscribeToken", "verificationToken", "verificationTokenExpires"];
+
+// Minimal Mongoose-like document: toObject returns a shallow copy of fields.
+function doc(fields: Record<string, any>): any {
+  return {
+    ...fields,
+    toObject() {
+      return { ...fields };
+    },
+    save: jest.fn(),
+  };
+}
+
+const findOneMock = jest.fn();
+const createMock = jest.fn();
+
+jest.mock("../newsletter.model", () => ({
+  __esModule: true,
+  NewsletterSubscriber: { findOne: findOneMock, create: createMock },
+}));
+
+import { subscribeNewsletter, verifyNewsletter } from "../newsletter.service";
+
+function assertNoSecretFields(subscriber: any, label: string) {
+  for (const f of SECRET_FIELDS) {
+    expect(subscriber).not.toHaveProperty(f, expect.any(String));
+    // Stronger: field must be absent entirely, not just undefined.
+    expect(f in (subscriber || {})).toBe(false);
+  }
+  // sanity: the public fields are still present
+  expect(subscriber).toHaveProperty("email");
+  expect(label).toBeTruthy(); // keep label referenced
+}
+
+describe("newsletter.service token leak (#6535)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("does not leak secret tokens for an already-active subscriber", async () => {
+    findOneMock.mockResolvedValue(
+      doc({
+        email: "a@x.com",
+        status: "active",
+        unsubscribeToken: "SECRET-UNSUB",
+        verificationToken: "SECRET-VERIFY",
+        verificationTokenExpires: new Date(),
+      })
+    );
+
+    const result: any = await subscribeNewsletter("a@x.com", "A", "web", undefined, "https://api.x");
+    expect(result.message).toBe("Already subscribed");
+    expect(result.subscriber).toBeTruthy();
+    assertNoSecretFields(result.subscriber, "active");
+  });
+
+  it("does not leak secret tokens for a resubscribed (unsubscribed) subscriber", async () => {
+    const existing = doc({
+      email: "b@x.com",
+      status: "unsubscribed",
+      unsubscribeToken: "SECRET-UNSUB",
+      verificationToken: "SECRET-VERIFY",
+      verificationTokenExpires: new Date(),
+    });
+    findOneMock.mockResolvedValue(existing);
+
+    const result: any = await subscribeNewsletter("b@x.com", undefined, undefined, undefined, "https://api.x");
+    expect(result.message).toContain("Re-subscribed");
+    assertNoSecretFields(result.subscriber, "resubscribe");
+  });
+
+  it("does not leak secret tokens for a brand-new subscriber", async () => {
+    findOneMock.mockResolvedValue(null);
+    createMock.mockResolvedValue(
+      doc({
+        email: "c@x.com",
+        status: "pending",
+        isVerified: false,
+        verificationToken: "SECRET-VERIFY",
+        verificationTokenExpires: new Date(),
+        unsubscribeToken: "SECRET-UNSUB",
+      })
+    );
+
+    const result: any = await subscribeNewsletter("c@x.com", "C", "web", undefined, "https://api.x");
+    expect(result.message).toContain("Subscribed");
+    assertNoSecretFields(result.subscriber, "new");
+  });
+
+  it("does not leak secret tokens in the verify response", async () => {
+    const subscriber = doc({
+      email: "d@x.com",
+      status: "pending",
+      isVerified: false,
+      verificationToken: "tok",
+      verificationTokenExpires: new Date(Date.now() + 60000),
+      unsubscribeToken: "SECRET-UNSUB",
+    });
+    findOneMock.mockResolvedValue(subscriber);
+
+    const result: any = await verifyNewsletter("tok");
+    expect(result.message).toContain("verified");
+    assertNoSecretFields(result.subscriber, "verify");
+  });
+});

--- a/backend/src/app/modules/newsletter/newsletter.service.ts
+++ b/backend/src/app/modules/newsletter/newsletter.service.ts
@@ -7,6 +7,26 @@ import { sendVerificationEmail } from "../../../utils/email.util";
 const buildUnsubscribeUrl = (baseUrl: string | undefined, token: string) =>
   baseUrl ? `${baseUrl}/api/v1/newsletter/unsubscribe/${token}` : undefined;
 
+// Secret fields must never leave the service in a response body. Anyone who
+// learns unsubscribeToken can unsubscribe an address without email access, and
+// verificationToken lets a third party activate a subscription. Strip them.
+const SECRET_FIELDS = [
+  "unsubscribeToken",
+  "verificationToken",
+  "verificationTokenExpires",
+] as const;
+
+const toPublicSubscriber = (subscriber: any) => {
+  if (!subscriber) return subscriber;
+  const obj = typeof subscriber.toObject === "function"
+    ? subscriber.toObject({ virtuals: false })
+    : { ...subscriber };
+  for (const field of SECRET_FIELDS) {
+    delete obj[field];
+  }
+  return obj;
+};
+
 export const subscribeNewsletter = async (
   email: string,
   name?: string,
@@ -19,7 +39,7 @@ export const subscribeNewsletter = async (
 
   if (existing) {
     if (existing.status === "active") {
-      return { message: "Already subscribed", subscriber: existing };
+      return { message: "Already subscribed", subscriber: toPublicSubscriber(existing) };
     }
     if (existing.status === "unsubscribed") {
       existing.status = "pending";
@@ -37,7 +57,7 @@ export const subscribeNewsletter = async (
         buildUnsubscribeUrl(baseUrl, existing.unsubscribeToken)
       );
 
-      return { message: "Re-subscribed. Please verify your email.", subscriber: existing };
+      return { message: "Re-subscribed. Please verify your email.", subscriber: toPublicSubscriber(existing) };
     }
   }
 
@@ -62,7 +82,7 @@ export const subscribeNewsletter = async (
     buildUnsubscribeUrl(baseUrl, unsubscribeToken)
   );
 
-  return { message: "Subscribed! Please verify your email.", subscriber };
+  return { message: "Subscribed! Please verify your email.", subscriber: toPublicSubscriber(subscriber) };
 };
 
 export const verifyNewsletter = async (token: string) => {
@@ -80,7 +100,7 @@ export const verifyNewsletter = async (token: string) => {
   subscriber.verificationTokenExpires = undefined;
   await subscriber.save();
 
-  return { message: "Email verified successfully.", subscriber };
+  return { message: "Email verified successfully.", subscriber: toPublicSubscriber(subscriber) };
 };
 
 export const unsubscribeByToken = async (token: string) => {


### PR DESCRIPTION
## Summary

`subscribeNewsletter` and `verifyNewsletter` returned the full `subscriber` Mongoose document in the JSON response, including the secret `unsubscribeToken` (and, on the pending/new path, `verificationToken`). Because subscribe is an **unauthenticated** endpoint, anyone who knows (or guesses) an email address can `POST /api/v1/newsletter/subscribe` with that email and read `subscriber.unsubscribeToken` from the response body. With that token they can then call `GET /api/v1/newsletter/unsubscribe/<token>` to unsubscribe the victim's address — without ever accessing the victim's inbox. The `verificationToken` leak likewise lets a third party activate a subscription they don't control.

The issue reproduces specifically when re-subscribing an already-`active` email (the early-return at the top of `subscribeNewsletter` returned `existing` wholesale), but the same leak exists on all four return paths: already-active, resubscribed, brand-new, and verify.

## Fix

Added a `toPublicSubscriber` helper in `backend/src/app/modules/newsletter/newsletter.service.ts` that strips the three secret fields and applied it to every response boundary:

```typescript
const SECRET_FIELDS = ["unsubscribeToken", "verificationToken", "verificationTokenExpires"] as const;

const toPublicSubscriber = (subscriber) => {
  if (!subscriber) return subscriber;
  const obj = typeof subscriber.toObject === "function"
    ? subscriber.toObject({ virtuals: false })
    : { ...subscriber };
  for (const field of SECRET_FIELDS) delete obj[field];
  return obj;
};
```

Applied to all four returns:
- already-active: `subscriber: toPublicSubscriber(existing)`
- resubscribed: `subscriber: toPublicSubscriber(existing)`
- new subscriber: `subscriber: toPublicSubscriber(subscriber)`
- verify: `subscriber: toPublicSubscriber(subscriber)`

The tokens remain on the document for internal use (building the unsubscribe link, `findOne({ verificationToken })` / `findOne({ unsubscribeToken })` lookups) and are stripped **only at the response boundary**, so no lookup or email-link-generation behavior changes. This is a targeted response-boundary fix rather than a schema `select: false` change, deliberately: `select: false` on `unsubscribeToken` would change the resubscribe path (line 29 `if (!existing.unsubscribeToken)` would always be true because the field isn't loaded), causing the unsubscribe token to be regenerated on every resubscribe and breaking previously-sent email links. Stripping at the response boundary preserves exact token-lifecycle behavior while closing the disclosure.

## Verification

New regression tests, **4 tests, all passing** (`backend/src/app/modules/newsletter/__tests__/newsletter.service.token-leak.test.ts`):

- `does not leak secret tokens for an already-active subscriber` — the exact issue scenario: re-subscribing an active email returns no secret fields.
- `does not leak secret tokens for a resubscribed (unsubscribed) subscriber`.
- `does not leak secret tokens for a brand-new subscriber`.
- `does not leak secret tokens in the verify response`.

Each test mocks the model with a Mongoose-like document carrying the secret tokens and asserts that `unsubscribeToken`, `verificationToken`, and `verificationTokenExpires` are **entirely absent** from the returned `subscriber` (not just `undefined`), while public fields like `email` remain.

The pre-existing `newsletter.service.test.ts` suite (8 tests) continues to pass — **12/12** total in the newsletter module.

```
PASS src/app/modules/newsletter/__tests__/newsletter.service.token-leak.test.ts
PASS src/app/modules/newsletter/__tests__/newsletter.service.test.ts
Tests: 12 passed
```

## Changes

- `backend/src/app/modules/newsletter/newsletter.service.ts` — `toPublicSubscriber` helper + applied on all 4 return paths.
- `backend/src/app/modules/newsletter/__tests__/newsletter.service.token-leak.test.ts` — new (4 tests).

Closes #6535
