### PR TITLE
test(#6229): add unit tests for getCallbacks utility

### DIFF
--- a/frontend/src/utils/__tests__/callbackDetector.test.ts
+++ b/frontend/src/utils/__tests__/callbackDetector.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { getCallbacks } from "../callbackDetector";
+
+describe("getCallbacks", () => {
+  it("returns a non-empty list of callback items", () => {
+    const r = getCallbacks();
+    expect(r.length).toBeGreaterThan(0);
+  });
+
+  it("each item has the required fields with correct types", () => {
+    const r = getCallbacks();
+    for (const c of r) {
+      expect(typeof c.id).toBe("number");
+      expect(typeof c.element).toBe("string");
+      expect(c.element.length).toBeGreaterThan(0);
+      expect(typeof c.firstAppearance).toBe("string");
+      expect(typeof c.callback).toBe("string");
+      expect(typeof c.suggestion).toBe("string");
+      expect(c.suggestion.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("ids are unique and sequential", () => {
+    const r = getCallbacks();
+    const ids = r.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toEqual([...Array(ids.length).keys()].map((i) => i + 1));
+  });
+
+  it("returns deterministic output across calls", () => {
+    const a = getCallbacks();
+    const b = getCallbacks();
+    expect(a).toEqual(b);
+  });
+
+  it("elements are unique", () => {
+    const r = getCallbacks();
+    const elements = r.map((c) => c.element);
+    expect(new Set(elements).size).toBe(elements.length);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6229

This PR implements the work described in issue #6229: **add unit tests for getCallbacks utility**.

### Changes
- Added `frontend/src/utils/__tests__/callbackDetector.test.ts` covering:
  - Returns a non-empty list of callback items.
  - Each item has the required fields (`id`, `element`, `firstAppearance`, `callback`, `suggestion`) with correct, non-empty types.
  - IDs are unique and sequential (1..N).
  - Deterministic output across repeated calls.
  - Elements are unique.

### Verification
- `npx vitest run` on `callbackDetector.test.ts` — all 5 tests pass locally.
- `eslint` on the new test file — clean.

### Notes
- Test-only PR; no production source changes. The existing `getCallbacks` behaviour is already correct, so the tests document and lock in that behaviour.

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
