### PR TITLE
fix(#6238): derive overall suspense score from sections in storySuspenseAnalyzer

### DIFF
--- a/frontend/src/utils/__tests__/storySuspenseAnalyzer.test.ts
+++ b/frontend/src/utils/__tests__/storySuspenseAnalyzer.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { analyzeStorySuspense } from "../storySuspenseAnalyzer";
+
+describe("analyzeStorySuspense - derived scores", () => {
+  it("returns a zeroed report for empty/whitespace input", () => {
+    expect(analyzeStorySuspense("")).toEqual({ overallScore: 0, sections: [] });
+    expect(analyzeStorySuspense("   \n  ")).toEqual({ overallScore: 0, sections: [] });
+  });
+
+  it("overallScore is the average of section tension scores, not a fixed 84", () => {
+    const story = "A calm day.\n\nSuddenly danger appeared from the unknown shadow.";
+    const r = analyzeStorySuspense(story);
+    expect(r.sections.length).toBe(2);
+    const avg =
+      r.sections.reduce((s, x) => s + x.tensionScore, 0) / r.sections.length;
+    expect(r.overallScore).toBe(Math.round(avg));
+    // Must not be the old hardcoded value for a generic input.
+    expect(r.overallScore).not.toBe(84);
+  });
+
+  it("sections with more suspense keywords get higher tension scores", () => {
+    const calm = "A calm ordinary day with clear skies.";
+    const tense = "Suddenly a shadow whispered a secret threat and panic.";
+    const rCalm = analyzeStorySuspense(calm);
+    const rTense = analyzeStorySuspense(tense);
+    expect(rTense.sections[0].tensionScore).toBeGreaterThan(
+      rCalm.sections[0].tensionScore
+    );
+  });
+
+  it("every section has finite scores within 0-100 and a valid status", () => {
+    const r = analyzeStorySuspense(
+      "Normal text here.\n\nSuddenly danger and fear!\n\nThe end."
+    );
+    for (const s of r.sections) {
+      expect(Number.isFinite(s.tensionScore)).toBe(true);
+      expect(s.tensionScore).toBeGreaterThanOrEqual(0);
+      expect(s.tensionScore).toBeLessThanOrEqual(100);
+      expect(["High", "Medium", "Low"]).toContain(s.status);
+    }
+    expect(r.overallScore).toBeGreaterThanOrEqual(0);
+    expect(r.overallScore).toBeLessThanOrEqual(100);
+  });
+});

--- a/frontend/src/utils/storySuspenseAnalyzer.ts
+++ b/frontend/src/utils/storySuspenseAnalyzer.ts
@@ -12,6 +12,35 @@ export interface SuspenseAnalysis {
   sections: SuspenseSection[];
 }
 
+const SUSPENSE_KEYWORDS = [
+  "suddenly",
+  "tension",
+  "fear",
+  "danger",
+  "mystery",
+  "threat",
+  "panic",
+  "shadow",
+  "unknown",
+  "secret",
+  "alarm",
+  "warning",
+  "whisper",
+  "silence",
+  "desperate",
+  "escape",
+  "chase",
+  "reveal",
+  "cliffhanger",
+  "unseen",
+];
+
+const clamp = (n: number, lo = 0, hi = 100) =>
+  Math.max(lo, Math.min(hi, n));
+
+const statusFor = (score: number): "High" | "Medium" | "Low" =>
+  score >= 80 ? "High" : score >= 55 ? "Medium" : "Low";
+
 export function analyzeStorySuspense(
   story: string
 ): SuspenseAnalysis {
@@ -22,40 +51,66 @@ export function analyzeStorySuspense(
     };
   }
 
+  // Split the story into narrative sections on blank-line boundaries.
+  const paragraphs = story
+    .split(/\n{2,}/)
+    .map((p) => p.trim())
+    .filter(Boolean);
+
+  const sections = paragraphs.map((paragraph, index) => {
+    const words = paragraph.split(/\s+/).filter(Boolean);
+    const wordCount = Math.max(words.length, 1);
+    const lower = paragraph.toLowerCase();
+    // Tension contribution from suspense-keyword density.
+    const hits = SUSPENSE_KEYWORDS.reduce(
+      (count, kw) => count + (lower.split(kw).length - 1),
+      0
+    );
+    const density = (hits / wordCount) * 100;
+    // Map keyword density onto a 30-100 tension band so a section with no
+    // keywords still registers a non-zero baseline tension.
+    const tensionScore = clamp(Math.round(30 + Math.min(density * 12, 70)));
+
+    let observation =
+      "This section moves at a steady pace with limited suspense cues.";
+    let suggestion =
+      "Add a moment of uncertainty or an unanswered question to heighten anticipation.";
+
+    if (tensionScore >= 80) {
+      observation =
+        "Conflict escalates effectively with strong anticipation.";
+      suggestion =
+        "Maintain momentum by increasing uncertainty before the climax.";
+    } else if (tensionScore < 55) {
+      observation =
+        "This section feels calm and lacks immediate tension.";
+      suggestion =
+        "Introduce a subtle threat or delay a key reveal to build suspense.";
+    }
+
+    return {
+      id: index + 1,
+      title: `Section ${index + 1}`,
+      tensionScore,
+      status: statusFor(tensionScore),
+      observation,
+      suggestion,
+    };
+  });
+
+  const overallScore =
+    sections.length > 0
+      ? clamp(
+          Math.round(
+            sections.reduce((sum, s) => sum + s.tensionScore, 0) /
+              sections.length
+          )
+        )
+      : 0;
+
   return {
-    overallScore: 84,
-    sections: [
-      {
-        id: 1,
-        title: "Opening",
-        tensionScore: 72,
-        status: "Medium",
-        observation:
-          "The opening establishes context but introduces conflict slowly.",
-        suggestion:
-          "Begin with a stronger hook or mystery to capture attention immediately.",
-      },
-      {
-        id: 2,
-        title: "Middle",
-        tensionScore: 91,
-        status: "High",
-        observation:
-          "Conflict escalates effectively with strong anticipation.",
-        suggestion:
-          "Maintain momentum by increasing uncertainty before the climax.",
-      },
-      {
-        id: 3,
-        title: "Ending",
-        tensionScore: 63,
-        status: "Low",
-        observation:
-          "The final reveal feels predictable and lacks a strong cliffhanger.",
-        suggestion:
-          "Delay key revelations and introduce unexpected twists for greater impact.",
-      },
-    ],
+    overallScore,
+    sections,
   };
 }
 


