### PR TITLE
fix(frontend): add subtle fade-in animation on page navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added subtle fade-in animation on page navigation with reduced-motion accessibility support (#4148)
 - Character library feature for managing story characters
 - Story genre transformation component
 - Story version history tracking

--- a/frontend/src/components/dashboard/dashboard_layout.component.tsx
+++ b/frontend/src/components/dashboard/dashboard_layout.component.tsx
@@ -4,6 +4,7 @@ import { MenuItem, menuItems } from "./dashboard.utils";
 import { getUserInfo, removeUserInfo } from "../../services/auth.service";
 import { useGetProfileInfoQuery } from "../../redux/apis/user.api";
 import { useNotifications } from "../../hooks/useNotifications";
+import PageTransition from "../layout/PageTransition";
 
 const DashboardLayout: React.FC = () => {
   const { unreadCount } = useNotifications();
@@ -294,7 +295,9 @@ const DashboardLayout: React.FC = () => {
         </aside>
 
         <main className="min-w-0 flex-1 overflow-auto bg-white px-4 py-4 text-slate-900 dark:bg-[#070c18] dark:text-white sm:px-6 sm:py-6">
-          <Outlet />
+          <PageTransition className="h-full w-full">
+            <Outlet />
+          </PageTransition>
         </main>
       </div>
     </div>

--- a/frontend/src/components/layout/PageTransition.test.tsx
+++ b/frontend/src/components/layout/PageTransition.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from "vitest";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { MemoryRouter } from "react-router-dom";
+import PageTransition from "./PageTransition";
+
+// Mock framer-motion to simplify testing in jsdom
+vi.mock("framer-motion", async () => {
+  const actual = await vi.importActual<typeof import("framer-motion")>("framer-motion");
+  return {
+    ...actual,
+    useReducedMotion: () => false,
+  };
+});
+
+describe("PageTransition Component", () => {
+  it("renders children successfully within the router context", () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <PageTransition>
+          <div data-testid="test-content">Page Content</div>
+        </PageTransition>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId("test-content")).toBeInTheDocument();
+    expect(screen.getByText("Page Content")).toBeInTheDocument();
+  });
+
+  it("applies custom className to wrapper element", () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={["/custom-route"]}>
+        <PageTransition className="custom-class-name">
+          <div>Child Content</div>
+        </PageTransition>
+      </MemoryRouter>
+    );
+
+    const animatedWrapper = container.firstElementChild;
+    expect(animatedWrapper).toHaveClass("custom-class-name");
+  });
+});

--- a/frontend/src/components/layout/PageTransition.test.tsx
+++ b/frontend/src/components/layout/PageTransition.test.tsx
@@ -1,20 +1,40 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { MemoryRouter } from "react-router-dom";
-import PageTransition from "./PageTransition";
+import PageTransition, { pageVariants } from "./PageTransition";
 
