### PR TITLE
test(#6201): add unit tests for analyzeConflictResolution utility

### DIFF
--- a/frontend/src/utils/__tests__/storyConflictResolutionEvaluator.test.ts
+++ b/frontend/src/utils/__tests__/storyConflictResolutionEvaluator.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import {
+  analyzeConflictResolution,
+  refreshConflictAnalysis,
+} from "../storyConflictResolutionEvaluator";
+
+const VALID_TYPES = ["Primary", "Secondary"] as const;
+const VALID_RESOLUTIONS = ["Resolved", "Partially Resolved", "Unresolved"] as const;
+
+describe("analyzeConflictResolution", () => {
+  it("returns [] for empty/whitespace input", () => {
+    expect(analyzeConflictResolution("")).toEqual([]);
+    expect(analyzeConflictResolution("   \n  ")).toEqual([]);
+  });
+
+  it("returns a non-empty list of conflicts for non-empty input", () => {
+    const r = analyzeConflictResolution("A story with conflict.");
+    expect(r.length).toBeGreaterThan(0);
+  });
+
+  it("each conflict has the required fields with valid type/resolution", () => {
+    const r = analyzeConflictResolution("A story.");
+    for (const c of r) {
+      expect(typeof c.id).toBe("number");
+      expect(typeof c.title).toBe("string");
+      expect(c.title.length).toBeGreaterThan(0);
+      expect(VALID_TYPES).toContain(c.type);
+      expect(VALID_RESOLUTIONS).toContain(c.resolution);
+      expect(typeof c.description).toBe("string");
+      expect(c.description.length).toBeGreaterThan(0);
+      expect(typeof c.suggestion).toBe("string");
+      expect(c.suggestion.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("conflict ids are unique and sequential", () => {
+    const r = analyzeConflictResolution("A story.");
+    const ids = r.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toEqual([...Array(ids.length).keys()].map((i) => i + 1));
+  });
+
+  it("includes exactly one Primary conflict", () => {
+    const r = analyzeConflictResolution("A story.");
+    const primaries = r.filter((c) => c.type === "Primary");
+    expect(primaries.length).toBe(1);
+  });
+
+  it("is deterministic for the same input", () => {
+    const story = "A deterministic story.";
+    expect(analyzeConflictResolution(story)).toEqual(analyzeConflictResolution(story));
+  });
+});
+
+describe("refreshConflictAnalysis", () => {
+  it("delegates to analyzeConflictResolution", () => {
+    const story = "A story to refresh.";
+    expect(refreshConflictAnalysis(story)).toEqual(analyzeConflictResolution(story));
+  });
+
+  it("returns [] for empty input", () => {
+    expect(refreshConflictAnalysis("")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6201

This PR implements the work described in issue #6201: **add unit tests for analyzeConflictResolution utility**.

### Changes
- Added `frontend/src/utils/__tests__/storyConflictResolutionEvaluator.test.ts` covering:
  - Empty/whitespace input → `[]`.
  - Non-empty input → a non-empty list of conflicts.
  - Each conflict has the required fields (`id`, `title`, `type`, `resolution`, `description`, `suggestion`); `type` is "Primary"/"Secondary" and `resolution` is "Resolved"/"Partially Resolved"/"Unresolved".
  - Conflict `id`s are unique and sequential (1..N).
  - Exactly one Primary conflict.
  - Deterministic output.
  - `refreshConflictAnalysis` delegates to `analyzeConflictResolution` and returns `[]` for empty input.

### Verification
- `npx vitest run` on `storyConflictResolutionEvaluator.test.ts` — all 8 tests pass locally.
- `eslint` on the new test file — clean.

### Notes
- Test-only PR; no production source changes. The existing `analyzeConflictResolution` behaviour is already correct, so the tests document and lock in that behaviour.

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
