### PR TITLE
test(#6198): add unit tests for analyzeReadingInfo utility

### DIFF
--- a/frontend/src/utils/__tests__/storyReadingInfo.test.ts
+++ b/frontend/src/utils/__tests__/storyReadingInfo.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { analyzeReadingInfo } from "../storyReadingInfo";
+
+const VALID_LEVELS = ["Beginner", "Intermediate", "Advanced"] as const;
+
+describe("analyzeReadingInfo", () => {
+  it("returns wordCount 0 and readingTime 1 for empty input", () => {
+    const r = analyzeReadingInfo("");
+    expect(r.wordCount).toBe(0);
+    expect(r.readingTime).toBe(1);
+    expect(r.difficulty).toBe("Beginner");
+  });
+
+  it("returns wordCount 0 for whitespace-only input", () => {
+    expect(analyzeReadingInfo("   \n  ").wordCount).toBe(0);
+  });
+
+  it("counts the number of words", () => {
+    expect(analyzeReadingInfo("one two three four five").wordCount).toBe(5);
+  });
+
+  it("readingTime is at least 1 and scales with word count (200 wpm)", () => {
+    expect(analyzeReadingInfo("short").readingTime).toBe(1);
+    expect(analyzeReadingInfo("w ".repeat(250).trim()).readingTime).toBe(2);
+  });
+
+  it("difficulty is Beginner for wordCount <= 1000", () => {
+    const r = analyzeReadingInfo("w ".repeat(500).trim());
+    expect(r.difficulty).toBe("Beginner");
+  });
+
+  it("difficulty is Intermediate for 1000 < wordCount <= 3000", () => {
+    const r = analyzeReadingInfo("w ".repeat(1500).trim());
+    expect(r.difficulty).toBe("Intermediate");
+  });
+
+  it("difficulty is Advanced for wordCount > 3000", () => {
+    const r = analyzeReadingInfo("w ".repeat(3001).trim());
+    expect(r.difficulty).toBe("Advanced");
+  });
+
+  it("difficulty is one of the valid values", () => {
+    const r = analyzeReadingInfo("a story");
+    expect(VALID_LEVELS).toContain(r.difficulty);
+  });
+
+  it("is deterministic for the same input", () => {
+    const story = "a deterministic story with some words";
+    expect(analyzeReadingInfo(story)).toEqual(analyzeReadingInfo(story));
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6198

This PR implements the work described in issue #6198: **add unit tests for analyzeReadingInfo utility**.

### Changes
- Added `frontend/src/utils/__tests__/storyReadingInfo.test.ts` covering:
  - Empty input → `wordCount: 0`, `readingTime: 1`, `difficulty: "Beginner"`.
  - Whitespace-only input → `wordCount: 0`.
  - `wordCount` matches the number of words.
  - `readingTime` is at least 1 and scales with word count (200 wpm).
  - `difficulty` is "Beginner" for ≤ 1000 words, "Intermediate" for 1000 < n ≤ 3000, and "Advanced" for > 3000.
  - `difficulty` is one of the valid values.
  - Deterministic output.

### Verification
- `npx vitest run` on `storyReadingInfo.test.ts` — all 9 tests pass locally.
- `eslint` on the new test file — clean.

### Notes
- Test-only PR; no production source changes. The existing `analyzeReadingInfo` behaviour is already correct, so the tests document and lock in that behaviour (including the 200 wpm reading-time calculation and the 1000/3000-word difficulty thresholds).

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
