### PR TITLE
test(#5284): rewrite corrupted useDocumentStats test suite

### DIFF
--- a/frontend/src/hooks/__tests__/useDocumentStats.test.ts
+++ b/frontend/src/hooks/__tests__/useDocumentStats.test.ts
@@ -1,76 +1,40 @@
-import { renderHook } from "@testing-library/react";
-import { useDocumentStats } from "../useDocumentStats";
-import { computeDocumentStats } from "../../utils/story-utils";
-import type { Chapter } from "../../types/story.types";
-
-vi.mock("../../utils/story-utils", () => ({
-  computeDocumentStats: vi.fn(),
-}));
-
-const mockStats = {
-  totalWords: 100,
-  uniqueWords: 80,
-  vocabularyRichness: 0.8,
-  readingTimeMin: 1.0,
-  estimatedPages: 0.5,
-};
-
-const zeroStats = {
-  totalWords: 0,
-  uniqueWords: 0,
-  vocabularyRichness: 0,
-  readingTimeMin: 0,
-  estimatedPages: 0,
-};
-
-const makeChapter = (id: number, title: string, content: string): Chapter =>
-  ({ id, title, content } as Chapter);
-
-describe("useDocumentStats", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    (computeDocumentStats as ReturnType<typeof vi.fn>).mockReturnValue(mockStats);
-  });
-
-  it("handles undefined chapters gracefully", () => {
-    (computeDocumentStats as ReturnType<typeof vi.fn>).mockReturnValueOnce(zeroStats);
-    const { result } = renderHook(() => useDocumentStats(undefined));
-    expect(result.current.chapterStats).toEqual([]);
 import { describe, it, expect } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { useDocumentStats } from "../useDocumentStats";
 import { Chapter } from "../../types/story.types";
 
-describe("useDocumentStats hook", () => {
-  const makeChapter = (id: number, title: string, content: string): Chapter => ({
-    id,
-    title,
-    content,
-    createdAt: new Date().toISOString(),
-  });
+const makeChapter = (id: number, title: string, content: string): Chapter => ({
+  id,
+  title,
+  content,
+  createdAt: new Date().toISOString(),
+});
 
-  it("should return zero stats for undefined chapters", () => {
+describe("useDocumentStats", () => {
+  it("returns zero stats for undefined chapters", () => {
     const { result } = renderHook(() => useDocumentStats(undefined));
-
     expect(result.current.docStats.totalWords).toBe(0);
     expect(result.current.docStats.uniqueWords).toBe(0);
     expect(result.current.chapterStats).toHaveLength(0);
-
     expect(result.current.chapterAvgWords).toBe(0);
     expect(result.current.maxChapterWords).toBe(0);
   });
 
+  it("returns zero stats for an empty chapters array", () => {
+    const { result } = renderHook(() => useDocumentStats([]));
+    expect(result.current.docStats.totalWords).toBe(0);
+    expect(result.current.chapterStats).toHaveLength(0);
+    expect(result.current.chapterAvgWords).toBe(0);
+    expect(result.current.maxChapterWords).toBe(0);
+  });
 
   it("computes per-chapter stats and aggregate stats for a single chapter", () => {
     const chapters: Chapter[] = [makeChapter(1, "Chapter 1", "Hello world test content")];
     const { result } = renderHook(() => useDocumentStats(chapters));
-
     expect(result.current.chapterStats).toHaveLength(1);
-    expect(result.current.chapterStats[0]).toMatchObject({
-      id: 1,
-      title: "Chapter 1",
-    });
-    expect(result.current.docStats).toEqual(mockStats);
+    expect(result.current.chapterStats[0]).toMatchObject({ id: 1, title: "Chapter 1" });
+    expect(result.current.chapterStats[0].totalWords).toBe(4);
+    expect(result.current.docStats.totalWords).toBe(4);
   });
 
   it("computes per-chapter stats for multiple chapters", () => {
@@ -79,124 +43,73 @@ describe("useDocumentStats hook", () => {
       makeChapter(2, "Ch2", "content two"),
     ];
     const { result } = renderHook(() => useDocumentStats(chapters));
-
-    // called once per chapter + once for combined
-    expect(computeDocumentStats).toHaveBeenCalledTimes(3);
     expect(result.current.chapterStats).toHaveLength(2);
     expect(result.current.chapterStats[0]).toMatchObject({ id: 1, title: "Ch1" });
     expect(result.current.chapterStats[1]).toMatchObject({ id: 2, title: "Ch2" });
+    // combined: "content one content two" = 4 words
+    expect(result.current.docStats.totalWords).toBe(4);
   });
 
   it("computes chapterAvgWords as docStats.totalWords / chapterCount", () => {
-    (computeDocumentStats as ReturnType<typeof vi.fn>)
-      .mockReturnValueOnce({ ...mockStats, totalWords: 100 })
-      .mockReturnValueOnce({ ...mockStats, totalWords: 100 })
-      .mockReturnValueOnce({ ...mockStats, totalWords: 200 });
-
     const chapters: Chapter[] = [
-      makeChapter(1, "Ch1", "chapter one"),
-      makeChapter(2, "Ch2", "chapter two"),
+      makeChapter(1, "Ch1", "one two three four five"), // 5
+      makeChapter(2, "Ch2", "six seven eight nine ten eleven twelve"), // 7
     ];
     const { result } = renderHook(() => useDocumentStats(chapters));
-    expect(result.current.chapterAvgWords).toBe(200 / 2);
+    expect(result.current.docStats.totalWords).toBe(12);
+    expect(result.current.chapterAvgWords).toBe(12 / 2);
   });
 
   it("computes maxChapterWords as the maximum word count across chapters", () => {
-    (computeDocumentStats as ReturnType<typeof vi.fn>)
-      .mockReturnValueOnce({ ...mockStats, totalWords: 50 })
-      .mockReturnValueOnce({ ...mockStats, totalWords: 200 })
-      .mockReturnValueOnce({ ...mockStats, totalWords: 100 });
-
     const chapters: Chapter[] = [
-      makeChapter(1, "Ch1", "short chapter"),
-      makeChapter(2, "Ch2", "long chapter"),
+      makeChapter(1, "Short", "a b c"), // 3
+      makeChapter(2, "Longest", "a b c d e f g h i j"), // 10
+      makeChapter(3, "Medium", "w x y z"), // 4
     ];
     const { result } = renderHook(() => useDocumentStats(chapters));
-    expect(result.current.maxChapterWords).toBe(200);
-  });
-
-  it("memoizes results — does not recompute for same chapters reference", () => {
-    const chapters: Chapter[] = [makeChapter(1, "Ch1", "content")];
-    const { result, rerender } = renderHook(() => useDocumentStats(chapters));
-    const firstStats = result.current;
-    rerender();
-    expect(result.current).toBe(firstStats);
-
-  it("should return zero stats for empty chapters array", () => {
-    const { result } = renderHook(() => useDocumentStats([]));
-
-    expect(result.current.docStats.totalWords).toBe(0);
-    expect(result.current.chapterStats).toHaveLength(0);
-    expect(result.current.chapterAvgWords).toBe(0);
-    expect(result.current.maxChapterWords).toBe(0);
-  });
-
-  it("should compute per-chapter and aggregate stats for a single chapter", () => {
-    const chapters: Chapter[] = [
-      makeChapter(1, "Chapter 1", "Hello world hello"),
-    ];
-
-    const { result } = renderHook(() => useDocumentStats(chapters));
-
-    // Per-chapter: 3 words total, 2 unique
-    expect(result.current.chapterStats).toHaveLength(1);
-    expect(result.current.chapterStats[0].id).toBe(1);
-    expect(result.current.chapterStats[0].title).toBe("Chapter 1");
-    expect(result.current.chapterStats[0].totalWords).toBe(3);
-    expect(result.current.chapterStats[0].uniqueWords).toBe(2);
-
-    // Aggregate: 3 words total, 2 unique, avg = 3, max = 3
-    expect(result.current.docStats.totalWords).toBe(3);
-    expect(result.current.docStats.uniqueWords).toBe(2);
-    expect(result.current.chapterAvgWords).toBe(3);
-    expect(result.current.maxChapterWords).toBe(3);
-  });
-
-  it("should compute correct aggregate stats across multiple chapters", () => {
-    const chapters: Chapter[] = [
-      makeChapter(1, "Chapter 1", "one two three four five"),
-      makeChapter(2, "Chapter 2", "six seven eight nine ten eleven twelve"),
-    ];
-
-    const { result } = renderHook(() => useDocumentStats(chapters));
-
-    // Chapter 1: 5 words, Chapter 2: 7 words
-    expect(result.current.chapterStats).toHaveLength(2);
-    expect(result.current.chapterStats[0].totalWords).toBe(5);
-    expect(result.current.chapterStats[1].totalWords).toBe(7);
-
-    // Aggregate: 12 total words, avg = 12/2 = 6, max = 7
-    expect(result.current.docStats.totalWords).toBe(12);
-    expect(result.current.chapterAvgWords).toBe(6);
-    expect(result.current.maxChapterWords).toBe(7);
-  });
-
-  it("should set maxChapterWords to the chapter with the most words", () => {
-    const chapters: Chapter[] = [
-      makeChapter(1, "Short", "a b c"),
-      makeChapter(2, "Longest", "a b c d e f g h i j"),
-      makeChapter(3, "Medium", "w x y z"),
-    ];
-
-    const { result } = renderHook(() => useDocumentStats(chapters));
-
     expect(result.current.maxChapterWords).toBe(10);
-    expect(result.current.chapterAvgWords).toBeCloseTo(6.0);
   });
 
-  it("should recompute when chapters array changes", () => {
+  it("chapterAvgWords is 0 when there are no chapters even if totalWords is 0", () => {
+    const { result } = renderHook(() => useDocumentStats([]));
+    expect(result.current.chapterAvgWords).toBe(0);
+  });
+
+  it("recomputes when chapters array changes", () => {
     const { result, rerender } = renderHook(
-      ({ chapters }: { chapters: Chapter[] | undefined }) =>
-        useDocumentStats(chapters),
+      ({ chapters }: { chapters: Chapter[] | undefined }) => useDocumentStats(chapters),
       { initialProps: { chapters: undefined as Chapter[] | undefined } }
     );
-
     expect(result.current.docStats.totalWords).toBe(0);
 
-    rerender({
-      chapters: [makeChapter(1, "Chapter 1", "hello world")],
-    });
-
+    rerender({ chapters: [makeChapter(1, "Chapter 1", "hello world")] });
     expect(result.current.docStats.totalWords).toBe(2);
+    expect(result.current.chapterStats).toHaveLength(1);
+  });
+
+  it("memoizes the result for the same chapters reference", () => {
+    const chapters: Chapter[] = [makeChapter(1, "Chapter 1", "hello world")];
+    const { result, rerender } = renderHook(
+      ({ chapters }: { chapters: Chapter[] }) => useDocumentStats(chapters),
+      { initialProps: { chapters } }
+    );
+    const first = result.current;
+    rerender({ chapters }); // same reference
+    expect(result.current).toBe(first);
+  });
+
+  it("chapterStats entries include id, title, and DocumentStats fields", () => {
+    const chapters: Chapter[] = [makeChapter(1, "Chapter 1", "hello world")];
+    const { result } = renderHook(() => useDocumentStats(chapters));
+    const stat = result.current.chapterStats[0];
+    expect(stat).toMatchObject({
+      id: 1,
+      title: "Chapter 1",
+      totalWords: 2,
+      uniqueWords: 2,
+    });
+    expect(typeof stat.vocabularyRichness).toBe("number");
+    expect(typeof stat.readingTimeMin).toBe("number");
+    expect(typeof stat.estimatedPages).toBe("number");
   });
 });


### PR DESCRIPTION
## Summary

Closes #5284

This PR implements the work described in issue #5284: **add unit tests for useDocumentStats hook**.

### Problem
The existing `frontend/src/hooks/__tests__/useDocumentStats.test.ts` was corrupted — it contained two concatenated test files with conflicting setups (one mocked `computeDocumentStats` via `vi.mock` but never imported `vi`/`describe`/`it`/`expect` from vitest; a second file imported them but referenced the first file's `mockStats`). This produced an esbuild transform error (`Unexpected "{"`) and **0 tests to run**.

### Changes
- Rewrote `frontend/src/hooks/__tests__/useDocumentStats.test.ts` as a single, clean suite (10 tests) using the real `computeDocumentStats` (a pure function — no mocking required):
  - returns zero stats for `undefined` chapters,
  - returns zero stats for an empty chapters array,
  - computes per-chapter and aggregate stats for a single chapter,
  - computes per-chapter stats for multiple chapters,
  - computes `chapterAvgWords` as `docStats.totalWords / chapterCount`,
  - computes `maxChapterWords` as the maximum word count across chapters,
  - `chapterAvgWords` is 0 when there are no chapters,
  - recomputes when the chapters array reference changes,
  - memoizes the result for the same chapters reference,
  - `chapterStats` entries include `id`, `title`, and `DocumentStats` fields.

### Verification
- `npx vitest run src/hooks/__tests__/useDocumentStats.test.ts` — all 10 tests pass locally (previously: transform error, 0 tests run).
- `eslint` on the file — clean.

### Notes
- Test-only PR; no production source changes. The `useDocumentStats` implementation is unchanged.

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
