### PR TITLE
test(#6210): add unit tests for analyzePlotGaps utility

### DIFF
--- a/frontend/src/utils/__tests__/plotGapAnalyzer.test.ts
+++ b/frontend/src/utils/__tests__/plotGapAnalyzer.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { analyzePlotGaps } from "../plotGapAnalyzer";
+
+const VALID_SEVERITIES = ["Low", "Medium", "High"] as const;
+
+describe("analyzePlotGaps", () => {
+  it("returns a 'No Issues' finding for an empty/whitespace story", () => {
+    const r = analyzePlotGaps("");
+    expect(r.length).toBe(1);
+    expect(r[0].type).toBe("No Issues");
+    expect(r[0].severity).toBe("Low");
+  });
+
+  it("returns a 'No Issues' finding for a story with no triggers", () => {
+    const r = analyzePlotGaps("A calm story about daily life and routine.");
+    expect(r.length).toBe(1);
+    expect(r[0].type).toBe("No Issues");
+  });
+
+  it("detects an Abrupt Transition when 'suddenly' is present", () => {
+    const r = analyzePlotGaps("Suddenly, everything changed.");
+    expect(r.some((f) => f.type === "Abrupt Transition")).toBe(true);
+  });
+
+  it("detects Abrupt Transition case-insensitively", () => {
+    const r = analyzePlotGaps("SUDDENLY the scene shifted.");
+    expect(r.some((f) => f.type === "Abrupt Transition")).toBe(true);
+  });
+
+  it("detects an Unresolved Plot when 'mystery' is present without 'solved'", () => {
+    const r = analyzePlotGaps("A deep mystery unfolded in the woods.");
+    expect(r.some((f) => f.type === "Unresolved Plot")).toBe(true);
+    expect(r.some((f) => f.type === "Unresolved Plot" && f.severity === "High")).toBe(true);
+  });
+
+  it("does NOT flag an Unresolved Plot when the mystery is solved", () => {
+    const r = analyzePlotGaps("The mystery was eventually solved by the detective.");
+    expect(r.some((f) => f.type === "Unresolved Plot")).toBe(false);
+  });
+
+  it("detects a Location Gap with castle+forest and no travel", () => {
+    const r = analyzePlotGaps("They stood at the castle then appeared in the forest.");
+    expect(r.some((f) => f.type === "Location Gap")).toBe(true);
+  });
+
+  it("does NOT flag a Location Gap when travel is mentioned", () => {
+    const r = analyzePlotGaps("They traveled from the castle to the forest.");
+    expect(r.some((f) => f.type === "Location Gap")).toBe(false);
+  });
+
+  it("each finding has the required fields and a valid severity", () => {
+    const r = analyzePlotGaps("suddenly a mystery at the castle and the forest");
+    for (const f of r) {
+      expect(typeof f.id).toBe("number");
+      expect(typeof f.type).toBe("string");
+      expect(f.type.length).toBeGreaterThan(0);
+      expect(VALID_SEVERITIES).toContain(f.severity);
+      expect(typeof f.description).toBe("string");
+      expect(f.description.length).toBeGreaterThan(0);
+      expect(typeof f.suggestion).toBe("string");
+      expect(f.suggestion.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("finding ids are unique and sequential", () => {
+    const r = analyzePlotGaps("suddenly a mystery at the castle and the forest");
+    const ids = r.map((f) => f.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toEqual([...Array(ids.length).keys()].map((i) => i + 1));
+  });
+
+  it("is deterministic for the same input", () => {
+    const story = "suddenly a mystery at the castle and the forest";
+    expect(analyzePlotGaps(story)).toEqual(analyzePlotGaps(story));
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6210

This PR implements the work described in issue #6210: **add unit tests for analyzePlotGaps utility**.

### Changes
- Added `frontend/src/utils/__tests__/plotGapAnalyzer.test.ts` covering:
  - Empty/whitespace story → a single "No Issues" finding.
  - A story with no triggers → "No Issues".
  - "suddenly" (case-insensitive) → "Abrupt Transition" finding.
  - "mystery" without "solved" → "Unresolved Plot" (High severity).
  - "mystery" with "solved" → no "Unresolved Plot" finding.
  - "castle" + "forest" without "travel" → "Location Gap" finding.
  - "castle" + "forest" with "travel" → no "Location Gap".
  - Each finding has the required fields and a valid severity ("Low"/"Medium"/"High").
  - Finding `id`s are unique and sequential.
  - Deterministic output for the same input.

### Verification
- `npx vitest run` on `plotGapAnalyzer.test.ts` — all 11 tests pass locally.
- `eslint` on the new test file — clean.

### Notes
- Test-only PR; no production source changes. The existing `analyzePlotGaps` behaviour is already correct, so the tests document and lock in that behaviour (including the case-insensitive keyword detection and the "solved"/"travel" suppression conditions).

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
