### PR TITLE
fix(#6240): clamp negative weights in normalizeWeights utility

### DIFF
--- a/frontend/src/utils/__tests__/genreWeights.test.ts
+++ b/frontend/src/utils/__tests__/genreWeights.test.ts
@@ -77,6 +77,32 @@ describe("normalizeWeights", () => {
     expect(result.genres[0]).toHaveProperty("genre");
     expect(result.genres[0]).toHaveProperty("weight");
   });
+
+  it("clamps negative weights to 0 so they cannot invert normalization", () => {
+    const config = {
+      genres: [
+        { genre: "fantasy", weight: -50 },
+        { genre: "sci-fi", weight: 50 },
+      ],
+    };
+    const result = normalizeWeights(config);
+    // The negative weight is clamped to 0, so only sci-fi remains and gets 100%.
+    const total = result.genres.reduce((sum, g) => sum + g.weight, 0);
+    expect(total).toBe(100);
+    expect(result.genres.find((g) => g.genre === "sci-fi")?.weight).toBe(100);
+    expect(result.genres.find((g) => g.genre === "fantasy")?.weight).toBe(0);
+  });
+
+  it("returns empty config when all weights are negative (clamped to 0)", () => {
+    const config = {
+      genres: [
+        { genre: "fantasy", weight: -10 },
+        { genre: "sci-fi", weight: -20 },
+      ],
+    };
+    const result = normalizeWeights(config);
+    expect(result.genres).toEqual([]);
+  });
 });
 
 describe("validateWeights", () => {

--- a/frontend/src/utils/genreWeights.ts
+++ b/frontend/src/utils/genreWeights.ts
@@ -14,17 +14,21 @@ export const normalizeWeights = (
     return { genres: [] };
   }
 
-  const total = config.genres.reduce(
-    (sum, g) => sum + g.weight,
-    0
-  );
+  // Clamp negative weights to 0 so a malformed/accidental negative entry
+  // cannot invert the normalization or produce negative percentages.
+  const clamped = config.genres.map((g) => ({
+    ...g,
+    weight: g.weight < 0 ? 0 : g.weight,
+  }));
+
+  const total = clamped.reduce((sum, g) => sum + g.weight, 0);
 
   if (total === 0) {
     return { genres: [] };
   }
 
   return {
-    genres: config.genres.map((g) => ({
+    genres: clamped.map((g) => ({
       ...g,
       weight: Math.round((g.weight / total) * 100),
     })),


### PR DESCRIPTION
## Summary

Closes #6240

This PR implements the fix described in issue #6240: **clamp negative weights in normalizeWeights utility in genreWeights**.

### Problem
`normalizeWeights` in `frontend/src/utils/genreWeights.ts` summed raw `weight` values and divided each by the total. A negative weight could invert the normalization — reducing the total, producing negative percentages for other genres, or flipping the relative weighting — corrupting the genre prompt/mix shown to users.

### Changes
- Clamp negative weights to `0` before computing the total and the normalized percentages, so a malformed/accidental negative entry can neither invert normalization nor produce negative percentages.
- The existing zero-total and empty-config early returns are preserved (when all weights are negative they clamp to 0 → total 0 → empty config returned, instead of returning `NaN`-producing entries).
- Added two regression tests to the existing `genreWeights.test.ts`: a mix of one negative + one positive weight clamps correctly (negative → 0, the other → 100%); and all-negative weights return an empty config.

### Verification
- `npx vitest run` on `genreWeights.test.ts` — all 20 tests pass locally (18 existing + 2 new).
- `eslint` on the changed files — clean.
- `tsc --noEmit` on the changed file — no type errors.

### Notes
- The change is minimal and isolated; non-negative weight configs keep their existing normalization behaviour exactly.

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
