### PR TITLE
test : added unit tests for useCallbackDetector hook

### DIFF
--- a/frontend/src/hooks/__tests__/useCallbackDetector.test.ts
+++ b/frontend/src/hooks/__tests__/useCallbackDetector.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { renderHook } from "@testing-library/react";
+import useCallbackDetector from "../useCallbackDetector";
+
+describe("useCallbackDetector", () => {
+  it("returns a callbacks array", () => {
+    const { result } = renderHook(() => useCallbackDetector());
+    expect(result.current.callbacks).toBeDefined();
+    expect(Array.isArray(result.current.callbacks)).toBe(true);
+  });
+
+  it("returns callbacks with expected structure", () => {
+    const { result } = renderHook(() => useCallbackDetector());
+    const callbacks = result.current.callbacks;
+
+    callbacks.forEach((cb: any) => {
+      expect(cb).toHaveProperty("id");
+      expect(cb).toHaveProperty("element");
+      expect(cb).toHaveProperty("firstAppearance");
+      expect(cb).toHaveProperty("callback");
+      expect(cb).toHaveProperty("suggestion");
+      expect(typeof cb.id).toBe("number");
+      expect(typeof cb.element).toBe("string");
+      expect(typeof cb.firstAppearance).toBe("string");
+      expect(typeof cb.callback).toBe("string");
+      expect(typeof cb.suggestion).toBe("string");
+    });
+  });
+
+  it("returns a rerunAnalysis function", () => {
+    const { result } = renderHook(() => useCallbackDetector());
+    expect(typeof result.current.rerunAnalysis).toBe("function");
+  });
+
+  it("memoizes callbacks — returns the same array on re-render", () => {
+    const { result, rerender } = renderHook(() => useCallbackDetector());
+    const first = result.current.callbacks;
+    rerender();
+    expect(result.current.callbacks).toBe(first);
+  });
+});


### PR DESCRIPTION
Closes #6743.

Summary of What Has Been Done:
Added vitest unit tests for the useCallbackDetector hook at frontend/src/hooks/useCallbackDetector.ts. The tests verify that the hook returns a callbacks array with the expected structure, that rerunAnalysis is a callable function, and that useMemo caches the callbacks result across re-renders.

Changes Made:
- frontend/src/hooks/__tests__/useCallbackDetector.test.ts: new test file with 4 test cases

Impact it Made:
- Test coverage for a previously untested hook
- All 4 tests pass locally via vitest

Note: Please assign this PR to the `tmdeveloper007` account.