### PR TITLE
fix(#6242): add zero/NaN division guards to calculateSessionProgress

### DIFF
--- a/frontend/src/utils/__tests__/storyWritingSessionGoalsTracker.test.ts
+++ b/frontend/src/utils/__tests__/storyWritingSessionGoalsTracker.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { calculateSessionProgress } from "../storyWritingSessionGoalsTracker";
+
+const now = Date.now();
+
+describe("calculateSessionProgress - zero/NaN division guards", () => {
+  it("returns 0 progress (no NaN/Infinity) when targets are zero", () => {
+    const r = calculateSessionProgress("one two three", {
+      targetWords: 0,
+      targetMinutes: 0,
+      targetChapters: 0,
+    }, now);
+    expect(Number.isFinite(r.wordProgress)).toBe(true);
+    expect(Number.isFinite(r.timeProgress)).toBe(true);
+    expect(Number.isFinite(r.chapterProgress)).toBe(true);
+    expect(r.wordProgress).toBe(0);
+    expect(r.timeProgress).toBe(0);
+    expect(r.chapterProgress).toBe(0);
+  });
+
+  it("returns 0 progress when targets are NaN", () => {
+    const r = calculateSessionProgress("one two three", {
+      targetWords: Number.NaN,
+      targetMinutes: Number.NaN,
+      targetChapters: Number.NaN,
+    }, now);
+    expect(Number.isFinite(r.wordProgress)).toBe(true);
+    expect(Number.isFinite(r.timeProgress)).toBe(true);
+    expect(Number.isFinite(r.chapterProgress)).toBe(true);
+    expect(r.wordProgress).toBe(0);
+    expect(r.timeProgress).toBe(0);
+    expect(r.chapterProgress).toBe(0);
+  });
+
+  it("caps progress at 100 when target is exceeded", () => {
+    const r = calculateSessionProgress("one two three four five", {
+      targetWords: 2,
+      targetMinutes: 100000,
+      targetChapters: 1,
+    }, now);
+    expect(r.wordProgress).toBe(100);
+    expect(r.chapterProgress).toBe(100);
+    // time progress is small relative to a huge target.
+    expect(r.timeProgress).toBeLessThanOrEqual(100);
+  });
+
+  it("counts current words and chapters correctly", () => {
+    const r = calculateSessionProgress("one two\n\nthree four", {
+      targetWords: 10,
+      targetMinutes: 60,
+      targetChapters: 5,
+    }, now);
+    expect(r.currentWords).toBe(4);
+    expect(r.completedChapters).toBe(2);
+  });
+});

--- a/frontend/src/utils/storyWritingSessionGoalsTracker.ts
+++ b/frontend/src/utils/storyWritingSessionGoalsTracker.ts
@@ -40,18 +40,28 @@ export function calculateSessionProgress(
     (Date.now() - startTime) / 60000
   );
 
+  // Guard zero/NaN targets: when a goal is unset (0) or invalid (NaN),
+  // the corresponding progress is undefined (NaN/Infinity) and pollutes the
+  // UI. Treat such targets as "no goal" → 0 progress.
+  const safeTarget = (target: number): number =>
+    Number.isFinite(target) && target > 0 ? target : 0;
+
+  const wordTarget = safeTarget(goals.targetWords);
+  const timeTarget = safeTarget(goals.targetMinutes);
+  const chapterTarget = safeTarget(goals.targetChapters);
+
   const wordProgress = Math.min(
-    (wordCount / goals.targetWords) * 100,
+    wordTarget > 0 ? (wordCount / wordTarget) * 100 : 0,
     100
   );
 
   const timeProgress = Math.min(
-    (minutes / goals.targetMinutes) * 100,
+    timeTarget > 0 ? (minutes / timeTarget) * 100 : 0,
     100
   );
 
   const chapterProgress = Math.min(
-    (chapterCount / goals.targetChapters) * 100,
+    chapterTarget > 0 ? (chapterCount / chapterTarget) * 100 : 0,
     100
   );
 


### PR DESCRIPTION
## Summary

Closes #6242

This PR implements the fix described in issue #6242: **add zero and NaN division safety guards to calculateSessionProgress utility**.

### Problem
`calculateSessionProgress` in `frontend/src/utils/storyWritingSessionGoalsTracker.ts` divides by `goals.targetWords`, `goals.targetMinutes`, and `goals.targetChapters` directly. When a goal is unset (`0`) or invalid (`NaN`), the division produces `NaN`/`Infinity`, which leaks into `wordProgress`/`timeProgress`/`chapterProgress` and breaks the UI (e.g. progress bars showing `NaN%`).

### Changes
- Introduced a `safeTarget` helper that treats a target as valid only when it is finite and `> 0`; otherwise it is treated as "no goal" → `0` progress.
- Applied the guard to all three progress calculations (`wordProgress`, `timeProgress`, `chapterProgress`), so they are always finite numbers and never `NaN`/`Infinity`.
- Added unit tests (`storyWritingSessionGoalsTracker.test.ts`) covering: zero targets → 0 progress (no NaN), `NaN` targets → 0 progress (no NaN), capping at 100 when a target is exceeded, and correct counting of current words/chapters.

### Verification
- `npx vitest run` on `storyWritingSessionGoalsTracker.test.ts` — all 4 tests pass locally.
- `eslint` on the changed files — clean.
- `tsc --noEmit` on the changed file — no type errors.

### Notes
- The change is minimal and isolated; normal (positive, finite) targets keep their existing progress behaviour.


