### PR TITLE
test(#6226): add unit tests for calculateWritingMilestones utility

### DIFF
--- a/frontend/src/utils/__tests__/writingMilestone.test.ts
+++ b/frontend/src/utils/__tests__/writingMilestone.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { calculateWritingMilestones } from "../writingMilestone";
+
+describe("calculateWritingMilestones", () => {
+  it("counts total words from the story", () => {
+    const r = calculateWritingMilestones("one two three four", 2);
+    expect(r.totalWords).toBe(4);
+  });
+
+  it("reports completedChapters equal to chapterCount", () => {
+    const r = calculateWritingMilestones("some story", 7);
+    expect(r.completedChapters).toBe(7);
+  });
+
+  it("totalChapters is at least 10 even when chapterCount is small", () => {
+    expect(calculateWritingMilestones("x", 3).totalChapters).toBe(10);
+    expect(calculateWritingMilestones("x", 25).totalChapters).toBe(25);
+  });
+
+  it("completionPercentage is words/5000 capped at 100", () => {
+    // 250 words / 5000 = 5%
+    const story = "w ".repeat(250).trim();
+    expect(calculateWritingMilestones(story, 1).completionPercentage).toBe(5);
+
+    // 10000 words → capped at 100
+    const big = "w ".repeat(10000).trim();
+    expect(calculateWritingMilestones(big, 1).completionPercentage).toBe(100);
+  });
+
+  it("editingProgress is derived from completionPercentage + chapterCount*5, capped at 100", () => {
+    const r = calculateWritingMilestones("w ".repeat(250).trim(), 10);
+    const expected = Math.min(Math.round((5 + 10 * 5) / 2), 100);
+    expect(r.editingProgress).toBe(expected);
+  });
+
+  it("returns 0 completion for empty/whitespace-only stories", () => {
+    expect(calculateWritingMilestones("", 0).totalWords).toBe(0);
+    expect(calculateWritingMilestones("", 0).completionPercentage).toBe(0);
+    expect(calculateWritingMilestones("   \n  ", 0).totalWords).toBe(0);
+  });
+
+  it("returns the full WritingMilestone shape", () => {
+    const r = calculateWritingMilestones("a b c", 4);
+    expect(r).toHaveProperty("totalWords");
+    expect(r).toHaveProperty("completedChapters");
+    expect(r).toHaveProperty("totalChapters");
+    expect(r).toHaveProperty("completionPercentage");
+    expect(r).toHaveProperty("editingProgress");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6226

This PR implements the work described in issue #6226: **add unit tests for calculateWritingMilestones utility**.

### Changes
- Added `frontend/src/utils/__tests__/writingMilestone.test.ts` covering:
  - `totalWords` is the word count of the story.
  - `completedChapters` equals the passed `chapterCount`.
  - `totalChapters` is `Math.max(chapterCount, 10)` (at least 10 even for small chapter counts).
  - `completionPercentage` is `words / 5000` capped at 100 (verified at 5% and at the 100% cap).
  - `editingProgress` is derived from `(completionPercentage + chapterCount * 5) / 2` capped at 100.
  - Empty/whitespace-only stories → `totalWords` 0 and `completionPercentage` 0.
  - The returned object has the full `WritingMilestone` shape.

### Verification
- `npx vitest run` on `writingMilestone.test.ts` — all 7 tests pass locally.
- `eslint` on the new test file — clean.

### Notes
- Test-only PR; no production source changes. The existing `calculateWritingMilestones` behaviour is already correct, so the tests document and lock in that behaviour.

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
