### PR TITLE
fix(#6235): add localStorage SSR guards to storySessionRecovery utility

### DIFF
--- a/frontend/src/utils/__tests__/storySessionRecovery.test.ts
+++ b/frontend/src/utils/__tests__/storySessionRecovery.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  saveDraft,
+  getRecoveredDraft,
+  discardRecoveredDraft,
+} from "../storySessionRecovery";
+
+describe("storySessionRecovery - SSR guards", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("saveDraft persists and getRecoveredDraft reads it back", () => {
+    const draft = saveDraft("hello world");
+    expect(draft).not.toBeNull();
+    const recovered = getRecoveredDraft();
+    expect(recovered?.content).toBe("hello world");
+    expect(typeof recovered?.savedAt).toBe("string");
+  });
+
+  it("discardRecoveredDraft clears the stored draft", () => {
+    saveDraft("to be discarded");
+    discardRecoveredDraft();
+    expect(getRecoveredDraft()).toBeNull();
+  });
+
+  it("getRecoveredDraft returns null when nothing is stored", () => {
+    expect(getRecoveredDraft()).toBeNull();
+  });
+
+  it("returns null when malformed JSON is stored", () => {
+    localStorage.setItem("story-session-recovery", "{not json");
+    expect(getRecoveredDraft()).toBeNull();
+  });
+
+  it("does not throw during SSR (no window/localStorage)", () => {
+    const originalWindow = globalThis.window;
+    // Simulate SSR: window undefined.
+    // @ts-expect-error - intentionally removing window for SSR simulation
+    delete globalThis.window;
+    try {
+      const draft = saveDraft("ssr content");
+      expect(draft).not.toBeNull();
+      expect(draft?.content).toBe("ssr content");
+      expect(getRecoveredDraft()).toBeNull();
+      expect(() => discardRecoveredDraft()).not.toThrow();
+    } finally {
+      globalThis.window = originalWindow;
+    }
+  });
+});

--- a/frontend/src/utils/storySessionRecovery.ts
+++ b/frontend/src/utils/storySessionRecovery.ts
@@ -5,11 +5,16 @@ export interface StoryRecoveryData {
 
 const STORAGE_KEY = "story-session-recovery";
 
-export function saveDraft(content: string) {
+const hasLocalStorage = (): boolean =>
+  typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+
+export function saveDraft(content: string): StoryRecoveryData | null {
   const draft: StoryRecoveryData = {
     content,
     savedAt: new Date().toISOString(),
   };
+
+  if (!hasLocalStorage()) return draft;
 
   localStorage.setItem(
     STORAGE_KEY,
@@ -20,6 +25,8 @@ export function saveDraft(content: string) {
 }
 
 export function getRecoveredDraft(): StoryRecoveryData | null {
+  if (!hasLocalStorage()) return null;
+
   const data = localStorage.getItem(STORAGE_KEY);
 
   if (!data) return null;
@@ -32,6 +39,7 @@ export function getRecoveredDraft(): StoryRecoveryData | null {
 }
 
 export function discardRecoveredDraft() {
+  if (!hasLocalStorage()) return;
   localStorage.removeItem(STORAGE_KEY);
 }
 


### PR DESCRIPTION
## Summary

Closes #6235

This PR implements the fix described in issue #6235: **add localStorage SSR guards to storySessionRecovery utility**.

### Problem
`saveDraft`, `getRecoveredDraft`, and `discardRecoveredDraft` in `frontend/src/utils/storySessionRecovery.ts` accessed `localStorage` directly. During SSR (or any non-browser environment) `localStorage`/`window` is undefined, so importing/calling these helpers throws a `ReferenceError`, crashing server rendering.

### Changes
- Added a `hasLocalStorage()` guard (`typeof window !== "undefined" && typeof window.localStorage !== "undefined"`) used at the top of all three functions.
- `saveDraft` now still returns the built `StoryRecoveryData` object (so callers get the timestamp) but skips the `localStorage.setItem` call in non-browser environments. `getRecoveredDraft` returns `null` and `discardRecoveredDraft` becomes a no-op when `localStorage` is unavailable — none of them throw.
- The existing happy-path behaviour in the browser is unchanged.

### Verification
- `npx vitest run` on `storySessionRecovery.test.ts` (jsdom env) — all 5 tests pass locally (save/read round-trip, discard, empty/malformed handling, and an SSR simulation where `window` is removed without throwing).
- `eslint` on the changed files — clean.
- `tsc --noEmit` on the changed file — no type errors.

### Notes
- The change is minimal and isolated; browser behaviour is preserved.

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
