### PR TITLE
fix : added empty story guard to outlineQualityAnalyzer utility

### DIFF
--- a/frontend/src/utils/outlineQualityAnalyzer.ts
+++ b/frontend/src/utils/outlineQualityAnalyzer.ts
@@ -23,6 +23,21 @@ export interface OutlineAnalysis {
 export const analyzeOutline = (
   outline: string
 ): OutlineAnalysis => {
+  if (!outline || !outline.trim()) {
+    return {
+      score: 0,
+      issues: [
+        {
+          id: "empty-outline",
+          category: "Pacing",
+          severity: "High",
+          message: "No outline provided.",
+          suggestion: "Please provide an outline for analysis.",
+        },
+      ],
+    };
+  }
+
   return {
     score: 90,
     issues: [],


### PR DESCRIPTION
Closes #6616.

Summary of What Has Been Done:
Added an empty-input guard to the analyzeOutline function in outlineQualityAnalyzer.ts. Previously, empty or whitespace-only outline strings would return score 90, misleading users into believing an empty outline had high quality. Now returns score 0 with a descriptive High-severity issue.

Changes Made:
- frontend/src/utils/outlineQualityAnalyzer.ts: Added empty/whitespace check at the top of analyzeOutline that returns score: 0 and an issue with id: 'empty-outline', category: 'Pacing', severity: 'High', message: 'No outline provided.', suggestion: 'Please provide an outline for analysis.'

Impact it Made:
- Prevents misleading score 90 for empty outlines
- Returns actionable feedback instead of false-positive quality assessment
- Follows the pattern used by other analyzer utilities (dialogueBalanceAnalyzer, emotionAnalyzer)

Note: Please assign this PR to the `tmdeveloper007` account.