### PR TITLE
test : added unit tests for useEndingSatisfaction hook

### DIFF
--- a/frontend/src/hooks/__tests__/useEndingSatisfaction.test.ts
+++ b/frontend/src/hooks/__tests__/useEndingSatisfaction.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { renderHook } from "@testing-library/react";
+import useEndingSatisfaction from "../useEndingSatisfaction";
+
+describe("useEndingSatisfaction", () => {
+  it("returns an array of ending metrics", () => {
+    const { result } = renderHook(() => useEndingSatisfaction());
+    expect(Array.isArray(result.current.metrics)).toBe(true);
+    expect(result.current.metrics.length).toBeGreaterThan(0);
+  });
+
+  it("each metric has required fields", () => {
+    const { result } = renderHook(() => useEndingSatisfaction());
+    for (const metric of result.current.metrics) {
+      expect(typeof metric.title).toBe("string");
+      expect(typeof metric.score).toBe("number");
+      expect(typeof metric.description).toBe("string");
+      expect(typeof metric.suggestion).toBe("string");
+    }
+  });
+
+  it("metrics include expected titles", () => {
+    const { result } = renderHook(() => useEndingSatisfaction());
+    const titles = result.current.metrics.map((m) => m.title);
+    expect(titles).toContain("Conflict Resolution");
+    expect(titles).toContain("Character Arc");
+    expect(titles).toContain("Emotional Payoff");
+    expect(titles).toContain("Pacing");
+  });
+
+  it("overallScore is a rounded number", () => {
+    const { result } = renderHook(() => useEndingSatisfaction());
+    expect(typeof result.current.overallScore).toBe("number");
+    expect(Number.isInteger(result.current.overallScore)).toBe(true);
+  });
+
+  it("overallScore is the average of all metric scores", () => {
+    const { result } = renderHook(() => useEndingSatisfaction());
+    const expectedScore = Math.round(
+      result.current.metrics.reduce((sum, m) => sum + m.score, 0) /
+        result.current.metrics.length
+    );
+    expect(result.current.overallScore).toBe(expectedScore);
+  });
+
+  it("rerunAnalysis is a function", () => {
+    const { result } = renderHook(() => useEndingSatisfaction());
+    expect(typeof result.current.rerunAnalysis).toBe("function");
+  });
+});


### PR DESCRIPTION
Closes #6614.

Summary of What Has Been Done:
Added unit tests for the useEndingSatisfaction React hook which wraps getEndingMetrics from endingSatisfaction.ts. Tests cover metrics return, required field validation, overallScore calculation, and rerunAnalysis method.

Changes Made:
- frontend/src/hooks/__tests__/useEndingSatisfaction.test.ts: New test file with 6 test cases covering metrics array structure, required fields, expected titles, overallScore calculation, and rerunAnalysis function type.

Impact it Made:
- Test coverage for a previously untested hook
- Prevents regression when endingSatisfaction.ts internals change
- Uses existing vitest + @testing-library/react test patterns from the codebase

Note: Please assign this PR to the `tmdeveloper007` account.