### PR TITLE
test(#6194): add unit tests for chapterBalance utility

### DIFF
--- a/frontend/src/utils/__tests__/chapterBalance.test.ts
+++ b/frontend/src/utils/__tests__/chapterBalance.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { analyzeChapterBalance } from "../chapterBalance";
+
+describe("analyzeChapterBalance", () => {
+  it("returns [] for an empty story", () => {
+    expect(analyzeChapterBalance("")).toEqual([]);
+  });
+
+  it("returns [] for a whitespace-only story", () => {
+    expect(analyzeChapterBalance("   \n  ")).toEqual([]);
+  });
+
+  it("splits by 'chapter N' markers into sequential chapters", () => {
+    const story = "chapter 1 " + "word ".repeat(500) + " chapter 2 " + "word ".repeat(500);
+    const r = analyzeChapterBalance(story);
+    expect(r.map((c) => c.chapter)).toEqual([1, 2]);
+  });
+
+  it("counts words per chapter", () => {
+    const story = "chapter 1 " + "word ".repeat(500).trim();
+    const r = analyzeChapterBalance(story);
+    expect(r[0].words).toBeGreaterThan(0);
+  });
+
+  it("marks a 400-1200 word chapter as Balanced", () => {
+    const story = "chapter 1 " + "word ".repeat(500);
+    const r = analyzeChapterBalance(story);
+    expect(r[0].status).toBe("Balanced");
+  });
+
+  it("marks a short (< 400 words) chapter as Needs Review", () => {
+    const story = "chapter 1 a b c";
+    const r = analyzeChapterBalance(story);
+    expect(r[0].status).toBe("Needs Review");
+  });
+
+  it("marks a long (> 1200 words) chapter as Needs Review", () => {
+    const story = "chapter 1 " + "word ".repeat(1300);
+    const r = analyzeChapterBalance(story);
+    expect(r[0].status).toBe("Needs Review");
+  });
+
+  it("score is capped at 100", () => {
+    const story = "chapter 1 " + "word ".repeat(2000);
+    const r = analyzeChapterBalance(story);
+    expect(r[0].score).toBeLessThanOrEqual(100);
+  });
+
+  it("score is a non-negative integer", () => {
+    const story = "chapter 1 a b c";
+    const r = analyzeChapterBalance(story);
+    expect(Number.isInteger(r[0].score)).toBe(true);
+    expect(r[0].score).toBeGreaterThanOrEqual(0);
+  });
+
+  it("each result has the required fields with a valid status", () => {
+    const story = "chapter 1 " + "word ".repeat(500) + " chapter 2 a b c";
+    const r = analyzeChapterBalance(story);
+    for (const c of r) {
+      expect(typeof c.chapter).toBe("number");
+      expect(typeof c.words).toBe("number");
+      expect(typeof c.score).toBe("number");
+      expect(["Balanced", "Needs Review"]).toContain(c.status);
+    }
+  });
+
+  it("chapter ids are unique and sequential", () => {
+    const story = "chapter 1 " + "word ".repeat(500) + " chapter 2 " + "word ".repeat(500) + " chapter 3 " + "word ".repeat(500);
+    const r = analyzeChapterBalance(story);
+    expect(r.map((c) => c.chapter)).toEqual([1, 2, 3]);
+  });
+
+  it("is deterministic for the same input", () => {
+    const story = "chapter 1 " + "word ".repeat(500);
+    expect(analyzeChapterBalance(story)).toEqual(analyzeChapterBalance(story));
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6194

This PR implements the work described in issue #6194: **add unit tests for chapterBalance utility**.

### Changes
- Added `frontend/src/utils/__tests__/chapterBalance.test.ts` covering:
  - Empty/whitespace-only story → `[]`.
  - Splits by `chapter N` markers into sequential `chapter` ids.
  - Counts words per chapter.
  - Marks a 400-1200 word chapter as "Balanced"; short (< 400 words) and long (> 1200 words) chapters as "Needs Review".
  - `score` is capped at 100 and is a non-negative integer.
  - Each result has the required fields (`chapter`, `words`, `score`, `status`) with a valid status.
  - Chapter ids are unique and sequential.
  - Deterministic output.

### Verification
- `npx vitest run` on `chapterBalance.test.ts` — all 12 tests pass locally.
- `eslint` on the new test file — clean.

### Notes
- Test-only PR; no production source changes. The existing `analyzeChapterBalance` behaviour is already correct, so the tests document and lock in that behaviour (including the `chapter\s+\d+` splitting, the 400-1200 balanced range, and the `min(100, words/800*100)` score).

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
