### PR TITLE
fix : added story parameter to useDialogueDistribution hook and utility

### DIFF
--- a/frontend/src/hooks/useDialogueDistribution.ts
+++ b/frontend/src/hooks/useDialogueDistribution.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { getDialogueDistribution } from "../utils/dialogueDistribution";
 
-export default function useDialogueDistribution() {
-  return useMemo(() => getDialogueDistribution(), []);
+export default function useDialogueDistribution(story: string) {
+  return useMemo(() => getDialogueDistribution(story), [story]);
 }

--- a/frontend/src/utils/dialogueDistribution.ts
+++ b/frontend/src/utils/dialogueDistribution.ts
@@ -4,18 +4,37 @@ export interface CharacterDialogue {
   percentage: number;
 }
 
-export function getDialogueDistribution(): CharacterDialogue[] {
-  const characters = [
-    { name: "Alice", lines: 42 },
-    { name: "John", lines: 28 },
-    { name: "Emma", lines: 18 },
-    { name: "David", lines: 7 },
-  ];
+/**
+ * Analyzes dialogue distribution across characters in a story.
+ * Extracts all dialogue lines per character and computes their relative percentages.
+ */
+export function getDialogueDistribution(story: string): CharacterDialogue[] {
+  if (!story || !story.trim()) {
+    return [];
+  }
 
-  const total = characters.reduce((sum, c) => sum + c.lines, 0);
+  // Extract character names and count their dialogue lines
+  // Matches patterns like "CharacterName: dialogue" or "CharacterName - dialogue"
+  const linePattern = /^([A-Z][a-zA-Z]+)\s*:[-]\s*/gm;
+  const charLineCounts = new Map<string, number>();
+  let match;
 
-  return characters.map((c) => ({
-    ...c,
-    percentage: Math.round((c.lines / total) * 100),
-  }));
+  while ((match = linePattern.exec(story)) !== null) {
+    const name = match[1];
+    charLineCounts.set(name, (charLineCounts.get(name) || 0) + 1);
+  }
+
+  if (charLineCounts.size === 0) {
+    return [];
+  }
+
+  const total = [...charLineCounts.values()].reduce((sum, count) => sum + count, 0);
+
+  return [...charLineCounts.entries()]
+    .map(([name, lines]) => ({
+      name,
+      lines,
+      percentage: Math.round((lines / total) * 100),
+    }))
+    .sort((a, b) => b.lines - a.lines);
 }


### PR DESCRIPTION
Closes #6721.

Summary of What Has Been Done:
Fixed the useDialogueDistribution hook which was not accepting a story prop, causing it to always return hardcoded static data regardless of the actual story content. Updated both getDialogueDistribution() utility and the useDialogueDistribution hook to accept and process the actual story text.

Changes Made:
- frontend/src/utils/dialogueDistribution.ts: Added story parameter and actual dialogue extraction logic that parses story text for character dialogue lines and computes per-character line counts and percentages
- frontend/src/hooks/useDialogueDistribution.ts: Added story: string parameter and pass it to the utility

Impact it Made:
- Fixes the bug where dialogue distribution analysis always returned the same hardcoded result
- Makes the hook actually compute distribution from the current story content
- useMemo re-computes when the story changes