### PR TITLE
test(#6203): add unit tests for analyzeVocabulary utility

### DIFF
--- a/frontend/src/utils/__tests__/storyVocabularyGrowthTracker.test.ts
+++ b/frontend/src/utils/__tests__/storyVocabularyGrowthTracker.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import {
+  analyzeVocabulary,
+  refreshVocabularyAnalysis,
+} from "../storyVocabularyGrowthTracker";
+
+describe("analyzeVocabulary", () => {
+  it("returns zeroed stats for empty/whitespace input", () => {
+    const expected = {
+      totalWords: 0,
+      uniqueWords: 0,
+      diversityScore: 0,
+      overusedWords: [],
+      growthHistory: [],
+    };
+    expect(analyzeVocabulary("")).toEqual(expected);
+    expect(analyzeVocabulary("   \n  ")).toEqual(expected);
+  });
+
+  it("counts total words excluding stop words", () => {
+    const r = analyzeVocabulary("the quick brown fox");
+    // "the" is a stop word; remaining: quick, brown, fox
+    expect(r.totalWords).toBe(3);
+  });
+
+  it("uniqueWords equals the number of distinct non-stop words", () => {
+    const r = analyzeVocabulary("cat dog cat bird");
+    // non-stop: cat, dog, cat, bird → distinct: cat, dog, bird
+    expect(r.uniqueWords).toBe(3);
+  });
+
+  it("diversityScore is 100 when every word is unique", () => {
+    const r = analyzeVocabulary("apple banana cherry");
+    expect(r.diversityScore).toBe(100);
+  });
+
+  it("diversityScore is a 0-100 percentage", () => {
+    const r = analyzeVocabulary("apple apple banana");
+    expect(r.diversityScore).toBeGreaterThanOrEqual(0);
+    expect(r.diversityScore).toBeLessThanOrEqual(100);
+  });
+
+  it("is case-insensitive (The/THE/the all treated as the stop word)", () => {
+    const r = analyzeVocabulary("The THE the cat");
+    expect(r.totalWords).toBe(1);
+    expect(r.uniqueWords).toBe(1);
+  });
+
+  it("flags words used >= 3 times as overused", () => {
+    const r = analyzeVocabulary("good good good bad bad bad");
+    const overused = r.overusedWords.map((o) => o.word);
+    expect(overused).toContain("good");
+    expect(overused).toContain("bad");
+  });
+
+  it("provides alternatives for known overused words", () => {
+    const r = analyzeVocabulary("good good good");
+    const good = r.overusedWords.find((o) => o.word === "good");
+    expect(good).toBeDefined();
+    expect(good!.alternatives.length).toBeGreaterThan(0);
+  });
+
+  it("returns empty alternatives for unknown overused words", () => {
+    const r = analyzeVocabulary("xyzzy xyzzy xyzzy");
+    const x = r.overusedWords.find((o) => o.word === "xyzzy");
+    expect(x).toBeDefined();
+    expect(x!.alternatives).toEqual([]);
+  });
+
+  it("limits overused words to at most 5", () => {
+    const story = Array.from({ length: 6 }, (_, i) =>
+      `word${i} `.repeat(3)
+    ).join(" ");
+    expect(analyzeVocabulary(story).overusedWords.length).toBeLessThanOrEqual(5);
+  });
+
+  it("growthHistory includes a Current entry with the current unique-word count", () => {
+    const r = analyzeVocabulary("apple banana cherry");
+    const current = r.growthHistory.find((g) => g.story === "Current");
+    expect(current).toBeDefined();
+    expect(current!.uniqueWords).toBe(3);
+  });
+
+  it("is deterministic for the same input", () => {
+    const story = "good good bad bad cat dog bird";
+    expect(analyzeVocabulary(story)).toEqual(analyzeVocabulary(story));
+  });
+});
+
+describe("refreshVocabularyAnalysis", () => {
+  it("delegates to analyzeVocabulary", () => {
+    const story = "apple banana cherry";
+    expect(refreshVocabularyAnalysis(story)).toEqual(analyzeVocabulary(story));
+  });
+
+  it("returns zeroed stats for empty input", () => {
+    expect(refreshVocabularyAnalysis("")).toEqual(analyzeVocabulary(""));
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6203

This PR implements the work described in issue #6203: **add unit tests for analyzeVocabulary utility** (in `storyVocabularyGrowthTracker`).

### Changes
- Added `frontend/src/utils/__tests__/storyVocabularyGrowthTracker.test.ts` covering:
  - Empty/whitespace input → zeroed stats (`totalWords: 0`, `uniqueWords: 0`, `diversityScore: 0`, empty `overusedWords`/`growthHistory`).
  - `totalWords` counts non-stop words.
  - `uniqueWords` equals the number of distinct non-stop words.
  - `diversityScore` is 100 for all-unique words and is always a 0-100 percentage.
  - Stop-word removal is case-insensitive ("The"/"THE"/"the").
  - Words used ≥ 3 times are flagged as overused.
  - Alternatives are provided for known overused words ("good") and empty for unknown ones.
  - At most 5 overused words are returned.
  - `growthHistory` includes a "Current" entry with the current unique-word count.
  - Deterministic output.
  - `refreshVocabularyAnalysis` delegates to `analyzeVocabulary`.

### Verification
- `npx vitest run` on `storyVocabularyGrowthTracker.test.ts` — all 14 tests pass locally.
- `eslint` on the new test file — clean.

### Notes
- Test-only PR; no production source changes. The existing `analyzeVocabulary` behaviour is already correct, so the tests document and lock in that behaviour. The verification command from the issue (`cd frontend && pnpm exec vitest run src/utils/__tests__/storyVocabularyGrowthTracker.test.ts`) now succeeds.

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
