### PR TITLE
test(#6216): add unit tests for estimateSceneDurations utility

### DIFF
--- a/frontend/src/utils/__tests__/estimateSceneDurations.test.ts
+++ b/frontend/src/utils/__tests__/estimateSceneDurations.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import {
+  estimateSceneDurations,
+  refreshSceneDurations,
+} from "../storySceneDurationEstimator";
+
+describe("estimateSceneDurations", () => {
+  it("returns empty scenes and 0 total for empty/whitespace input", () => {
+    const expected = { scenes: [], totalReadingTime: 0 };
+    expect(estimateSceneDurations("")).toEqual(expected);
+    expect(estimateSceneDurations("   \n  ")).toEqual(expected);
+  });
+
+  it("splits the story into scenes by blank lines", () => {
+    const story = "Scene one text here.\n\nScene two text here.";
+    const r = estimateSceneDurations(story);
+    expect(r.scenes.length).toBe(2);
+    expect(r.scenes[0].id).toBe(1);
+    expect(r.scenes[1].id).toBe(2);
+    expect(r.scenes[0].title).toBe("Scene 1");
+    expect(r.scenes[1].title).toBe("Scene 2");
+  });
+
+  it("computes wordCount per scene", () => {
+    const r = estimateSceneDurations("one two three\n\nfour five");
+    expect(r.scenes[0].wordCount).toBe(3);
+    expect(r.scenes[1].wordCount).toBe(2);
+  });
+
+  it("readingTime is at least 1 minute per non-empty scene", () => {
+    const r = estimateSceneDurations("tiny\n\nanother");
+    for (const s of r.scenes) {
+      expect(s.readingTime).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("readingTime scales with word count (200 wpm)", () => {
+    const big = "w ".repeat(250).trim();
+    const r = estimateSceneDurations(big);
+    expect(r.scenes[0].readingTime).toBe(2);
+  });
+
+  it("totalReadingTime is the sum of scene reading times", () => {
+    const r = estimateSceneDurations("a b c\n\nd e f g h");
+    const sum = r.scenes.reduce((acc, s) => acc + s.readingTime, 0);
+    expect(r.totalReadingTime).toBe(sum);
+  });
+
+  it("ignores blank/whitespace-only scenes", () => {
+    const r = estimateSceneDurations("real scene\n\n   \n\nanother real scene");
+    expect(r.scenes.length).toBe(2);
+  });
+
+  it("each scene has id, title, wordCount, readingTime", () => {
+    const r = estimateSceneDurations("a story");
+    for (const s of r.scenes) {
+      expect(typeof s.id).toBe("number");
+      expect(typeof s.title).toBe("string");
+      expect(typeof s.wordCount).toBe("number");
+      expect(typeof s.readingTime).toBe("number");
+    }
+  });
+});
+
+describe("refreshSceneDurations", () => {
+  it("delegates to estimateSceneDurations", () => {
+    const story = "A story to refresh.";
+    expect(refreshSceneDurations(story)).toEqual(estimateSceneDurations(story));
+  });
+
+  it("returns the empty result for empty input", () => {
+    expect(refreshSceneDurations("")).toEqual({ scenes: [], totalReadingTime: 0 });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6216

This PR implements the work described in issue #6216: **add unit tests for estimateSceneDurations utility**.

### Changes
- Added `frontend/src/utils/__tests__/estimateSceneDurations.test.ts` covering:
  - Empty/whitespace input → `{ scenes: [], totalReadingTime: 0 }`.
  - Splits the story into scenes by blank lines, with sequential `id`s and `title`s ("Scene 1", "Scene 2", ...).
  - `wordCount` per scene matches the trimmed word count.
  - `readingTime` is at least 1 minute per non-empty scene.
  - `readingTime` scales with word count (200 wpm: 250 words → 2 minutes).
  - `totalReadingTime` is the sum of scene reading times.
  - Blank/whitespace-only scenes are ignored.
  - Each scene has the required `SceneDuration` shape.
  - `refreshSceneDurations` delegates to `estimateSceneDurations` and returns the empty result for empty input.

### Verification
- `npx vitest run` on `estimateSceneDurations.test.ts` — all 10 tests pass locally.
- `eslint` on the new test file — clean.

### Notes
- Test-only PR; no production source changes. The tests document and lock in the existing `estimateSceneDurations` behaviour. A separate, focused zero-word-scene guard is covered by a test file added under #6247; this file scopes to the structural/behavioural contract to avoid overlap.

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
