### PR TITLE
test(#6230): add unit tests for getDialogueDistribution utility

### DIFF
--- a/frontend/src/utils/__tests__/dialogueDistribution.comprehensive.test.ts
+++ b/frontend/src/utils/__tests__/dialogueDistribution.comprehensive.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { getDialogueDistribution } from "../dialogueDistribution";
+
+describe("getDialogueDistribution", () => {
+  it("returns a non-empty list of characters", () => {
+    const r = getDialogueDistribution();
+    expect(r.length).toBeGreaterThan(0);
+  });
+
+  it("each entry has name, lines, and percentage fields", () => {
+    const r = getDialogueDistribution();
+    for (const c of r) {
+      expect(typeof c.name).toBe("string");
+      expect(c.name.length).toBeGreaterThan(0);
+      expect(typeof c.lines).toBe("number");
+      expect(c.lines).toBeGreaterThanOrEqual(0);
+      expect(typeof c.percentage).toBe("number");
+    }
+  });
+
+  it("percentages sum to ~100 (within rounding tolerance)", () => {
+    const r = getDialogueDistribution();
+    const total = r.reduce((sum, c) => sum + c.percentage, 0);
+    // Rounding each percentage independently can leave the sum off by 1.
+    expect(total).toBeGreaterThanOrEqual(99);
+    expect(total).toBeLessThanOrEqual(101);
+  });
+
+  it("percentages are within 0-100 and finite", () => {
+    const r = getDialogueDistribution();
+    for (const c of r) {
+      expect(Number.isFinite(c.percentage)).toBe(true);
+      expect(c.percentage).toBeGreaterThanOrEqual(0);
+      expect(c.percentage).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it("percentage is proportional to line count relative to total", () => {
+    const r = getDialogueDistribution();
+    const totalLines = r.reduce((sum, c) => sum + c.lines, 0);
+    for (const c of r) {
+      const expected = Math.round((c.lines / totalLines) * 100);
+      expect(c.percentage).toBe(expected);
+    }
+  });
+
+  it("the character with the most lines has the highest percentage", () => {
+    const r = getDialogueDistribution();
+    const maxLines = Math.max(...r.map((c) => c.lines));
+    const top = r.find((c) => c.lines === maxLines);
+    expect(top).toBeDefined();
+    for (const c of r) {
+      expect(top!.percentage).toBeGreaterThanOrEqual(c.percentage);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6230

This PR implements the work described in issue #6230: **add unit tests for getDialogueDistribution utility**.

### Changes
- Added `frontend/src/utils/__tests__/dialogueDistribution.comprehensive.test.ts` covering:
  - Returns a non-empty list of characters.
  - Each entry has `name`, `lines`, and `percentage` with correct types and ranges.
  - Percentages sum to ~100 (within ±1 rounding tolerance, since each percentage is rounded independently).
  - All percentages are finite and within 0-100.
  - Each `percentage` equals `Math.round((lines / totalLines) * 100)` (proportional to line count).
  - The character with the most lines has the highest percentage.

### Verification
- `npx vitest run` on `dialogueDistribution.comprehensive.test.ts` — all 6 tests pass locally.
- `eslint` on the new test file — clean.

### Notes
- Test-only PR; no production source changes. The existing `getDialogueDistribution` behaviour is already correct, so the tests document and lock in that behaviour (including the independent per-entry rounding that can leave the sum at 99 or 101).

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
