### PR TITLE
test(#5285): fix normalizeWhitespace test to use jest globals

### DIFF
--- a/backend/src/app/utils/__tests__/normalizeWhitespace.test.ts
+++ b/backend/src/app/utils/__tests__/normalizeWhitespace.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from 'vitest';
 import { normalizeWhitespace } from '../sanitization';
 
 describe('normalizeWhitespace', () => {


### PR DESCRIPTION
## Summary

Closes #5285

This PR implements the work described in issue #5285: **add unit tests for normalizeWhitespace utility**.

### Problem
The existing `backend/src/app/utils/__tests__/normalizeWhitespace.test.ts` could not run because it imported `describe`, `it`, and `expect` from `vitest`, but the **backend uses Jest** (`jest --runInBand`, `ts-jest` preset). Vitest is not configured for the backend, so Jest failed to transform the file and **0 tests ran**.

### Changes
- Removed the broken `import { describe, it, expect } from 'vitest';` line from `backend/src/app/utils/__tests__/normalizeWhitespace.test.ts`. The backend's other test files (e.g. `formatError.test.ts`, `emailValidator.test.ts`) rely on Jest's globals directly, so the test now uses the global `describe`/`it`/`expect`. The 14 test cases and the `normalizeWhitespace` implementation are unchanged.

### Verification
- `npx jest src/app/utils/__tests__/normalizeWhitespace.test.ts` — all 14 tests pass locally (previously: 0 tests ran due to the vitest import).

### Notes
- Test-only PR; no production source changes. `normalizeWhitespace` (`sanitization.ts`) is unchanged.

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
