### PR TITLE
fix: reset selectedEventId on content change in GeneratedStoryTimeline 

### DIFF
--- a/frontend/src/components/stories/GeneratedStoryTimeline.tsx
+++ b/frontend/src/components/stories/GeneratedStoryTimeline.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import type { NarrationPlaybackState } from "../AudioPlayer";
 
@@ -91,6 +91,12 @@ const GeneratedStoryTimeline = ({
 }: GeneratedStoryTimelineProps) => {
   const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
   const events = useMemo(() => splitStoryIntoEvents(content), [content]);
+
+  // Reset selected event whenever the story content changes — old event IDs
+  // are position-based and become stale when new content produces new events.
+  useEffect(() => {
+    setSelectedEventId(null);
+  }, [content]);
 
   const narratedEvent = events.find(
     (event) =>


### PR DESCRIPTION
### Description
Adds `useEffect(() => { setSelectedEventId(null); }, [content])`.
When content changes (new story generated), `selectedEventId` is
cleared. The `activeEventId` fallback chain then correctly uses
`events[0]?.id` for the new story. Imports `useEffect` alongside
the existing `useMemo` and `useState` imports.

### Related Issues
Closes #6628 