### PR TITLE
test(#6200): add unit tests for analyzeStoryForeshadowing utility

### DIFF
--- a/frontend/src/utils/__tests__/storyForeshadowingAnalyzer.test.ts
+++ b/frontend/src/utils/__tests__/storyForeshadowingAnalyzer.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import {
+  analyzeStoryForeshadowing,
+  refreshForeshadowingAnalysis,
+} from "../storyForeshadowingAnalyzer";
+
+const VALID_STATUSES = ["Strong", "Weak", "Unresolved"] as const;
+
+describe("analyzeStoryForeshadowing", () => {
+  it("returns [] for empty/whitespace input", () => {
+    expect(analyzeStoryForeshadowing("")).toEqual([]);
+    expect(analyzeStoryForeshadowing("   \n  ")).toEqual([]);
+  });
+
+  it("returns a non-empty list of items for non-empty input", () => {
+    const r = analyzeStoryForeshadowing("A story with foreshadowing.");
+    expect(r.length).toBeGreaterThan(0);
+  });
+
+  it("each item has the required fields with a valid status", () => {
+    const r = analyzeStoryForeshadowing("A story.");
+    for (const f of r) {
+      expect(typeof f.id).toBe("number");
+      expect(typeof f.hint).toBe("string");
+      expect(f.hint.length).toBeGreaterThan(0);
+      expect(typeof f.relatedEvent).toBe("string");
+      expect(f.relatedEvent.length).toBeGreaterThan(0);
+      expect(VALID_STATUSES).toContain(f.status);
+      expect(typeof f.suggestion).toBe("string");
+      expect(f.suggestion.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("item ids are unique and sequential", () => {
+    const r = analyzeStoryForeshadowing("A story.");
+    const ids = r.map((f) => f.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toEqual([...Array(ids.length).keys()].map((i) => i + 1));
+  });
+
+  it("includes at least one Unresolved item (for the 'strange necklace')", () => {
+    const r = analyzeStoryForeshadowing("A story.");
+    expect(r.some((f) => f.status === "Unresolved")).toBe(true);
+  });
+
+  it("is deterministic for the same input", () => {
+    const story = "A deterministic story.";
+    expect(analyzeStoryForeshadowing(story)).toEqual(analyzeStoryForeshadowing(story));
+  });
+});
+
+describe("refreshForeshadowingAnalysis", () => {
+  it("delegates to analyzeStoryForeshadowing", () => {
+    const story = "A story to refresh.";
+    expect(refreshForeshadowingAnalysis(story)).toEqual(analyzeStoryForeshadowing(story));
+  });
+
+  it("returns [] for empty input", () => {
+    expect(refreshForeshadowingAnalysis("")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6200

This PR implements the work described in issue #6200: **add unit tests for analyzeStoryForeshadowing utility**.

### Changes
- Added `frontend/src/utils/__tests__/storyForeshadowingAnalyzer.test.ts` covering:
  - Empty/whitespace input → `[]`.
  - Non-empty input → a non-empty list of items.
  - Each item has the required fields (`id`, `hint`, `relatedEvent`, `status`, `suggestion`); `status` is "Strong"/"Weak"/"Unresolved".
  - Item `id`s are unique and sequential (1..N).
  - At least one Unresolved item.
  - Deterministic output.
  - `refreshForeshadowingAnalysis` delegates to `analyzeStoryForeshadowing` and returns `[]` for empty input.

### Verification
- `npx vitest run` on `storyForeshadowingAnalyzer.test.ts` — all 8 tests pass locally.
- `eslint` on the new test file — clean.

### Notes
- Test-only PR; no production source changes. The existing `analyzeStoryForeshadowing` behaviour is already correct, so the tests document and lock in that behaviour.

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
