### PR TITLE
test(#6221): add unit tests for getEndingMetrics utility

### DIFF
--- a/frontend/src/utils/__tests__/endingSatisfaction.test.ts
+++ b/frontend/src/utils/__tests__/endingSatisfaction.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { getEndingMetrics } from "../endingSatisfaction";
+
+describe("getEndingMetrics", () => {
+  it("returns a non-empty list of ending metrics", () => {
+    const r = getEndingMetrics();
+    expect(r.length).toBeGreaterThan(0);
+  });
+
+  it("each metric has the required fields with correct types", () => {
+    const r = getEndingMetrics();
+    for (const m of r) {
+      expect(typeof m.title).toBe("string");
+      expect(m.title.length).toBeGreaterThan(0);
+      expect(typeof m.score).toBe("number");
+      expect(typeof m.description).toBe("string");
+      expect(m.description.length).toBeGreaterThan(0);
+      expect(typeof m.suggestion).toBe("string");
+      expect(m.suggestion.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("all scores are finite and within 0-100", () => {
+    const r = getEndingMetrics();
+    for (const m of r) {
+      expect(Number.isFinite(m.score)).toBe(true);
+      expect(m.score).toBeGreaterThanOrEqual(0);
+      expect(m.score).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it("titles are unique", () => {
+    const r = getEndingMetrics();
+    const titles = r.map((m) => m.title);
+    expect(new Set(titles).size).toBe(titles.length);
+  });
+
+  it("returns deterministic output across calls", () => {
+    expect(getEndingMetrics()).toEqual(getEndingMetrics());
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6221

This PR implements the work described in issue #6221: **add unit tests for getEndingMetrics utility**.

### Changes
- Added `frontend/src/utils/__tests__/endingSatisfaction.test.ts` covering:
  - Returns a non-empty list of ending metrics.
  - Each metric has the required fields (`title`, `score`, `description`, `suggestion`) with correct, non-empty types.
  - All `score`s are finite and within 0-100.
  - Titles are unique.
  - Deterministic output across repeated calls.

### Verification
- `npx vitest run` on `endingSatisfaction.test.ts` — all 5 tests pass locally.
- `eslint` on the new test file — clean.

### Notes
- Test-only PR; no production source changes. The existing `getEndingMetrics` behaviour is already correct, so the tests document and lock in that behaviour.

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
