### PR TITLE
test(#6193): rewrite broken formatError test suite

### DIFF
--- a/backend/src/app/utils/__tests__/formatError.test.ts
+++ b/backend/src/app/utils/__tests__/formatError.test.ts
@@ -1,51 +1,6 @@
-import { ZodError } from "zod";
-import { formatError } from "../formatError";
-import ApiError from "../../../errors/api_error";
-
-describe("formatError", () => {
-  describe("ZodError handling", () => {
-    it("formats ZodError with 400 status and validation issues", () => {
-      const zodError = new ZodError([
-        { code: "custom", path: ["email"], message: "Invalid email address" },
-        { code: "custom", path: ["username"], message: "Username is required" },
-      ]);
-
-      const result = formatError(zodError);
-
-      expect(result.statusCode).toBe(400);
-      expect(result.message).toBe("Validation Error");
-      expect(result.errorMessages).toHaveLength(2);
-      expect(result.errorMessages[0]).toEqual({
-        path: "email",
-        message: "Invalid email address",
-      });
-      expect(result.errorMessages[1]).toEqual({
-        path: "username",
-        message: "Username is required",
-      });
-    });
-
-    it("maps empty path issue to empty string path", () => {
-      const zodError = new ZodError([
-        { code: "custom", path: [], message: "Required field" },
-      ]);
-
-      const result = formatError(zodError);
-
-      expect(result.errorMessages[0].path).toBe("");
-    });
-
-    it("maps nested path to last segment", () => {
-      const zodError = new ZodError([
-        { code: "custom", path: ["body", "name", 0], message: "Invalid" },
-      ]);
-
-      const result = formatError(zodError);
-
-      expect(result.errorMessages[0].path).toBe("0");
 import { ZodError, ZodIssueCode } from "zod";
-import ApiError from "../../../errors/api_error";
 import { formatError } from "../formatError";
+import ApiError from "../../../errors/api_error";
 
 describe("formatError", () => {
   describe("ZodError handling", () => {
@@ -61,6 +16,7 @@ describe("formatError", () => {
       ]);
       const result = formatError(zodError);
       expect(result.statusCode).toBe(400);
+      expect(result.message).toBe("Validation Error");
     });
 
     it("maps ZodError issues to errorMessages with path and message", () => {
@@ -80,57 +36,39 @@ describe("formatError", () => {
       ]);
     });
 
+    it("uses the last path segment as the path string", () => {
+      const zodError = new ZodError([
+        { code: ZodIssueCode.custom, path: ["body", "name", 0], message: "Invalid" },
+      ]);
+      const result = formatError(zodError);
+      expect(result.errorMessages[0].path).toBe("0");
+    });
+
     it("uses empty path string when path array is empty", () => {
       const zodError = new ZodError([
-        {
-          code: ZodIssueCode.custom,
-          path: [],
-          message: "Root-level error",
-        },
+        { code: ZodIssueCode.custom, path: [], message: "Root-level error" },
       ]);
       const result = formatError(zodError);
       expect(result.errorMessages).toEqual([{ path: "", message: "Root-level error" }]);
+    });
 
+    it("maps multiple issues in order", () => {
+      const zodError = new ZodError([
+        { code: ZodIssueCode.custom, path: ["email"], message: "Invalid email" },
+        { code: ZodIssueCode.custom, path: ["password"], message: "Too short" },
+      ]);
+      const result = formatError(zodError);
+      expect(result.errorMessages).toHaveLength(2);
+      expect(result.errorMessages[1]).toEqual({ path: "password", message: "Too short" });
     });
   });
 
   describe("ApiError handling", () => {
-
     it("preserves statusCode and message from ApiError", () => {
       const apiError = new ApiError(404, "Story not found");
-
       const result = formatError(apiError);
-
       expect(result.statusCode).toBe(404);
       expect(result.message).toBe("Story not found");
-      expect(result.errorMessages).toEqual([
-        { path: "", message: "Story not found" },
-      ]);
-    });
-
-    it("handles ApiError with undefined message", () => {
-      const apiError = new ApiError(500, undefined);
-
-      const result = formatError(apiError);
-
-      expect(result.statusCode).toBe(500);
-      expect(result.message).toBe("An error occurred");
-      expect(result.errorMessages).toEqual([]);
-    });
-
-    it("preserves custom status codes", () => {
-      const apiError = new ApiError(403, "Access denied");
-
-      const result = formatError(apiError);
-
-      expect(result.statusCode).toBe(403);
-      expect(result.message).toBe("Access denied");
-
-    it("returns the ApiError statusCode and message", () => {
-      const apiError = new ApiError(404, "Resource not found");
-      const result = formatError(apiError);
-      expect(result.statusCode).toBe(404);
-      expect(result.message).toBe("Resource not found");
     });
 
     it("includes the message in errorMessages", () => {
@@ -139,36 +77,21 @@ describe("formatError", () => {
       expect(result.errorMessages).toEqual([{ path: "", message: "Unauthorized" }]);
     });
 
-    it("uses default message when ApiError message is empty", () => {
+    it("preserves custom status codes", () => {
+      const apiError = new ApiError(403, "Access denied");
+      const result = formatError(apiError);
+      expect(result.statusCode).toBe(403);
+    });
+
+    it("uses default message when ApiError message is undefined", () => {
       const apiError = new ApiError(500, undefined);
       const result = formatError(apiError);
       expect(result.message).toBe("An error occurred");
       expect(result.errorMessages).toEqual([]);
-
     });
   });
 
   describe("generic Error handling", () => {
-    it("formats generic Error with 500 status", () => {
-      const error = new Error("Database connection failed");
-
-      const result = formatError(error);
-
-      expect(result.statusCode).toBe(500);
-      expect(result.message).toBe("Database connection failed");
-      expect(result.errorMessages).toEqual([
-        { path: "", message: "Database connection failed" },
-      ]);
-    });
-
-    it("uses fallback message for Error with empty message", () => {
-      const error = new Error("");
-
-      const result = formatError(error);
-
-      expect(result.statusCode).toBe(500);
-      expect(result.message).toBe("Something went wrong");
-      expect(result.errorMessages).toEqual([]);
     it("returns statusCode 500 for generic Error", () => {
       const error = new Error("Something went wrong");
       const result = formatError(error);
@@ -185,39 +108,23 @@ describe("formatError", () => {
       const error = new Error("Network timeout");
       const result = formatError(error);
       expect(result.errorMessages).toEqual([{ path: "", message: "Network timeout" }]);
+    });
 
+    it("uses fallback message for Error with empty message", () => {
+      const error = new Error("");
+      const result = formatError(error);
+      expect(result.message).toBe("Something went wrong");
+      expect(result.errorMessages).toEqual([]);
     });
   });
 
   describe("unknown input handling", () => {
     it("returns 500 with generic message for string input", () => {
-      const result = formatError("not an error" as unknown as Error);
-
+      const result = formatError("not an error");
       expect(result.statusCode).toBe(500);
       expect(result.message).toBe("Something went wrong");
       expect(result.errorMessages).toEqual([]);
     });
-
-    it("handles null input", () => {
-      const result = formatError(null);
-
-      expect(result.statusCode).toBe(500);
-      expect(result.message).toBe("Something went wrong");
-      expect(result.errorMessages).toEqual([]);
-    });
-
-    it("handles undefined input", () => {
-      const result = formatError(undefined);
-
-      expect(result.statusCode).toBe(500);
-      expect(result.message).toBe("Something went wrong");
-      expect(result.errorMessages).toEqual([]);
-    });
-
-    it("handles plain object without Error properties", () => {
-      const result = formatError({ code: 500, msg: "oops" } as unknown as Error);
-
-      expect(result.statusCode).toBe(500);
 
     it("returns statusCode 500 for null", () => {
       const result = formatError(null);


### PR DESCRIPTION
## Summary

Closes #6193

This PR implements the work described in issue #6193: **add unit tests for formatError utility**.

### Problem
The existing `backend/src/app/utils/__tests__/formatError.test.ts` was malformed — it contained two concatenated test files (with duplicate `describe`/`it` blocks and unmatched braces from a bad merge), which caused a TypeScript parser error and **0 tests to run** (jest: "The parser expected to find a '}'").

### Changes
- Rewrote `backend/src/app/utils/__tests__/formatError.test.ts` as a single, clean test suite (18 tests) covering:
  - **ZodError handling**: 400 status, "Validation Error" message, issue → `{ path, message }` mapping (including the last-path-segment rule and the empty-path → `""` rule), and multiple-issue ordering.
  - **ApiError handling**: preserves `statusCode`/`message`, includes the message in `errorMessages`, preserves custom status codes, and uses "An error occurred" when the message is undefined.
  - **generic Error handling**: 500 status, message in the `message` field and `errorMessages`, and the "Something went wrong" fallback for an empty message.
  - **unknown input handling**: 500/generic-message/empty-`errorMessages` for strings, `null`, `undefined`, and plain non-Error objects.

### Verification
- `npx jest src/app/utils/__tests__/formatError.test.ts` — all 18 tests pass locally (previously: parser error, 0 tests run).

### Notes
- This PR replaces a broken test file with a working one; no production source changes. The `formatError` implementation is unchanged.

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
