### PR TITLE
fix: truncate event summaries at word boundary in GeneratedStoryTimeline — mid-word cuts showed broken text in timeline cards

### DIFF
--- a/frontend/src/components/stories/GeneratedStoryTimeline.tsx
+++ b/frontend/src/components/stories/GeneratedStoryTimeline.tsx
@@ -27,7 +27,11 @@ const cleanText = (text: string) => text.replace(/\s+/g, " ").trim();
 const truncate = (text: string, maxLength: number) => {
   const normalized = cleanText(text);
   if (normalized.length <= maxLength) return normalized;
-  return `${normalized.slice(0, maxLength).trimEnd()}...`;
+  // Trim to maxLength then remove any trailing partial word so the
+  // ellipsis always follows a complete word — not a mid-word cut.
+  const sliced = normalized.slice(0, maxLength);
+  const wordBoundary = sliced.replace(/\s+\S*$/, "").trimEnd();
+  return `${wordBoundary || sliced.trimEnd()}...`;
 };
 
 const splitStoryIntoEvents = (content: string): TimelineEvent[] => {


### PR DESCRIPTION
### Description
After `normalized.slice(0, maxLength)`, applies
`.replace(/\s+\S*$/, "").trimEnd()` to strip any trailing partial
word before appending "...". Falls back to the character-trimmed
slice (trimmed) if the word-boundary replacement removes all content
(e.g., a single very long word). Affects all 5 timeline event summary
cards and the Highlight panel which both use the `truncate` output.

### Related Issues
Closes #6630 