### PR TITLE
fix(#6232): return zero reading time for empty text in analyzeReadingInfo

### DIFF
--- a/frontend/src/utils/__tests__/storyReadingInfo.test.ts
+++ b/frontend/src/utils/__tests__/storyReadingInfo.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { analyzeReadingInfo } from "../storyReadingInfo";
+
+describe("analyzeReadingInfo - zero reading time for empty text", () => {
+  it("returns readingTime 0 for an empty string", () => {
+    const r = analyzeReadingInfo("");
+    expect(r.wordCount).toBe(0);
+    expect(r.readingTime).toBe(0);
+    expect(r.difficulty).toBe("Beginner");
+  });
+
+  it("returns readingTime 0 for whitespace-only text", () => {
+    const r = analyzeReadingInfo("   \n\t  ");
+    expect(r.wordCount).toBe(0);
+    expect(r.readingTime).toBe(0);
+  });
+
+  it("returns readingTime >= 1 for non-empty text", () => {
+    const r = analyzeReadingInfo("one two three four");
+    expect(r.wordCount).toBe(4);
+    expect(r.readingTime).toBeGreaterThanOrEqual(1);
+  });
+
+  it("scales readingTime with word count", () => {
+    const short = analyzeReadingInfo("a b c");
+    const long = analyzeReadingInfo("w ".repeat(500).trim());
+    expect(long.readingTime).toBeGreaterThan(short.readingTime);
+  });
+
+  it("classifies difficulty by word count", () => {
+    expect(analyzeReadingInfo("a b c").difficulty).toBe("Beginner");
+    const mid = analyzeReadingInfo("w ".repeat(1200).trim());
+    expect(mid.difficulty).toBe("Intermediate");
+    const big = analyzeReadingInfo("w ".repeat(3200).trim());
+    expect(big.difficulty).toBe("Advanced");
+  });
+});

--- a/frontend/src/utils/storyReadingInfo.ts
+++ b/frontend/src/utils/storyReadingInfo.ts
@@ -21,6 +21,16 @@ export function analyzeReadingInfo(
 
   const wordCount = words.length;
 
+  // For empty/whitespace-only text there are no words to read, so report a
+  // reading time of 0 instead of 1 (caused by the Math.max(1, ...) floor).
+  if (wordCount === 0) {
+    return {
+      wordCount: 0,
+      readingTime: 0,
+      difficulty: "Beginner",
+    };
+  }
+
   let difficulty: DifficultyLevel = "Beginner";
 
   if (wordCount > 1000) {


### PR DESCRIPTION
## Summary

Closes #6232

This PR implements the fix described in issue #6232: **return zero reading time for empty text in analyzeReadingInfo utility**.

### Problem
`analyzeReadingInfo` in `frontend/src/utils/storyReadingInfo.ts` computed `readingTime = Math.max(1, Math.ceil(wordCount / 200))`. The `Math.max(1, ...)` floor meant empty/whitespace-only input reported a reading time of `1` minute even though there are no words to read.

### Changes
- Added an early return for `wordCount === 0` that reports `wordCount: 0`, `readingTime: 0`, `difficulty: "Beginner"`, instead of `1`.
- Non-empty input keeps the existing `Math.max(1, ...)` behaviour and difficulty thresholds unchanged.

### Verification
- `npx vitest run` on `storyReadingInfo.test.ts` — all 5 tests pass locally (empty string → `0`, whitespace-only → `0`, non-empty → `≥1`, reading-time scaling, difficulty classification by word count).
- `eslint` on the changed files — clean.
- `tsc --noEmit` on the changed file — no type errors.

### Notes
- The change is minimal and isolated; it only affects the zero-length input edge case.

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
