### PR TITLE
fix(#6180): add isMountedRef guard to extractScenes in StoryTrailer

### DIFF
--- a/frontend/src/components/trailer/StoryTrailer.tsx
+++ b/frontend/src/components/trailer/StoryTrailer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import CinematicSlide from "./CinematicSlide";
 import { useGenerateModelMutation } from "../../redux/apis/ai.model.api";
 
@@ -17,12 +17,15 @@ export default function StoryTrailer({ title, content, tag, isLogin, onClose }: 
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState("");
 
+  const isMountedRef = useRef(true);
+
   const totalSlides = scenes.length + 1; // +1 for final title slide
 
   // Extract scenes using Gemini via existing API
   const [generateModel] = useGenerateModelMutation();
 
   useEffect(() => {
+    isMountedRef.current = true;
     const extractScenes = async () => {
       setIsLoading(true);
       try {
@@ -38,6 +41,8 @@ Example format: ["The darkness consumed everything around him", "She ran but cou
           numStories: 1,
           language: "English",
         }).unwrap();
+
+        if (!isMountedRef.current) return;
 
         if (result?.data?.[0]?.content) {
           try {
@@ -66,13 +71,21 @@ Example format: ["The darkness consumed everything around him", "She ran but cou
         ]);
         setIsPlaying(true);
       } catch {
-        setError("Failed to generate trailer. Please try again.");
+        if (isMountedRef.current) {
+          setError("Failed to generate trailer. Please try again.");
+        }
       } finally {
-        setIsLoading(false);
+        if (isMountedRef.current) {
+          setIsLoading(false);
+        }
       }
     };
 
     extractScenes();
+
+    return () => {
+      isMountedRef.current = false;
+    };
   }, [content]);
 
   // Auto-advance slides


### PR DESCRIPTION
## Summary

Closes #6180

This PR fixes the stale-state bug described in #6180: **add an `isMountedRef` guard to `extractScenes` in `StoryTrailer`** to prevent setting state after the component unmounts.

### Problem
`StoryTrailer`'s `extractScenes` async function awaits `generateModel(...).unwrap()`. If the component unmounts while that promise is pending, the subsequent `setScenes`/`setIsPlaying`/`setError`/`setIsLoading` calls fire on an unmounted component — a React "Can't perform a state update on an unmounted component" warning and potential stale-state bugs.

### Changes
- `frontend/src/components/trailer/StoryTrailer.tsx`:
  - Imported `useRef` and added `const isMountedRef = useRef(true)`.
  - In the `extractScenes` `useEffect`, set `isMountedRef.current = true` on entry and `isMountedRef.current = false` in the cleanup function (runs on unmount).
  - After the `await generateModel(...).unwrap()`, return early if `!isMountedRef.current`.
  - Guard `setError` (in `catch`) and `setIsLoading` (in `finally`) with `isMountedRef.current` checks.

### Verification
- `eslint` on `StoryTrailer.tsx` — no new errors or warnings (the single pre-existing `react-hooks/exhaustive-deps` warning is unchanged and exists on `main`).

### Notes
- No behavioural change to the happy path; only suppresses state updates after unmount, eliminating the stale-state warning.

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
