### PR TITLE
fix : deferred object URL revocation in downloadBlob

### DIFF
--- a/frontend/src/utils/story-export.utils.ts
+++ b/frontend/src/utils/story-export.utils.ts
@@ -25,7 +25,10 @@ export const downloadBlob = (blob: Blob, fileName: string): void => {
   link.click();
   link.remove();
 
-  URL.revokeObjectURL(url);
+  // Defer revocation so the browser has time to complete the download
+  // before the URL is invalidated. Synchronous revocation can cause
+  // silent failures in Firefox and Safari.
+  setTimeout(() => URL.revokeObjectURL(url), 0);
 };
 
 const escapeHtml = (value: string): string =>


### PR DESCRIPTION
Closes #6733.

Summary of What Has Been Done:
Fixed the downloadBlob function in frontend/src/utils/story-export.utils.ts to defer the URL.revokeObjectURL call using setTimeout, preventing silent download failures in Firefox and Safari where synchronous revocation could occur before the browser finished reading the URL.

Changes Made:
- frontend/src/utils/story-export.utils.ts: changed synchronous URL.revokeObjectURL(url) to setTimeout(() => URL.revokeObjectURL(url), 0)

Impact it Made:
- Downloads now work reliably in Firefox and Safari
- No behavior change for Chrome users
- All lint and typecheck checks pass

Note: Please assign this PR to the `tmdeveloper007` account.