### PR TITLE
fix: append anchor to DOM and defer revokeObjectURL in exportPrompts — Firefox export was silently broken

### DIFF
--- a/frontend/src/components/stories/RecentPromptsPanel.tsx
+++ b/frontend/src/components/stories/RecentPromptsPanel.tsx
@@ -45,8 +45,14 @@ const RecentPromptsPanel: React.FC<RecentPromptsPanelProps> = ({
     const a = document.createElement("a");
     a.href = url;
     a.download = "recent-prompts.json";
+    // Firefox requires the anchor to be in the DOM to trigger a download.
+    document.body.appendChild(a);
     a.click();
-    URL.revokeObjectURL(url);
+    document.body.removeChild(a);
+    // Defer revocation — browser initiates download asynchronously.
+    // Synchronous revocation races the download and causes silent failures
+    // in Firefox and Safari.
+    setTimeout(() => URL.revokeObjectURL(url), 100);
   };
 
   return (


### PR DESCRIPTION
### Description
Adds `document.body.appendChild(a)` before `a.click()` and
`document.body.removeChild(a)` after. Replaces synchronous
`URL.revokeObjectURL(url)` with `setTimeout(() => URL.revokeObjectURL(url), 100)`.
Fixes two compounding bugs that made the Export Prompts feature
completely non-functional in Firefox. Consistent with the standard
programmatic download pattern.

### Related Issues
Closes #6640 