### PR TITLE
test(#5898): add useRevisionTimeline hook test suite

### DIFF
--- a/frontend/src/hooks/__tests__/useRevisionTimeline.test.ts
+++ b/frontend/src/hooks/__tests__/useRevisionTimeline.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import useRevisionTimeline from "../useRevisionTimeline";
+import { createRevision } from "../../utils/revisionTimeline";
+
+describe("useRevisionTimeline", () => {
+  it("starts with an empty revisions list", () => {
+    const { result } = renderHook(() => useRevisionTimeline());
+    expect(result.current.revisions).toEqual([]);
+  });
+
+  it("saveRevision prepends a new revision to the list", () => {
+    const { result } = renderHook(() => useRevisionTimeline());
+    act(() => {
+      result.current.saveRevision("first content");
+    });
+    expect(result.current.revisions).toHaveLength(1);
+    expect(result.current.revisions[0].content).toBe("first content");
+  });
+
+  it("saveRevision prepends (most recent first)", () => {
+    const { result } = renderHook(() => useRevisionTimeline());
+    act(() => {
+      result.current.saveRevision("first");
+    });
+    act(() => {
+      result.current.saveRevision("second");
+    });
+    expect(result.current.revisions).toHaveLength(2);
+    expect(result.current.revisions[0].content).toBe("second");
+    expect(result.current.revisions[1].content).toBe("first");
+  });
+
+  it("each saved revision has id, timestamp, summary, and content", () => {
+    const { result } = renderHook(() => useRevisionTimeline());
+    act(() => {
+      result.current.saveRevision("hello world");
+    });
+    const rev = result.current.revisions[0];
+    expect(typeof rev.id).toBe("string");
+    expect(rev.id.length).toBeGreaterThan(0);
+    expect(typeof rev.timestamp).toBe("string");
+    expect(typeof rev.summary).toBe("string");
+    expect(rev.content).toBe("hello world");
+  });
+
+  it("uses a default summary when none is provided", () => {
+    const { result } = renderHook(() => useRevisionTimeline());
+    act(() => {
+      result.current.saveRevision("content");
+    });
+    expect(result.current.revisions[0].summary).toBe("Story updated");
+  });
+
+  it("createRevision accepts a custom summary", () => {
+    const rev = createRevision("content", "custom summary");
+    expect(rev.summary).toBe("custom summary");
+    expect(rev.content).toBe("content");
+  });
+
+  it("saveRevision is a function exposed on the returned object", () => {
+    const { result } = renderHook(() => useRevisionTimeline());
+    expect(typeof result.current.saveRevision).toBe("function");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #5898

This PR implements the work described in issue #5898: **add unit tests for useRevisionTimeline hook**.

### Changes
- Added `frontend/src/hooks/__tests__/useRevisionTimeline.test.ts` (7 tests) covering the `useRevisionTimeline` hook and the `createRevision` helper it depends on:
  - starts with an empty revisions list,
  - `saveRevision` prepends a new revision to the list,
  - `saveRevision` keeps the most recent revision first (prepend order),
  - each saved revision has `id`, `timestamp`, `summary`, and `content`,
  - uses a default summary (`"Story updated"`) when none is provided,
  - `createRevision` accepts a custom summary,
  - `saveRevision` is exposed as a function on the returned object.

### Verification
- `npx vitest run src/hooks/__tests__/useRevisionTimeline.test.ts` — all 7 tests pass locally.
- `eslint` on the file — clean.

### Notes
- Test-only PR; no production source changes. The `useRevisionTimeline` implementation is unchanged.

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
