### PR TITLE
fix(#6246): add SSR guard to scrollToChapter helper

### DIFF
--- a/frontend/src/utils/__tests__/scroll-to-chapter.test.ts
+++ b/frontend/src/utils/__tests__/scroll-to-chapter.test.ts
@@ -40,4 +40,16 @@ describe("scrollToChapter", () => {
     scrollToChapter(100);
     expect(mockGetElementById).toHaveBeenCalledWith("chapter-100");
   });
+
+  it("does not throw when document is undefined (SSR guard)", () => {
+    const original = globalThis.document;
+    // @ts-expect-error - intentionally removing document to simulate SSR
+    delete globalThis.document;
+    try {
+      expect(() => scrollToChapter(42)).not.toThrow();
+      expect(mockScrollIntoView).not.toHaveBeenCalled();
+    } finally {
+      globalThis.document = original;
+    }
+  });
 });

--- a/frontend/src/utils/scroll-to-chapter.ts
+++ b/frontend/src/utils/scroll-to-chapter.ts
@@ -6,6 +6,7 @@
  * shared ref or context.
  */
 export function scrollToChapter(chapterId: number): void {
+  if (typeof document === "undefined") return;
   const node = document.getElementById(`chapter-${chapterId}`);
   if (!node) return;
   node.scrollIntoView({ behavior: "smooth", block: "start" });


### PR DESCRIPTION
## Summary

Closes #6246

This PR implements the fix described in issue #6246: **add SSR guard to scrollToChapter helper**.

### Problem
`scrollToChapter` in `frontend/src/utils/scroll-to-chapter.ts` calls `document.getElementById(...)` directly. In a non-browser (SSR / Node) environment, `document` is undefined, so simply importing or invoking the helper at module-eval time crashes with a `ReferenceError`.

### Changes
- Added a `typeof document === "undefined"` guard at the top of `scrollToChapter` so the function returns early (no-op) in non-browser environments instead of throwing.
- Added a unit test asserting the function does not throw and does not attempt to scroll when `document` is absent (SSR simulation), alongside the existing browser-behaviour tests which continue to pass unchanged.

### Verification
- `npx vitest run` on `scroll-to-chapter.test.ts` — all 4 tests pass locally (including the new SSR guard test).
- `eslint` on the changed files — clean.
- `tsc --noEmit` on the changed file — no type errors.

### Notes
- The change is minimal and only adds a defensive early return; browser behaviour is unchanged.

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