### PR DESCRIPTION
## Summary

Closes #6238

This PR implements the fix described in issue #6238: **derive overall suspense score from sections in storySuspenseAnalyzer utility**.

### Problem
`analyzeStorySuspense` in `frontend/src/utils/storySuspenseAnalyzer.ts` returned a fixed `overallScore: 84` and three hardcoded sections ("Opening/Middle/Ending") regardless of the input text. The score was not derived from the story at all, so the analysis was identical for every input.

### Changes
- Split the story into sections on blank-line (`\n{2,}`) boundaries and compute a per-section `tensionScore` from suspense-keyword density (a curated list of ~20 tension cue words) mapped onto a 30-100 band, so a section with no cues still registers a baseline tension and a cue-heavy section scores higher.
- Derive `overallScore` as the rounded average of the section tension scores (clamped to 0-100), instead of the fixed `84`.
- Generate `status` ("High"/"Medium"/"Low") and `observation`/`suggestion` text from the computed score, so the qualitative feedback now tracks the actual content.
- Preserved the existing empty-input early return (zeroed report).
- Added unit tests (`storySuspenseAnalyzer.test.ts`) covering: empty/whitespace input, `overallScore` equal to the section average (not the old fixed 84), cue-heavy sections scoring higher than calm ones, and all scores being finite/in-range with valid statuses.

### Verification
- `npx vitest run` on `storySuspenseAnalyzer.test.ts` — all 4 tests pass locally.
- `eslint` on the changed files — clean.
- `tsc --noEmit` on the changed file — no type errors.

### Notes
- The change is self-contained within the analyzer; the public `SuspenseAnalysis`/`SuspenseSection` interfaces are unchanged, so callers are unaffected.

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
