### PR TITLE
fix(#6239): guard zero-length input in generateStoryAnalytics utility

### DIFF
--- a/frontend/src/utils/__tests__/storyReadingAnalytics.test.ts
+++ b/frontend/src/utils/__tests__/storyReadingAnalytics.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { generateStoryAnalytics, refreshAnalytics } from "../storyReadingAnalytics";
+
+describe("generateStoryAnalytics - zero-length input guard", () => {
+  it("returns zeroed metrics for an empty string", () => {
+    const r = generateStoryAnalytics("");
+    expect(r.totalViews).toBe(0);
+    expect(r.averageReadingTime).toBe(0);
+    expect(r.completionRate).toBe(0);
+    expect(r.likes).toBe(0);
+    expect(r.bookmarks).toBe(0);
+    expect(r.shares).toBe(0);
+    expect(r.engagementTrend).toEqual([]);
+  });
+
+  it("returns zeroed metrics for a whitespace-only string", () => {
+    const r = generateStoryAnalytics("    \n\t  ");
+    expect(r.averageReadingTime).toBe(0);
+    expect(r.totalViews).toBe(0);
+    expect(r.engagementTrend).toEqual([]);
+  });
+
+  it("returns normal analytics for non-empty input", () => {
+    const r = generateStoryAnalytics("one two three four");
+    expect(r.totalViews).toBe(1248);
+    expect(r.averageReadingTime).toBeGreaterThanOrEqual(1);
+    expect(r.engagementTrend.length).toBeGreaterThan(0);
+  });
+
+  it("averageReadingTime grows with word count for non-empty input", () => {
+    const short = generateStoryAnalytics("a b c d");
+    const long = generateStoryAnalytics("w ".repeat(500).trim());
+    expect(long.averageReadingTime).toBeGreaterThan(short.averageReadingTime);
+  });
+
+  it("refreshAnalytics delegates to generateStoryAnalytics", () => {
+    expect(refreshAnalytics("")).toEqual(generateStoryAnalytics(""));
+  });
+});

--- a/frontend/src/utils/storyReadingAnalytics.ts
+++ b/frontend/src/utils/storyReadingAnalytics.ts
@@ -13,6 +13,21 @@ export function generateStoryAnalytics(
 ): StoryAnalytics {
   const words = story.trim().split(/\s+/).filter(Boolean).length;
 
+  // For empty/whitespace-only input there is no story to analyse; return a
+  // zeroed report instead of fabricated engagement stats and a reading time
+  // of 1 (caused by the Math.max(1, ...) floor).
+  if (words === 0) {
+    return {
+      totalViews: 0,
+      averageReadingTime: 0,
+      completionRate: 0,
+      likes: 0,
+      bookmarks: 0,
+      shares: 0,
+      engagementTrend: [],
+    };
+  }
+
   return {
     totalViews: 1248,
     averageReadingTime: Math.max(1, Math.ceil(words / 200)),


### PR DESCRIPTION
## Summary

Closes #6239

This PR implements the fix described in issue #6239: **guard zero-length input in generateStoryAnalytics utility**.

### Problem
`generateStoryAnalytics` in `frontend/src/utils/storyReadingAnalytics.ts` returned fabricated engagement stats (`totalViews: 1248`, `likes: 312`, a hardcoded `engagementTrend`, etc.) and a reading time of `1` (from the `Math.max(1, ...)` floor) even for empty/whitespace-only input, presenting bogus analytics where there is no story to analyse.

### Changes
- After computing the word count, return a fully zeroed `StoryAnalytics` report (`totalViews`/`averageReadingTime`/`completionRate`/`likes`/`bookmarks`/`shares` all `0`, `engagementTrend: []`) when there are no words.
- Non-empty input keeps the existing analytics behaviour and reading-time computation unchanged.

### Verification
- `npx vitest run` on `storyReadingAnalytics.test.ts` — all 5 tests pass locally (empty string, whitespace-only, normal input, reading-time scaling, `refreshAnalytics` delegation).
- `eslint` on the changed files — clean.
- `tsc --noEmit` on the changed file — no type errors.

### Notes
- The change is minimal and isolated; it only affects the zero-length input edge case.

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
