### PR TITLE
fix(#6233): add zero-division guard to diversity score in storyVocabularyGrowthTracker

### DIFF
--- a/frontend/src/utils/__tests__/storyVocabularyGrowthTracker.test.ts
+++ b/frontend/src/utils/__tests__/storyVocabularyGrowthTracker.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { analyzeVocabulary } from "../storyVocabularyGrowthTracker";
+
+describe("analyzeVocabulary - diversity score zero-division guard", () => {
+  it("returns a finite diversityScore for normal input", () => {
+    const r = analyzeVocabulary("the big bad wolf and the good wolf");
+    expect(Number.isFinite(r.diversityScore)).toBe(true);
+    expect(r.diversityScore).toBeGreaterThanOrEqual(0);
+    expect(r.diversityScore).toBeLessThanOrEqual(100);
+  });
+
+  it("diversityScore is 0 (not NaN) when all words are stop words", () => {
+    // After stop-word filtering, words.length === 0 → would be NaN without guard.
+    const r = analyzeVocabulary("the a an and or to of in is was");
+    expect(Number.isFinite(r.diversityScore)).toBe(true);
+    expect(r.diversityScore).toBe(0);
+    expect(r.totalWords).toBe(0);
+    expect(r.uniqueWords).toBe(0);
+  });
+
+  it("returns zeroed stats for empty/whitespace input", () => {
+    expect(analyzeVocabulary("")).toEqual({
+      totalWords: 0,
+      uniqueWords: 0,
+      diversityScore: 0,
+      overusedWords: [],
+      growthHistory: [],
+    });
+    const ws = analyzeVocabulary("   \n  ");
+    expect(ws.diversityScore).toBe(0);
+  });
+
+  it("computes diversity as unique/total percentage", () => {
+    const r = analyzeVocabulary("apple apple banana");
+    // stop-word-filtered words: apple, apple, banana → total 3, unique 2 → 67%.
+    expect(r.uniqueWords).toBe(2);
+    expect(r.totalWords).toBe(3);
+    expect(r.diversityScore).toBe(67);
+  });
+});

--- a/frontend/src/utils/storyVocabularyGrowthTracker.ts
+++ b/frontend/src/utils/storyVocabularyGrowthTracker.ts
@@ -74,9 +74,10 @@ export function analyzeVocabulary(
   return {
     totalWords: words.length,
     uniqueWords: frequency.size,
-    diversityScore: Math.round(
-      (frequency.size / words.length) * 100
-    ),
+    diversityScore:
+      words.length > 0
+        ? Math.round((frequency.size / words.length) * 100)
+        : 0,
     overusedWords,
     growthHistory: [
       {


### PR DESCRIPTION
## Summary

Closes #6233

This PR implements the fix described in issue #6233: **add zero-division guard to diversity score in storyVocabularyGrowthTracker utility**.

### Problem
`analyzeVocabulary` in `frontend/src/utils/storyVocabularyGrowthTracker.ts` computed `diversityScore = Math.round((frequency.size / words.length) * 100)`. The empty-string case was already handled by an early return, but if the input contained **only stop words** (e.g. `"the a an and or"`), stop-word filtering reduced `words.length` to `0` while bypassing the empty-input guard, producing `uniqueWords/0` = `NaN` for `diversityScore`.

### Changes
- Guarded the division: `diversityScore` is `Math.round((frequency.size / words.length) * 100)` only when `words.length > 0`, otherwise `0`. This keeps the score a finite number in the all-stop-words edge case.
- All other behaviour (stop-word filtering, overused-words detection, growth history) is unchanged.

### Verification
- `npx vitest run` on `storyVocabularyGrowthTracker.test.ts` — all 4 tests pass locally (finite score for normal input, all-stop-words input → `0` not `NaN`, empty/whitespace zeroed stats, percentage correctness).
- `eslint` on the changed files — clean.
- `tsc --noEmit` on the changed file — no type errors.

### Notes
- The change is minimal and isolated; normal inputs keep their existing scoring.

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
