### PR TITLE
test(#6196): add unit tests for useChapterBalance hook

### DIFF
--- a/frontend/src/hooks/__tests__/useChapterBalance.test.ts
+++ b/frontend/src/hooks/__tests__/useChapterBalance.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { renderHook } from "@testing-library/react";
+import useChapterBalance from "../../hooks/useChapterBalance";
+
+describe("useChapterBalance", () => {
+  it("returns the analysis from analyzeChapterBalance for the given story", () => {
+    const story = "chapter 1 " + "word ".repeat(500);
+    const { result } = renderHook(() => useChapterBalance(story));
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].chapter).toBe(1);
+    expect(result.current[0].words).toBeGreaterThan(0);
+  });
+
+  it("returns an empty array for an empty story", () => {
+    const { result } = renderHook(() => useChapterBalance(""));
+    expect(result.current).toEqual([]);
+  });
+
+  it("memoizes: returns a stable reference for the same story value", () => {
+    const story = "chapter 1 " + "word ".repeat(500);
+    const { result, rerender } = renderHook(() => useChapterBalance(story));
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+
+  it("returns a new reference when the story changes", () => {
+    const storyA = "chapter 1 " + "word ".repeat(500);
+    const storyB = "chapter 1 " + "word ".repeat(600);
+    const { result, rerender } = renderHook(
+      ({ s }) => useChapterBalance(s),
+      { initialProps: { s: storyA } }
+    );
+    const first = result.current;
+    rerender({ s: storyB });
+    expect(result.current).not.toBe(first);
+    expect(result.current[0].words).toBeGreaterThan(first[0].words);
+  });
+
+  it("returns chapter analysis with balanced/needs-review status", () => {
+    const story = "chapter 1 " + "word ".repeat(500);
+    const { result } = renderHook(() => useChapterBalance(story));
+    for (const c of result.current) {
+      expect(["Balanced", "Needs Review"]).toContain(c.status);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6196

This PR implements the work described in issue #6196: **add unit tests for useChapterBalance hook**.

### Changes
- Added `frontend/src/hooks/__tests__/useChapterBalance.test.ts` covering:
  - Returns the analysis from `analyzeChapterBalance` for the given story (one chapter-analysis entry per `chapter N` section).
  - Returns an empty array for an empty story.
  - Memoization: returns a stable reference for the same story value across re-renders (via `useMemo`).
  - Returns a new reference when the story changes, and the new word count differs.
  - Each chapter-analysis entry has a `status` of "Balanced" or "Needs Review".

The tests use `@testing-library/react`'s `renderHook` (already a dev dependency) under the existing jsdom vitest environment.

### Verification
- `npx vitest run` on `useChapterBalance.test.ts` — all 5 tests pass locally.
- `eslint` on the new test file — clean.

### Notes
- Test-only PR; no production source changes. The existing `useChapterBalance` behaviour (a thin `useMemo` wrapper over `analyzeChapterBalance`) is already correct, so the tests document and lock in that behaviour, including the memoization guarantee.

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
