### PR TITLE
test(#6209): add unit tests for analyzeEmotionJourney utility

### DIFF
--- a/frontend/src/utils/__tests__/emotionAnalyzer.test.ts
+++ b/frontend/src/utils/__tests__/emotionAnalyzer.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { analyzeEmotionJourney } from "../emotionAnalyzer";
+
+describe("analyzeEmotionJourney", () => {
+  it("returns an empty array for an empty story", () => {
+    expect(analyzeEmotionJourney("")).toEqual([]);
+  });
+
+  it("returns an empty array for a whitespace-only story", () => {
+    expect(analyzeEmotionJourney("   \n\n   \n   ")).toEqual([]);
+  });
+
+  it("splits a single-scene story into one emotion point", () => {
+    const r = analyzeEmotionJourney("A happy scene with hope.");
+    expect(r).toHaveLength(1);
+    expect(r[0].scene).toBe(1);
+  });
+
+  it("splits by blank lines into sequential scenes", () => {
+    const r = analyzeEmotionJourney("Scene one.\n\nScene two.\n\nScene three.");
+    expect(r.map((p) => p.scene)).toEqual([1, 2, 3]);
+  });
+
+  it("counts joy-related keywords case-insensitively", () => {
+    const r = analyzeEmotionJourney("They were HAPPY and laughed and smiled.");
+    expect(r[0].joy).toBeGreaterThanOrEqual(2);
+  });
+
+  it("counts each emotion category independently", () => {
+    const r = analyzeEmotionJourney("She was happy but felt fear in the dark.");
+    expect(r[0].joy).toBeGreaterThanOrEqual(1);
+    expect(r[0].fear).toBeGreaterThanOrEqual(2);
+  });
+
+  it("returns 0 for categories with no matching keywords", () => {
+    const r = analyzeEmotionJourney("A perfectly calm and ordinary scene.");
+    for (const key of ["joy", "fear", "sadness", "anger", "hope", "suspense"] as const) {
+      expect(r[0][key]).toBe(0);
+    }
+  });
+
+  it("all emotion values are non-negative finite integers", () => {
+    const r = analyzeEmotionJourney("A scene with joy and fear and anger.");
+    for (const p of r) {
+      for (const key of ["joy", "fear", "sadness", "anger", "hope", "suspense"] as const) {
+        expect(Number.isInteger(p[key])).toBe(true);
+        expect(p[key]).toBeGreaterThanOrEqual(0);
+      }
+    }
+  });
+
+  it("ignores blank/whitespace-only scenes", () => {
+    const r = analyzeEmotionJourney("real scene\n\n   \n\nanother scene");
+    expect(r).toHaveLength(2);
+  });
+
+  it("is deterministic for the same input", () => {
+    const story = "A happy scene.\n\nA sad scene with fear.";
+    expect(analyzeEmotionJourney(story)).toEqual(analyzeEmotionJourney(story));
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6209

This PR implements the work described in issue #6209: **add unit tests for analyzeEmotionJourney utility**.

### Changes
- Added `frontend/src/utils/__tests__/emotionAnalyzer.test.ts` covering:
  - Empty/whitespace-only story → `[]`.
  - A single-scene story → one emotion point with `scene: 1`.
  - Blank-line splitting into sequential `scene` numbers.
  - Joy keywords counted case-insensitively.
  - Each emotion category counted independently.
  - Categories with no matching keywords return 0.
  - All emotion values are non-negative finite integers.
  - Blank/whitespace-only scenes are ignored.
  - Deterministic output for the same input.

### Verification
- `npx vitest run` on `emotionAnalyzer.test.ts` — all 10 tests pass locally.
- `eslint` on the new test file — clean.

### Notes
- Test-only PR; no production source changes. The existing `analyzeEmotionJourney` behaviour is already correct, so the tests document and lock in that behaviour (including the blank-line scene splitting and the six emotion keyword categories).

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