-// Mock framer-motion to simplify testing in jsdom
+let mockReducedMotion = false;
+let capturedMotionProps: Record<string, any> = {};
+
+// Mock framer-motion to capture props and control reduced motion in tests
 vi.mock("framer-motion", async () => {
   const actual = await vi.importActual<typeof import("framer-motion")>("framer-motion");
   return {
     ...actual,
-    useReducedMotion: () => false,
+    useReducedMotion: () => mockReducedMotion,
+    motion: {
+      ...actual.motion,
+      div: ({ children, className, ...props }: any) => {
+        capturedMotionProps = props;
+        return (
+          <div className={className} data-testid="motion-div">
+            {children}
+          </div>
+        );
+      },
+    },
+    AnimatePresence: ({ children }: any) => <>{children}</>,
   };
 });
 
 describe("PageTransition Component", () => {
+  beforeEach(() => {
+    mockReducedMotion = false;
+    capturedMotionProps = {};
+  });
+
   it("renders children successfully within the router context", () => {
     render(
       <MemoryRouter initialEntries={["/"]}>
@@ -39,5 +59,49 @@ describe("PageTransition Component", () => {
 
     const animatedWrapper = container.firstElementChild;
     expect(animatedWrapper).toHaveClass("custom-class-name");
+  });
+
+  it("applies standard transition duration and initial state when reduced motion is disabled", () => {
+    mockReducedMotion = false;
+
+    render(
+      <MemoryRouter initialEntries={["/standard"]}>
+        <PageTransition>
+          <div>Standard Content</div>
+        </PageTransition>
+      </MemoryRouter>
+    );
+
+    expect(capturedMotionProps.initial).toBe("initial");
+    expect(capturedMotionProps.custom).toBe(false);
+    expect(capturedMotionProps.transition?.duration).toBe(0.22);
+
+    const initialVariant = pageVariants.initial(false);
+    expect(initialVariant.opacity).toBe(0);
+    expect(initialVariant.y).toBe(8);
+  });
+
+  it("bypasses motion and sets duration to 0 with fully visible initial state when reduced motion is enabled", () => {
+    mockReducedMotion = true;
+
+    render(
+      <MemoryRouter initialEntries={["/reduced-motion"]}>
+        <PageTransition>
+          <div>Accessible Content</div>
+        </PageTransition>
+      </MemoryRouter>
+    );
+
+    expect(capturedMotionProps.initial).toBe(false);
+    expect(capturedMotionProps.custom).toBe(true);
+    expect(capturedMotionProps.transition?.duration).toBe(0);
+
+    const initialVariant = pageVariants.initial(true);
+    expect(initialVariant.opacity).toBe(1);
+    expect(initialVariant.y).toBe(0);
+
+    const exitVariant = pageVariants.exit(true);
+    expect(exitVariant.opacity).toBe(1);
+    expect(exitVariant.y).toBe(0);
   });
 });

--- a/frontend/src/components/layout/PageTransition.tsx
+++ b/frontend/src/components/layout/PageTransition.tsx
@@ -1,0 +1,53 @@
+import React, { ReactNode } from "react";
+import { useLocation } from "react-router-dom";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+
+interface PageTransitionProps {
+  children: ReactNode;
+  className?: string;
+}
+
+const pageVariants = {
+  initial: (reducedMotion: boolean) => ({
+    opacity: 0,
+    y: reducedMotion ? 0 : 8,
+  }),
+  animate: {
+    opacity: 1,
+    y: 0,
+  },
+  exit: (reducedMotion: boolean) => ({
+    opacity: 0,
+    y: reducedMotion ? 0 : -8,
+  }),
+};
+
+const PageTransition: React.FC<PageTransitionProps> = ({
+  children,
+  className = "flex-grow min-h-0",
+}) => {
+  const { pathname } = useLocation();
+  const shouldReduceMotion = !!useReducedMotion();
+
+  return (
+    <AnimatePresence mode="wait">
+      <motion.div
+        key={pathname}
+        custom={shouldReduceMotion}
+        initial="initial"
+        animate="animate"
+        exit="exit"
+        variants={pageVariants}
+        transition={{
+          duration: shouldReduceMotion ? 0 : 0.22,
+          ease: [0.25, 0.1, 0.25, 1],
+        }}
+        className={className}
+      >
+        {children}
+      </motion.div>
+    </AnimatePresence>
+  );
+};
+
+export default PageTransition;

--- a/frontend/src/components/layout/PageTransition.tsx
+++ b/frontend/src/components/layout/PageTransition.tsx
@@ -7,9 +7,9 @@ interface PageTransitionProps {
   className?: string;
 }
 
-const pageVariants = {
+export const pageVariants = {
   initial: (reducedMotion: boolean) => ({
-    opacity: 0,
+    opacity: reducedMotion ? 1 : 0,
     y: reducedMotion ? 0 : 8,
   }),
   animate: {
@@ -17,7 +17,7 @@ const pageVariants = {
     y: 0,
   },
   exit: (reducedMotion: boolean) => ({
-    opacity: 0,
+    opacity: reducedMotion ? 1 : 0,
     y: reducedMotion ? 0 : -8,
   }),
 };
@@ -34,7 +34,7 @@ const PageTransition: React.FC<PageTransitionProps> = ({
       <motion.div
         key={pathname}
         custom={shouldReduceMotion}
-        initial="initial"
+        initial={shouldReduceMotion ? false : "initial"}
         animate="animate"
         exit="exit"
         variants={pageVariants}

--- a/frontend/src/components/layout/root_layout.component.tsx
+++ b/frontend/src/components/layout/root_layout.component.tsx
@@ -6,6 +6,8 @@ import FooterComponent from "../footer/footer.component";
 import ChatComponent from "../chat/Chat";
 import ScrollToTopButton from "../ScrollToTopButton";
 
+import PageTransition from "./PageTransition";
+
 interface RootLayoutProps {
   children: ReactNode;
 }
@@ -31,7 +33,7 @@ const RootLayout: React.FC<RootLayoutProps> = ({ children }) => {
       {!hideHeader && <NavListComponent />}
       <CookieConsentBanner onLayoutChange={handleCookieLayoutChange} />
 
-      <div className="flex-grow min-h-0">{children}</div>
+      <PageTransition className="flex-grow min-h-0">{children}</PageTransition>
       {!hideFooter && <FooterComponent />}
       {!isAuthPage && (
         <>


### PR DESCRIPTION
## Before you open this PR

- **Issue:** Closes #4148
- **Description:** Added subtle fade-in animation on page navigation with accessibility support.


https://github.com/user-attachments/assets/73f70d29-9e6f-4a97-a01b-72a504bf2c8a


## What this PR does

- Implemented a reusable `PageTransition` component using `framer-motion`.
- Added smooth, subtle fade-in page transitions on route changes in `RootLayout` and `DashboardLayout`.
- Included accessibility check (`useReducedMotion`) so animation is safely bypassed when reduced motion is preferred.
- Added unit tests for `PageTransition` component.
- Updated `CHANGELOG.md`.

> 🌟 **Note:** This is my first open-source contribution to StorySparkAI!

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update

## Related issue

Closes #4148

## Checklist

- [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
- [x] I have filled in the related issue number when there is one.
- [x] I have tested my changes.
- [x] I have done a self-review of the code.
