### PR TITLE
fix: await clipboard writeText with toast feedback in PromptHistoryDashboard Copy button

### DIFF
--- a/frontend/src/components/stories/PromptHistoryDashboard.tsx
+++ b/frontend/src/components/stories/PromptHistoryDashboard.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import toast from "react-hot-toast";
 import { useNavigate } from "react-router-dom";
 import { IRecentPrompt, useRecentPrompts } from "../../hooks/useRecentPrompts";
 
@@ -311,7 +312,14 @@ const PromptHistoryDashboard = () => {
                     </button>
                     <button
                       type="button"
-                      onClick={() => navigator.clipboard?.writeText(prompt.prompt)}
+                      onClick={async () => {
+                        try {
+                          await navigator.clipboard.writeText(prompt.prompt);
+                          toast.success("Prompt copied to clipboard!");
+                        } catch {
+                          toast.error("Failed to copy. Please try again.");
+                        }
+                      }}
                       className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-2 text-sm font-bold text-slate-700 transition hover:bg-slate-100 dark:border-white/10 dark:bg-white/5 dark:text-slate-200"
                     >
                       Copy


### PR DESCRIPTION
### Description
Changes the Copy button `onClick` to an async handler. Awaits
`navigator.clipboard.writeText(prompt.prompt)` inside `try/catch`.
Shows `toast.success("Prompt copied to clipboard!")` on success and
`toast.error("Failed to copy. Please try again.")` in the catch block.
Removes the `?.` optional chaining — the try/catch handles the case
where clipboard API is unavailable. Imports `react-hot-toast`.

### Related Issues
Closes #6632 