### PR TITLE
fix: add onContinue guard to Continue Reading button in ReadingProgressBar — undefined handler was rendering a non-functional CTA

### DIFF
--- a/frontend/src/components/stories/ReadingProgressBar.tsx
+++ b/frontend/src/components/stories/ReadingProgressBar.tsx
@@ -29,8 +29,10 @@ const ReadingProgressBar: React.FC<ReadingProgressBarProps> = ({
         />
       </div>
 
-      {/* Continue Reading Button */}
-      {progress > 0 && progress < 100 && (
+      {/* Continue Reading Button — only render when onContinue is provided.
+          Without this guard, the button is visible but completely non-functional
+          when the prop is omitted, since onClick={undefined} is a silent no-op. */}
+      {progress > 0 && progress < 100 && onContinue && (
         <button
           type="button"
           onClick={onContinue}


### PR DESCRIPTION
### Description
Adds `&& onContinue` to the button's display condition. The button
is now only rendered when `onContinue` is defined. When the prop
is omitted (read-only progress display use case), no button is shown
rather than a styled no-op button. Single condition addition —
no change to button markup or styling.

### Related Issues
Closes #6638 