### PR TITLE
fix(#6244): handle whitespace-only titles in analyzeTitle utility

### DIFF
--- a/frontend/src/utils/__tests__/storyTitleRating.test.ts
+++ b/frontend/src/utils/__tests__/storyTitleRating.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { analyzeTitle } from "../storyTitleRating";
+
+describe("analyzeTitle - whitespace-only handling", () => {
+  it("returns a zeroed report for a blank title", () => {
+    const result = analyzeTitle("");
+    expect(result.score).toBe(0);
+    expect(result.creativity).toBe(0);
+    expect(result.relevance).toBe(0);
+    expect(result.clarity).toBe(0);
+    expect(result.appeal).toBe(0);
+    expect(result.strengths).toEqual([]);
+    expect(result.weaknesses).toContain("Title is empty");
+  });
+
+  it("returns a zeroed report for a whitespace-only title", () => {
+    const result = analyzeTitle("     \t\n  ");
+    expect(result.score).toBe(0);
+    expect(result.suggestions).not.toContainEqual(" Chronicles");
+    // Suggestions must not contain the raw whitespace title.
+    for (const s of result.suggestions) {
+      expect(s.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it("returns a normal analysis for a non-empty title", () => {
+    const result = analyzeTitle("The Lost Kingdom");
+    expect(result.score).toBeGreaterThan(0);
+    expect(result.suggestions).toContain("The Lost Kingdom Chronicles");
+  });
+
+  it("uses the trimmed title in suggestions", () => {
+    const result = analyzeTitle("  Dragon Flight  ");
+    expect(result.suggestions).toContain("Dragon Flight Chronicles");
+    expect(result.suggestions).toContain("The Dragon Flight");
+  });
+});

--- a/frontend/src/utils/storyTitleRating.ts
+++ b/frontend/src/utils/storyTitleRating.ts
@@ -12,7 +12,23 @@ export interface TitleAnalysis {
 export function analyzeTitle(
   title: string
 ): TitleAnalysis {
-  const length = title.trim().length;
+  const trimmed = title.trim();
+  const length = trimmed.length;
+
+  // A blank or whitespace-only title has nothing meaningful to analyse;
+  // return a zeroed report instead of suggestions like " Chronicles".
+  if (length === 0) {
+    return {
+      score: 0,
+      creativity: 0,
+      relevance: 0,
+      clarity: 0,
+      appeal: 0,
+      strengths: [],
+      weaknesses: ["Title is empty"],
+      suggestions: ["Provide a descriptive title"],
+    };
+  }
 
   const score =
     length > 10 && length < 50 ? 88 : 70;
@@ -34,9 +50,9 @@ export function analyzeTitle(
     ],
 
     suggestions: [
-      `${title} Chronicles`,
-      `The ${title}`,
-      `${title}: A New Beginning`,
+      `${trimmed} Chronicles`,
+      `The ${trimmed}`,
+      `${trimmed}: A New Beginning`,
     ],
   };
 }


### PR DESCRIPTION
## Summary

Closes #6244

This PR implements the fix described in issue #6244: **handle titles with only whitespace in analyzeTitle utility**.

### Problem
`analyzeTitle` in `frontend/src/utils/storyTitleRating.ts` used `title.trim().length` but still built suggestions from the raw `title`. A whitespace-only title produced a non-zero length check inconsistency and suggestions like `" Chronicles"` (a bare leading space with no actual title), leaking garbage into the UI.

### Changes
- Compute a `trimmed` title once and derive `length` from it.
- When `length === 0` (blank or whitespace-only title), return a zeroed `TitleAnalysis` (score/creativity/relevance/clarity/appeal all `0`, empty `strengths`, a `"Title is empty"` weakness, and a single helpful suggestion) instead of malformed suggestions.
- For non-empty titles, build suggestions from the trimmed title (so leading/trailing whitespace no longer appears in suggestions like `" Chronicles"`).

### Verification
- `npx vitest run` on `storyTitleRating.test.ts` — all 4 tests pass locally (blank title, whitespace-only title, normal title, trimmed-suggestions).
- `eslint` on the changed files — clean.
- `tsc --noEmit` on the changed file — no type errors.

### Notes
- The change is minimal and isolated; normal (non-empty) titles keep their existing scoring behaviour.

