### PR TITLE
fix(#6181): replace div onClick with button on StoryTrailer progress dots

### DIFF
--- a/frontend/src/components/trailer/StoryTrailer.tsx
+++ b/frontend/src/components/trailer/StoryTrailer.tsx
@@ -265,12 +265,18 @@ Example format: ["The darkness consumed everything around him", "She ran but cou
           zIndex: 50,
         }}>
           {Array.from({ length: totalSlides }).map((_, i) => (
-            <div
+            <button
               key={i}
+              type="button"
+              aria-label={`Go to scene ${i + 1} of ${totalSlides}`}
+              aria-current={i === currentScene ? "true" : undefined}
               onClick={() => { setCurrentScene(i); setIsPlaying(false); }}
               style={{
                 width: i === currentScene ? "24px" : "8px",
                 height: "8px",
+                padding: 0,
+                margin: 0,
+                border: "none",
                 borderRadius: "4px",
                 background: i === currentScene ? "#fff" : "rgba(255,255,255,0.3)",
                 transition: "all 0.3s ease",


### PR DESCRIPTION
## Summary

Closes #6181

This PR fixes the accessibility issue described in #6181: **StoryTrailer progress dots use `<div onClick>`**, which is not focusable and has no semantic meaning as an interactive element.

### Changes
- `frontend/src/components/trailer/StoryTrailer.tsx`: replaced each progress-dot `<div onClick>` with a native `<button type="button">` element that:
  - is natively focusable and keyboard-activatable (Enter/Space),
  - has `aria-label="Go to scene N of M"` so screen readers announce each dot's purpose,
  - sets `aria-current="true"` on the active dot,
  - preserves the existing visual styling (width/height/border-radius/background/transition/cursor) via inline styles, with `padding: 0`, `margin: 0`, and `border: "none"` so the button renders like the previous div.

### Verification
- `eslint` on `StoryTrailer.tsx` — no new errors or warnings (the single pre-existing `react-hooks/exhaustive-deps` warning on the `useEffect` is unchanged by this change and exists on `main`).

### Notes
- Keyboard users can now Tab to each progress dot and activate it with Enter/Space to jump to that scene, and screen readers correctly announce "Go to scene N of M" and the current dot. No behavioural change to mouse users.

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
