### PR TITLE
fix: add onPromptUse call to Use button in RecentPromptsPanel — primary action button was missing usage tracking

### DIFF
--- a/frontend/src/components/stories/RecentPromptsPanel.tsx
+++ b/frontend/src/components/stories/RecentPromptsPanel.tsx
@@ -132,6 +132,7 @@ const RecentPromptsPanel: React.FC<RecentPromptsPanelProps> = ({
                     <button
                       type="button"
                       onClick={() => {
+                        onPromptUse?.(item.id);  // track usage — same as clicking prompt text
                         onSelectPrompt(item.prompt);
                         onToggle();
                       }}


### PR DESCRIPTION
### Description
Adds `onPromptUse?.(item.id)` to the blue "Use" button's onClick
handler — immediately before `onSelectPrompt` and `onToggle`, 
matching the identical call already in the prompt text button.
Ensures `lastUsedAt` and `useCount` are updated regardless of
which interaction path the user takes to select a prompt.

### Related Issues
Closes #6642 