### PR TITLE
test(#6231): add unit tests for generateEndingAlternatives utility

### DIFF
--- a/frontend/src/utils/__tests__/storyEndingAlternatives.test.ts
+++ b/frontend/src/utils/__tests__/storyEndingAlternatives.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import {
+  generateEndingAlternatives,
+  regenerateEndingAlternatives,
+} from "../storyEndingAlternatives";
+
+describe("generateEndingAlternatives", () => {
+  it("returns [] for empty/whitespace input", () => {
+    expect(generateEndingAlternatives("")).toEqual([]);
+    expect(generateEndingAlternatives("   \n  ")).toEqual([]);
+  });
+
+  it("returns ending alternatives for non-empty input", () => {
+    const r = generateEndingAlternatives("A story with a beginning and middle.");
+    expect(r.length).toBeGreaterThan(0);
+  });
+
+  it("each alternative has the required fields with correct types", () => {
+    const r = generateEndingAlternatives("Some story.");
+    for (const alt of r) {
+      expect(typeof alt.id).toBe("number");
+      expect(typeof alt.title).toBe("string");
+      expect(alt.title.length).toBeGreaterThan(0);
+      expect(typeof alt.style).toBe("string");
+      expect(typeof alt.emotionalImpact).toBe("string");
+      expect(typeof alt.content).toBe("string");
+      expect(alt.content.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("alternative ids are unique and sequential", () => {
+    const r = generateEndingAlternatives("Story text.");
+    const ids = r.map((a) => a.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toEqual([...Array(ids.length).keys()].map((i) => i + 1));
+  });
+
+  it("returns the same alternatives for the same input (deterministic)", () => {
+    const story = "A consistent story.";
+    const a = generateEndingAlternatives(story);
+    const b = generateEndingAlternatives(story);
+    expect(a).toEqual(b);
+  });
+});
+
+describe("regenerateEndingAlternatives", () => {
+  it("delegates to generateEndingAlternatives", () => {
+    const story = "A story to regenerate endings for.";
+    expect(regenerateEndingAlternatives(story)).toEqual(
+      generateEndingAlternatives(story)
+    );
+  });
+
+  it("returns [] for empty input", () => {
+    expect(regenerateEndingAlternatives("")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6231

This PR implements the work described in issue #6231: **add unit tests for generateEndingAlternatives utility**.

### Changes
- Added `frontend/src/utils/__tests__/storyEndingAlternatives.test.ts` covering:
  - Empty/whitespace input → `[]`.
  - Non-empty input → non-empty alternatives list.
  - Each alternative has the required fields (`id`, `title`, `style`, `emotionalImpact`, `content`) with correct, non-empty types.
  - IDs are unique and sequential (1..N).
  - Deterministic output (same input → same alternatives).
  - `regenerateEndingAlternatives` delegates to `generateEndingAlternatives` and returns `[]` for empty input.

### Verification
- `npx vitest run` on `storyEndingAlternatives.test.ts` — all 7 tests pass locally.
- `eslint` on the new test file — clean.

### Notes
- Test-only PR; no production source changes. The existing `generateEndingAlternatives`/`regenerateEndingAlternatives` behaviour is already correct, so the tests document and lock in that behaviour.

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
