### PR TITLE
test(#6222): add unit tests for analyzeFoilCharacters utility

### DIFF
--- a/frontend/src/utils/__tests__/foilCharacterAnalyzer.test.ts
+++ b/frontend/src/utils/__tests__/foilCharacterAnalyzer.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { analyzeFoilCharacters } from "../foilCharacterAnalyzer";
+
+describe("analyzeFoilCharacters", () => {
+  it("returns a non-empty list of foil pairs", () => {
+    const r = analyzeFoilCharacters();
+    expect(r.length).toBeGreaterThan(0);
+  });
+
+  it("each pair has the required FoilPair fields with non-empty strings", () => {
+    const r = analyzeFoilCharacters();
+    for (const p of r) {
+      expect(typeof p.protagonist).toBe("string");
+      expect(p.protagonist.length).toBeGreaterThan(0);
+      expect(typeof p.foil).toBe("string");
+      expect(p.foil.length).toBeGreaterThan(0);
+      expect(typeof p.contrast).toBe("string");
+      expect(p.contrast.length).toBeGreaterThan(0);
+      expect(typeof p.suggestion).toBe("string");
+      expect(p.suggestion.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("protagonist and foil are distinct within each pair", () => {
+    const r = analyzeFoilCharacters();
+    for (const p of r) {
+      expect(p.protagonist).not.toBe(p.foil);
+    }
+  });
+
+  it("returns deterministic output across calls", () => {
+    expect(analyzeFoilCharacters()).toEqual(analyzeFoilCharacters());
+  });
+
+  it("protagonists are unique across pairs", () => {
+    const r = analyzeFoilCharacters();
+    const names = r.map((p) => p.protagonist);
+    expect(new Set(names).size).toBe(names.length);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6222

This PR implements the work described in issue #6222: **add unit tests for analyzeFoilCharacters utility**.

### Changes
- Added `frontend/src/utils/__tests__/foilCharacterAnalyzer.test.ts` covering:
  - Returns a non-empty list of foil pairs.
  - Each pair has the required `FoilPair` fields (`protagonist`, `foil`, `contrast`, `suggestion`) with non-empty strings.
  - `protagonist` and `foil` are distinct within each pair.
  - Deterministic output across repeated calls.
  - Protagonists are unique across pairs.

### Verification
- `npx vitest run` on `foilCharacterAnalyzer.test.ts` — all 5 tests pass locally.
- `eslint` on the new test file — clean.

### Notes
- Test-only PR; no production source changes. The existing `analyzeFoilCharacters` behaviour is already correct, so the tests document and lock in that behaviour.

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
