### PR TITLE
fix: use progress >= 100 for completion check in ReadingProgressBar — floating-point === 100 never fired

### DIFF
--- a/frontend/src/components/stories/ReadingProgressBar.tsx
+++ b/frontend/src/components/stories/ReadingProgressBar.tsx
@@ -40,7 +40,9 @@ const ReadingProgressBar: React.FC<ReadingProgressBarProps> = ({
         </button>
       )}
 
-      {progress === 100 && (
+      {/* Use >= 100 instead of === 100 — floating-point division rarely
+          produces exactly 100.0, causing the completion message to never show */}
+      {progress >= 100 && (
         <p className="mt-3 text-green-400 font-medium">
           ✅ Story completed!
         </p>


### PR DESCRIPTION
### Description
Single operator change: `progress === 100` → `progress >= 100`.
Handles floating-point progress values that exceed 100 due to
division imprecision. The `progress < 100` guard on the "Continue
Reading" button already correctly excludes values ≥ 100, so the
two conditions remain mutually exclusive.

### Related Issues
Closes #6636 