### PR TITLE
test : added unit tests for useGenreRecommendation hook

### DIFF
--- a/frontend/src/hooks/__tests__/useGenreRecommendation.test.ts
+++ b/frontend/src/hooks/__tests__/useGenreRecommendation.test.ts
@@ -1,0 +1,48 @@
+/**
+ * useGenreRecommendation.test.ts
+ * Unit tests for the useGenreRecommendation React hook.
+ */
+import { describe, it, expect } from "vitest";
+import { renderHook } from "@testing-library/react";
+import useGenreRecommendation from "../useGenreRecommendation";
+
+describe("useGenreRecommendation", () => {
+  it("returns an array of genre recommendations", () => {
+    const { result } = renderHook(() => useGenreRecommendation());
+    expect(Array.isArray(result.current)).toBe(true);
+    expect(result.current.length).toBeGreaterThan(0);
+  });
+
+  it("each recommendation has genre, confidence, and reason fields", () => {
+    const { result } = renderHook(() => useGenreRecommendation());
+    result.current.forEach((rec) => {
+      expect(typeof rec.genre).toBe("string");
+      expect(typeof rec.confidence).toBe("number");
+      expect(typeof rec.reason).toBe("string");
+    });
+  });
+
+  it("confidence scores are within valid range", () => {
+    const { result } = renderHook(() => useGenreRecommendation());
+    result.current.forEach((rec) => {
+      expect(rec.confidence).toBeGreaterThanOrEqual(0);
+      expect(rec.confidence).toBeLessThanOrEqual(100);
+    });
+  });
+
+  it("returns the same reference on repeated renders (memoization)", () => {
+    const { result, rerender } = renderHook(() => useGenreRecommendation());
+    const firstResult = result.current;
+
+    rerender();
+    rerender();
+    rerender();
+
+    expect(result.current).toBe(firstResult);
+  });
+
+  it("includes at least one genre recommendation", () => {
+    const { result } = renderHook(() => useGenreRecommendation());
+    expect(result.current.length).toBeGreaterThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
Closes #6722.

Summary of What Has Been Done:
Added unit tests for the useGenreRecommendation hook in frontend/src/hooks/__tests__/useGenreRecommendation.test.ts. The hook returns a memoized result from getGenreRecommendations() and tests cover the expected return type, recommendation structure, confidence score validity, memoization behavior, and minimum content requirements.

Changes Made:
- frontend/src/hooks/__tests__/useGenreRecommendation.test.ts: New test file with 5 test cases

Impact it Made:
- Adds test coverage for a previously untested hook
- Verifies the hook returns the correct data structure
- Confirms memoization prevents unnecessary re-computation