### PR TITLE
test(#6220): add unit tests for analyzeStorySuspense utility

### DIFF
--- a/frontend/src/utils/__tests__/analyzeStorySuspense.test.ts
+++ b/frontend/src/utils/__tests__/analyzeStorySuspense.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import {
+  analyzeStorySuspense,
+  refreshSuspenseAnalysis,
+} from "../storySuspenseAnalyzer";
+
+const VALID_STATUSES = ["High", "Medium", "Low"] as const;
+
+describe("analyzeStorySuspense", () => {
+  it("returns a zeroed analysis for empty/whitespace input", () => {
+    const expected = { overallScore: 0, sections: [] };
+    expect(analyzeStorySuspense("")).toEqual(expected);
+    expect(analyzeStorySuspense("   \n  ")).toEqual(expected);
+  });
+
+  it("returns an overall score and non-empty sections for non-empty input", () => {
+    const r = analyzeStorySuspense("A tense opening scene.");
+    expect(typeof r.overallScore).toBe("number");
+    expect(r.sections.length).toBeGreaterThan(0);
+  });
+
+  it("overallScore is finite and within 0-100 for non-empty input", () => {
+    const r = analyzeStorySuspense("A story with some suspense.");
+    expect(Number.isFinite(r.overallScore)).toBe(true);
+    expect(r.overallScore).toBeGreaterThanOrEqual(0);
+    expect(r.overallScore).toBeLessThanOrEqual(100);
+  });
+
+  it("each section has the required fields", () => {
+    const r = analyzeStorySuspense("A story to analyze.");
+    for (const s of r.sections) {
+      expect(typeof s.id).toBe("number");
+      expect(typeof s.title).toBe("string");
+      expect(s.title.length).toBeGreaterThan(0);
+      expect(typeof s.tensionScore).toBe("number");
+      expect(VALID_STATUSES).toContain(s.status);
+      expect(typeof s.observation).toBe("string");
+      expect(s.observation.length).toBeGreaterThan(0);
+      expect(typeof s.suggestion).toBe("string");
+      expect(s.suggestion.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("section ids are unique and sequential", () => {
+    const r = analyzeStorySuspense("A story.");
+    const ids = r.sections.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toEqual([...Array(ids.length).keys()].map((i) => i + 1));
+  });
+
+  it("tensionScores are finite and within 0-100", () => {
+    const r = analyzeStorySuspense("A story.");
+    for (const s of r.sections) {
+      expect(Number.isFinite(s.tensionScore)).toBe(true);
+      expect(s.tensionScore).toBeGreaterThanOrEqual(0);
+      expect(s.tensionScore).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it("is deterministic for the same input", () => {
+    const story = "A deterministic suspenseful story.";
+    expect(analyzeStorySuspense(story)).toEqual(analyzeStorySuspense(story));
+  });
+});
+
+describe("refreshSuspenseAnalysis", () => {
+  it("delegates to analyzeStorySuspense", () => {
+    const story = "A story to refresh the suspense analysis for.";
+    expect(refreshSuspenseAnalysis(story)).toEqual(analyzeStorySuspense(story));
+  });
+
+  it("returns a zeroed analysis for empty input", () => {
+    expect(refreshSuspenseAnalysis("")).toEqual({ overallScore: 0, sections: [] });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6220

This PR implements the work described in issue #6220: **add unit tests for analyzeStorySuspense utility**.

### Changes
- Added `frontend/src/utils/__tests__/analyzeStorySuspense.test.ts` covering:
  - Empty/whitespace input → `{ overallScore: 0, sections: [] }`.
  - Non-empty input → an `overallScore` plus a non-empty `sections` array.
  - `overallScore` is finite and within 0-100.
  - Each section has the required fields (`id`, `title`, `tensionScore`, `status`, `observation`, `suggestion`); `status` is one of "High"/"Medium"/"Low".
  - Section `id`s are unique and sequential (1..N).
  - `tensionScore`s are finite and within 0-100.
  - Deterministic output for the same input.
  - `refreshSuspenseAnalysis` delegates to `analyzeStorySuspense` and returns the zeroed analysis for empty input.

### Verification
- `npx vitest run` on `analyzeStorySuspense.test.ts` — all 9 tests pass locally.
- `eslint` on the new test file — clean.

### Notes
- Test-only PR; no production source changes. The tests document and lock in the existing `analyzeStorySuspense` behaviour. The derivation of `overallScore` from sections is covered by a separate, focused test file added under #6238; this file intentionally scopes to the structural/behavioural contract to avoid overlap.

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
