### PR TITLE
test : added unit tests for useCallbackDetector hook

### DIFF
--- a/frontend/src/hooks/__tests__/useCallbackDetector.test.ts
+++ b/frontend/src/hooks/__tests__/useCallbackDetector.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { renderHook } from "@testing-library/react";
+import useCallbackDetector from "../useCallbackDetector";
+import { CallbackItem } from "../../utils/callbackDetector";
+
+describe("useCallbackDetector hook", () => {
+  it("returns an object with callbacks and rerunAnalysis", () => {
+    const { result } = renderHook(() => useCallbackDetector());
+    expect(result.current).toHaveProperty("callbacks");
+    expect(result.current).toHaveProperty("rerunAnalysis");
+  });
+
+  it("returns an array of callbacks", () => {
+    const { result } = renderHook(() => useCallbackDetector());
+    expect(Array.isArray(result.current.callbacks)).toBe(true);
+  });
+
+  it("returns a function for rerunAnalysis", () => {
+    const { result } = renderHook(() => useCallbackDetector());
+    expect(typeof result.current.rerunAnalysis).toBe("function");
+  });
+
+  it("callbacks array contains objects with expected shape", () => {
+    const { result } = renderHook(() => useCallbackDetector());
+    result.current.callbacks.forEach((item: CallbackItem) => {
+      expect(item).toHaveProperty("id");
+      expect(item).toHaveProperty("element");
+      expect(item).toHaveProperty("firstAppearance");
+      expect(item).toHaveProperty("callback");
+      expect(item).toHaveProperty("suggestion");
+    });
+  });
+});


### PR DESCRIPTION
Closes #6731.

Summary of What Has Been Done:
Added unit tests for the useCallbackDetector hook at frontend/src/hooks/useCallbackDetector.ts. Tests cover the expected return shape, callback array structure, and rerunAnalysis function.

Changes Made:
- Created frontend/src/hooks/__tests__/useCallbackDetector.test.ts

Impact it Made:
- Test coverage for a hook used in the story analysis pipeline
- Verified correct return structure and callback array shape

Note: Please assign this PR to the `tmdeveloper007` account.