### PR TITLE
fix(#6472): make Suddenly detection case-insensitive in narrativeFlowAnalyzer

### DIFF
--- a/frontend/src/utils/__tests__/narrativeFlowAnalyzer.test.ts
+++ b/frontend/src/utils/__tests__/narrativeFlowAnalyzer.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { analyzeNarrativeFlow } from "../narrativeFlowAnalyzer";
+
+describe("analyzeNarrativeFlow - Suddenly detection", () => {
+  it("detects capitalized 'Suddenly'", () => {
+    const issues = analyzeNarrativeFlow("Suddenly, the door opened.");
+    expect(
+      issues.some((i) => i.type === "Abrupt Transition")
+    ).toBe(true);
+  });
+
+  it("detects lowercase 'suddenly' (case-insensitive)", () => {
+    const issues = analyzeNarrativeFlow("and then suddenly the lights went out.");
+    expect(
+      issues.some((i) => i.type === "Abrupt Transition")
+    ).toBe(true);
+  });
+
+  it("detects uppercase 'SUDDENLY' (case-insensitive)", () => {
+    const issues = analyzeNarrativeFlow("SUDDENLY everything changed.");
+    expect(
+      issues.some((i) => i.type === "Abrupt Transition")
+    ).toBe(true);
+  });
+
+  it("does not flag text without 'suddenly'", () => {
+    const issues = analyzeNarrativeFlow("The sun set slowly over the hills.");
+    expect(
+      issues.some((i) => i.type === "Abrupt Transition")
+    ).toBe(false);
+  });
+});

--- a/frontend/src/utils/narrativeFlowAnalyzer.ts
+++ b/frontend/src/utils/narrativeFlowAnalyzer.ts
@@ -6,7 +6,7 @@ export function analyzeNarrativeFlow(
 
   const issues: NarrativeIssue[] = [];
 
-  if (story.includes("Suddenly")) {
+  if (/suddenly/i.test(story)) {
     issues.push({
       id: 1,
       type: "Abrupt Transition",


### PR DESCRIPTION
## Summary

Closes #6472

This PR implements the fix described in issue #6472: **make Suddenly detection case-insensitive in narrativeFlowAnalyzer**.

### Problem
The narrative flow analyzer in `frontend/src/utils/narrativeFlowAnalyzer.ts` used `story.includes("Suddenly")`, which is case-sensitive. As a result, lowercase `suddenly` or uppercase `SUDDENLY` did not trigger the "Abrupt Transition" issue, producing false negatives for real story text.

### Changes
- Replaced the case-sensitive `story.includes("Suddenly")` check with a case-insensitive `/suddenly/i.test(story)` regex test, so the detector works regardless of how the word is capitalised in the text.
- Added focused unit tests (`narrativeFlowAnalyzer.test.ts`) covering capitalised, lowercase, uppercase, and negative (no "suddenly") cases to make the fix regression-safe.

### Verification
- `npx vitest run` on the new test file — all 4 tests pass locally.
- `eslint` on the changed files — clean (no warnings/errors).
- `tsc --noEmit` on the changed files — no type errors.

### Notes
- The change is minimal and follows the existing code conventions in the surrounding file.
- No behaviour outside the described detection is altered.

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
