### PR TITLE
fix(#6237): compute pacing from section density in storyPaceHeatmap

### DIFF
--- a/frontend/src/utils/__tests__/storyPaceHeatmap.test.ts
+++ b/frontend/src/utils/__tests__/storyPaceHeatmap.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { analyzeStoryPace } from "../storyPaceHeatmap";
+
+describe("analyzeStoryPace - computed pacing", () => {
+  it("returns [] for empty/whitespace input", () => {
+    expect(analyzeStoryPace("")).toEqual([]);
+    expect(analyzeStoryPace("   \n  ")).toEqual([]);
+  });
+
+  it("derives score from section density, not a fixed cycle", () => {
+    const story = "one two three four five six seven eight nine ten.\n\na.";
+    const r = analyzeStoryPace(story);
+    expect(r).toHaveLength(2);
+    // Scores must be finite numbers within range.
+    for (const s of r) {
+      expect(Number.isFinite(s.score)).toBe(true);
+      expect(s.score).toBeGreaterThanOrEqual(30);
+      expect(s.score).toBeLessThanOrEqual(95);
+      expect(["Fast", "Balanced", "Slow"]).toContain(s.pace);
+    }
+    // The first (long-sentence) section scores higher than the second (1 word).
+    expect(r[0].score).toBeGreaterThan(r[1].score);
+  });
+
+  it("no longer cycles Fast/Balanced/Slow by index", () => {
+    // Three identical-length sections previously produced Fast/Balanced/Slow
+    // purely by position. They should now all share the same pace/score.
+    const para = "one two three four five six seven eight nine ten.";
+    const story = [para, para, para].join("\n\n");
+    const r = analyzeStoryPace(story);
+    expect(r).toHaveLength(3);
+    const paces = r.map((s) => s.pace);
+    const scores = r.map((s) => s.score);
+    expect(new Set(paces).size).toBe(1);
+    expect(new Set(scores).size).toBe(1);
+  });
+
+  it("long-sentence sections are classified as Fast", () => {
+    const long = ("word ".repeat(25).trim()) + ".";
+    const r = analyzeStoryPace(long);
+    expect(r[0].pace).toBe("Fast");
+  });
+});

--- a/frontend/src/utils/storyPaceHeatmap.ts
+++ b/frontend/src/utils/storyPaceHeatmap.ts
@@ -13,28 +13,42 @@ export function analyzeStoryPace(
 
   const sections = story
     .split(/\n{2,}/)
-    .filter(Boolean);
+    .filter((s) => s.trim());
 
-  return sections.map((_, index) => {
-    const paceTypes = ["Fast", "Balanced", "Slow"] as const;
-    const pace = paceTypes[index % 3];
+  return sections.map((section, index) => {
+    const words = section.trim().split(/\s+/).filter(Boolean);
+    const sentences = section
+      .split(/[.!?]+/)
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const wordCount = Math.max(words.length, 1);
+    const sentenceCount = Math.max(sentences.length, 1);
+
+    // Average words per sentence is a real proxy for pacing: more words per
+    // sentence → faster/denser narration; fewer → slower, more descriptive.
+    const wordsPerSentence = wordCount / sentenceCount;
+    // Map ~6-30 words/sentence onto a 30-95 score band.
+    const score = Math.max(
+      30,
+      Math.min(95, Math.round(30 + (wordsPerSentence - 6) * 2.8))
+    );
+
+    const pace: PaceSection["pace"] =
+      score >= 75 ? "Fast" : score >= 50 ? "Balanced" : "Slow";
+
+    const suggestion =
+      pace === "Fast"
+        ? "Consider adding more descriptive details to slow the pacing slightly."
+        : pace === "Balanced"
+        ? "This section has a healthy pacing balance."
+        : "Consider shortening descriptions or adding dialogue/action.";
 
     return {
       id: index + 1,
       title: `Section ${index + 1}`,
       pace,
-      score:
-        pace === "Fast"
-          ? 90
-          : pace === "Balanced"
-          ? 65
-          : 35,
-      suggestion:
-        pace === "Fast"
-          ? "Consider adding more descriptive details to slow the pacing slightly."
-          : pace === "Balanced"
-          ? "This section has a healthy pacing balance."
-          : "Consider shortening descriptions or adding dialogue/action.",
+      score,
+      suggestion,
     };
   });
 }


### PR DESCRIPTION
## Summary

Closes #6237

This PR implements the fix described in issue #6237: **return computed pacing instead of cycling fixed values in storyPaceHeatmap utility**.

### Problem
`analyzeStoryPace` in `frontend/src/utils/storyPaceHeatmap.ts` cycled `["Fast", "Balanced", "Slow"]` purely by section index (`paceTypes[index % 3]`) and assigned fixed scores (90/65/35). The pace and score were therefore independent of the actual story content — identical-length sections always alternated paces regardless of their text.

### Changes
- For each section, compute the average words-per-sentence (a real proxy for pacing density) and map it onto a 30-95 score band.
- Derive the `pace` label ("Fast" ≥ 75, "Balanced" ≥ 50, "Slow" otherwise) and the `suggestion` from the computed score, so the analysis now reflects the actual content.
- Identical sections now produce identical pace/score instead of cycling by position; denser (longer-sentence) sections score higher than sparse ones.
- Preserved the existing empty-input early return (`[]`).

### Verification
- `npx vitest run` on `storyPaceHeatmap.test.ts` — all 4 tests pass locally (empty input, density-derived scoring, no index-cycling for identical sections, long-sentence → Fast).
- `eslint` on the changed files — clean.
- The change is self-contained; the public `PaceSection` interface is unchanged.

### Notes
- Note: the repo's project-wide `tsc -b` typecheck is already red on `main` due to pre-existing unrelated errors (missing modules elsewhere); this change introduces no new type errors in the touched file.

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
