### PR TITLE
test(#6217): add unit tests for generateChecklist utility in storyChecklist

### DIFF
--- a/frontend/src/utils/__tests__/storyChecklist.test.ts
+++ b/frontend/src/utils/__tests__/storyChecklist.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { generateChecklist } from "../storyChecklist";
+
+describe("generateChecklist", () => {
+  it("returns a checklist with all six items", () => {
+    const r = generateChecklist({ title: "", content: "" });
+    expect(r.map((c) => c.id)).toEqual([
+      "title",
+      "characters",
+      "setting",
+      "conflict",
+      "climax",
+      "conclusion",
+    ]);
+  });
+
+  it("each item has id, label, and a boolean completed", () => {
+    const r = generateChecklist({ title: "T", content: "c" });
+    for (const c of r) {
+      expect(typeof c.id).toBe("string");
+      expect(c.id.length).toBeGreaterThan(0);
+      expect(typeof c.label).toBe("string");
+      expect(c.label.length).toBeGreaterThan(0);
+      expect(typeof c.completed).toBe("boolean");
+    }
+  });
+
+  it("ids are unique", () => {
+    const r = generateChecklist({ title: "", content: "" });
+    const ids = r.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("marks all items complete for a fully-formed story", () => {
+    const story = {
+      title: "The Hero's Journey",
+      content:
+        "The hero met a friend in the city. A villain caused a problem and a fight broke out. The battle was the climax, and the story had a happy ending.",
+    };
+    const r = generateChecklist(story);
+    expect(r.every((c) => c.completed)).toBe(true);
+  });
+
+  it("marks only the title complete for an empty-content story with a title", () => {
+    const r = generateChecklist({ title: "My Story", content: "" });
+    const byId = Object.fromEntries(r.map((c) => [c.id, c.completed]));
+    expect(byId.title).toBe(true);
+    expect(byId.characters).toBe(false);
+    expect(byId.setting).toBe(false);
+    expect(byId.conflict).toBe(false);
+    expect(byId.climax).toBe(false);
+    expect(byId.conclusion).toBe(false);
+  });
+
+  it("marks title incomplete for whitespace-only title", () => {
+    const r = generateChecklist({ title: "   ", content: "hero city fight battle finally ended" });
+    expect(r.find((c) => c.id === "title")!.completed).toBe(false);
+  });
+
+  it("detects characters/setting/conflict/climax/conclusion case-insensitively", () => {
+    const r = generateChecklist({
+      title: "T",
+      content: "HERO in the CITY faced a PROBLEM; the BATTLE was the CLIMAX and it ENDED.",
+    });
+    expect(r.find((c) => c.id === "characters")!.completed).toBe(true);
+    expect(r.find((c) => c.id === "setting")!.completed).toBe(true);
+    expect(r.find((c) => c.id === "conflict")!.completed).toBe(true);
+    expect(r.find((c) => c.id === "climax")!.completed).toBe(true);
+    expect(r.find((c) => c.id === "conclusion")!.completed).toBe(true);
+  });
+
+  it("is deterministic for the same input", () => {
+    const story = { title: "T", content: "A story with a hero." };
+    expect(generateChecklist(story)).toEqual(generateChecklist(story));
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6217

This PR implements the work described in issue #6217: **add unit tests for generateChecklist utility in storyChecklist**.

### Changes
- Added `frontend/src/utils/__tests__/storyChecklist.test.ts` covering:
  - Returns a checklist with all six items in order: `title`, `characters`, `setting`, `conflict`, `climax`, `conclusion`.
  - Each item has `id`, `label`, and a boolean `completed`.
  - `id`s are unique.
  - A fully-formed story marks all items complete.
  - An empty-content story with a title marks only `title` complete.
  - A whitespace-only title marks `title` incomplete.
  - Keyword detection (characters/setting/conflict/climax/conclusion) is case-insensitive.
  - Deterministic output for the same input.

### Verification
- `npx vitest run` on `storyChecklist.test.ts` — all 8 tests pass locally.
- `eslint` on the new test file — clean.

### Notes
- Test-only PR; no production source changes. The existing `generateChecklist` behaviour is already correct, so the tests document and lock in that behaviour.

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
