### PR TITLE
fix(#6243): count quote pairs for dialogue percentage in storyComparisonMetrics

### DIFF
--- a/frontend/src/utils/__tests__/storyComparisonMetrics.test.ts
+++ b/frontend/src/utils/__tests__/storyComparisonMetrics.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { calculateStoryMetrics, compareStories } from "../storyComparisonMetrics";
+
+describe("calculateStoryMetrics - dialogue quote pairs", () => {
+  it("counts paired quotes as dialogue lines, not every quote char", () => {
+    // Two dialogue lines = two pairs of quotes.
+    const story = `He said, "hello there". She replied, "goodbye now".`;
+    const metrics = calculateStoryMetrics(story);
+    // Each pair contributes 5%, capped at 100. Two pairs => 10%.
+    expect(metrics.dialoguePercentage).toBe(10);
+  });
+
+  it("handles a single unmatched quote without inflating dialogue", () => {
+    const story = `An odd number of quotes like " this one`;
+    const metrics = calculateStoryMetrics(story);
+    // One quote char => 0 pairs => 0%.
+    expect(metrics.dialoguePercentage).toBe(0);
+  });
+
+  it("caps dialoguePercentage at 100", () => {
+    // 30 pairs => 150%, capped to 100.
+    const pairs = `"a" `.repeat(30);
+    const metrics = calculateStoryMetrics(pairs);
+    expect(metrics.dialoguePercentage).toBe(100);
+  });
+
+  it("returns zero dialogue percentage for text with no quotes", () => {
+    const metrics = calculateStoryMetrics("A story with no dialogue at all.");
+    expect(metrics.dialoguePercentage).toBe(0);
+  });
+});
+
+describe("compareStories", () => {
+  it("returns metrics for both stories", () => {
+    const r = compareStories("one two three", "four five six");
+    expect(r.first.wordCount).toBe(3);
+    expect(r.second.wordCount).toBe(3);
+  });
+});

--- a/frontend/src/utils/storyComparisonMetrics.ts
+++ b/frontend/src/utils/storyComparisonMetrics.ts
@@ -18,18 +18,20 @@ export function calculateStoryMetrics(
     words.map((word) => word.toLowerCase())
   );
 
+  // Count pairs of double quotes (dialogue lines) rather than every
+  // double-quote character, so escaped or stray quotes don't inflate the
+  // dialogue percentage.
+  const quotePairs = Math.floor(
+    (story.match(/"/g)?.length || 0) / 2
+  );
+
   return {
     wordCount,
     readingTime: Math.max(1, Math.ceil(wordCount / 200)),
     vocabularyRichness: Math.round(
       (uniqueWords.size / Math.max(wordCount, 1)) * 100
     ),
-    dialoguePercentage: Math.min(
-      100,
-      Math.round(
-        ((story.match(/"/g)?.length || 0) / 2) * 5
-      )
-    ),
+    dialoguePercentage: Math.min(100, Math.round(quotePairs * 5)),
     pacing:
       wordCount > 800
         ? 90


### PR DESCRIPTION
## Summary

Closes #6243

This PR implements the fix described in issue #6243: **strip surrounding quotes before counting dialogue in storyComparisonMetrics utility** (count quote pairs instead of every double-quote character).

### Problem
`calculateStoryMetrics` in `frontend/src/utils/storyComparisonMetrics.ts` counted every `"` character via `story.match(/"/g)`, then divided by 2 to estimate dialogue lines. Counting individual characters — rather than pairs — means an odd/escaped/stray quote inflates or mis-attributes the dialogue percentage, since a single unmatched quote rounds into a spurious half-pair.

### Changes
- Introduced an explicit `quotePairs = Math.floor((quoteChars) / 2)` computation, so dialogue percentage is derived from whole pairs of quotes (opening + closing) rather than raw character counts.
- A single unmatched quote now contributes `0` pairs (no inflation), and the percentage remains capped at 100.
- Added unit tests (`storyComparisonMetrics.test.ts`) covering: paired quotes counted as dialogue lines, a single unmatched quote contributing 0%, capping at 100%, zero dialogue for quote-free text, and `compareStories` returning both metrics.

### Verification
- `npx vitest run` on `storyComparisonMetrics.test.ts` — all 5 tests pass locally.
- `eslint` on the changed files — clean.
- `tsc --noEmit` on the changed file — no type errors.

### Notes
- The change is minimal and isolated; it only refines the dialogue-counting computation while preserving the existing 5%-per-pair weighting and 100% cap.

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
