### PR TITLE
test(#6225): add unit tests for generateStoryAnalytics utility

### DIFF
--- a/frontend/src/utils/__tests__/generateStoryAnalytics.test.ts
+++ b/frontend/src/utils/__tests__/generateStoryAnalytics.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { generateStoryAnalytics, refreshAnalytics } from "../storyReadingAnalytics";
+
+describe("generateStoryAnalytics - comprehensive", () => {
+  it("returns an object with all required fields for non-empty input", () => {
+    const r = generateStoryAnalytics("one two three four five six");
+    expect(r).toHaveProperty("totalViews");
+    expect(r).toHaveProperty("averageReadingTime");
+    expect(r).toHaveProperty("completionRate");
+    expect(r).toHaveProperty("likes");
+    expect(r).toHaveProperty("bookmarks");
+    expect(r).toHaveProperty("shares");
+    expect(r).toHaveProperty("engagementTrend");
+    expect(Array.isArray(r.engagementTrend)).toBe(true);
+  });
+
+  it("averageReadingTime scales with word count", () => {
+    const short = generateStoryAnalytics("a b c");
+    const long = generateStoryAnalytics("w ".repeat(500).trim());
+    expect(long.averageReadingTime).toBeGreaterThan(short.averageReadingTime);
+  });
+
+  it("engagementTrend is a non-empty ascending-ish series for non-empty input", () => {
+    const r = generateStoryAnalytics("a story");
+    expect(r.engagementTrend.length).toBeGreaterThan(0);
+    for (const v of r.engagementTrend) {
+      expect(typeof v).toBe("number");
+    }
+  });
+
+  it("is deterministic for the same input", () => {
+    const story = "a deterministic story with several words in it.";
+    expect(generateStoryAnalytics(story)).toEqual(generateStoryAnalytics(story));
+  });
+
+  it("refreshAnalytics delegates to generateStoryAnalytics", () => {
+    const story = "a story for refresh.";
+    expect(refreshAnalytics(story)).toEqual(generateStoryAnalytics(story));
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6225

This PR implements the work described in issue #6225: **add unit tests for generateStoryAnalytics utility**.

### Changes
- Added `frontend/src/utils/__tests__/generateStoryAnalytics.test.ts` covering:
  - Non-empty input returns an object with all required fields (`totalViews`, `averageReadingTime`, `completionRate`, `likes`, `bookmarks`, `shares`, `engagementTrend`), and `engagementTrend` is a non-empty numeric array.
  - `averageReadingTime` scales with word count.
  - `engagementTrend` is a non-empty numeric series for non-empty input.
  - Deterministic output for the same input.
  - `refreshAnalytics` delegates to `generateStoryAnalytics`.

### Verification
- `npx vitest run` on `generateStoryAnalytics.test.ts` — all 5 tests pass locally.
- `eslint` on the new test file — clean.

### Notes
- Test-only PR; no production source changes. The tests document and lock in the existing `generateStoryAnalytics` behaviour. The empty-input zeroing behaviour is covered by a separate, focused test file added under #6239; this file intentionally focuses on the non-empty happy path to avoid overlap.

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
