### PR TITLE
fix(#6234): add localStorage SSR guards to storyEditingSessionStatistics utility

### DIFF
--- a/frontend/src/utils/__tests__/storyEditingSessionStatistics.test.ts
+++ b/frontend/src/utils/__tests__/storyEditingSessionStatistics.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  calculateEditingSession,
+  getSessionHistory,
+  saveSessionHistory,
+} from "../storyEditingSessionStatistics";
+
+describe("storyEditingSessionStatistics - SSR guards", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("saveSessionHistory then getSessionHistory round-trips", () => {
+    const history = [
+      { id: 1, date: "2026-01-01", duration: 10, revisions: 3 },
+    ];
+    saveSessionHistory(history);
+    expect(getSessionHistory()).toEqual(history);
+  });
+
+  it("getSessionHistory returns [] when nothing stored or malformed", () => {
+    expect(getSessionHistory()).toEqual([]);
+    localStorage.setItem("editing-session-history", "{bad json");
+    expect(getSessionHistory()).toEqual([]);
+  });
+
+  it("calculateEditingSession computes added/removed/paragraphs", () => {
+    const r = calculateEditingSession(
+      "one two three\n\nfour",
+      "one two\n\nthree four five",
+      Date.now() - 120000
+    );
+    expect(r.wordsRemoved).toBeGreaterThanOrEqual(0);
+    expect(r.wordsAdded).toBeGreaterThanOrEqual(0);
+    expect(r.totalRevisions).toBe(1);
+    expect(r.editingDuration).toBe(2);
+  });
+
+  it("does not throw during SSR (no window/localStorage)", () => {
+    const originalWindow = globalThis.window;
+    // @ts-expect-error - intentionally removing window for SSR simulation
+    delete globalThis.window;
+    try {
+      expect(getSessionHistory()).toEqual([]);
+      expect(() =>
+        saveSessionHistory([{ id: 1, date: "x", duration: 1, revisions: 1 }])
+      ).not.toThrow();
+    } finally {
+      globalThis.window = originalWindow;
+    }
+  });
+});

--- a/frontend/src/utils/storyEditingSessionStatistics.ts
+++ b/frontend/src/utils/storyEditingSessionStatistics.ts
@@ -48,6 +48,9 @@ export function calculateEditingSession(
 }
 
 export function getSessionHistory(): EditingSessionHistory[] {
+  if (typeof window === "undefined" || typeof window.localStorage === "undefined") {
+    return [];
+  }
   try {
     return JSON.parse(
       localStorage.getItem("editing-session-history") || "[]"
@@ -60,6 +63,9 @@ export function getSessionHistory(): EditingSessionHistory[] {
 export function saveSessionHistory(
   history: EditingSessionHistory[]
 ) {
+  if (typeof window === "undefined" || typeof window.localStorage === "undefined") {
+    return;
+  }
   localStorage.setItem(
     "editing-session-history",
     JSON.stringify(history)


### PR DESCRIPTION
## Summary

Closes #6234

This PR implements the fix described in issue #6234: **add localStorage SSR guards to storyEditingSessionStatistics utility**.

### Problem
`getSessionHistory` and `saveSessionHistory` in `frontend/src/utils/storyEditingSessionStatistics.ts` touched `localStorage` directly (`getSessionHistory` already had a `try/catch` for parse errors but no SSR guard; `saveSessionHistory` had none at all). During SSR, `localStorage`/`window` is undefined, so these calls throw a `ReferenceError` and crash server rendering.

### Changes
- Added a `typeof window === "undefined" || typeof window.localStorage === "undefined"` guard at the top of both functions.
- `getSessionHistory` returns `[]` (its existing empty fallback) and `saveSessionHistory` becomes a no-op when `localStorage` is unavailable — neither throws during SSR.
- The existing `try/catch` for malformed JSON in `getSessionHistory` is preserved, and browser behaviour is unchanged.

### Verification
- `npx vitest run` on `storyEditingSessionStatistics.test.ts` (jsdom env) — all 4 tests pass locally (save/read round-trip, empty/malformed handling, `calculateEditingSession` correctness, and an SSR simulation where `window` is removed without throwing).
- `eslint` on the changed files — clean.
- `tsc --noEmit` on the changed file — no type errors.

### Notes
- The change is minimal and isolated; browser behaviour is preserved.

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
