### PR TITLE
fix : replace alert() in useCallbackDetector with onComplete callback prop

### DIFF
--- a/frontend/src/hooks/__tests__/useCallbackDetector.test.ts
+++ b/frontend/src/hooks/__tests__/useCallbackDetector.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import useCallbackDetector from "../useCallbackDetector";
+
+describe("useCallbackDetector", () => {
+  it("returns a callbacks array", () => {
+    const { result } = renderHook(() => useCallbackDetector());
+    expect(result.current.callbacks).toBeDefined();
+    expect(Array.isArray(result.current.callbacks)).toBe(true);
+  });
+
+  it("returns callbacks with expected structure", () => {
+    const { result } = renderHook(() => useCallbackDetector());
+    const callbacks = result.current.callbacks;
+
+    callbacks.forEach((cb: any) => {
+      expect(cb).toHaveProperty("id");
+      expect(cb).toHaveProperty("element");
+      expect(cb).toHaveProperty("firstAppearance");
+      expect(cb).toHaveProperty("callback");
+      expect(cb).toHaveProperty("suggestion");
+      expect(typeof cb.id).toBe("number");
+      expect(typeof cb.element).toBe("string");
+      expect(typeof cb.firstAppearance).toBe("string");
+      expect(typeof cb.callback).toBe("string");
+      expect(typeof cb.suggestion).toBe("string");
+    });
+  });
+
+  it("returns a rerunAnalysis function", () => {
+    const { result } = renderHook(() => useCallbackDetector());
+    expect(typeof result.current.rerunAnalysis).toBe("function");
+  });
+
+  it("memoizes callbacks — returns the same array on re-render", () => {
+    const { result, rerender } = renderHook(() => useCallbackDetector());
+    const first = result.current.callbacks;
+    rerender();
+    expect(result.current.callbacks).toBe(first);
+  });
+
+  it("calls onComplete when rerunAnalysis is invoked", () => {
+    const onComplete = vi.fn();
+    const { result } = renderHook(() => useCallbackDetector({ onComplete }));
+    result.current.rerunAnalysis();
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not throw when onComplete is not provided", () => {
+    const { result } = renderHook(() => useCallbackDetector());
+    expect(() => result.current.rerunAnalysis()).not.toThrow();
+  });
+});

--- a/frontend/src/hooks/useCallbackDetector.ts
+++ b/frontend/src/hooks/useCallbackDetector.ts
@@ -1,11 +1,19 @@
 import { useMemo } from "react";
 import { getCallbacks } from "../utils/callbackDetector";
 
-export default function useCallbackDetector() {
+interface UseCallbackDetectorOptions {
+  onComplete?: () => void;
+}
+
+export default function useCallbackDetector(options: UseCallbackDetectorOptions = {}) {
+  const { onComplete } = options;
+
   const callbacks = useMemo(() => getCallbacks(), []);
 
   const rerunAnalysis = () => {
-    alert("Callback analysis completed.");
+    if (onComplete) {
+      onComplete();
+    }
   };
 
   return {


### PR DESCRIPTION
Closes #6745.

Summary of What Has Been Done:
Replaced the window.alert() call inside useCallbackDetector's rerunAnalysis with an optional onComplete callback prop. This makes the hook suitable for production use — callers can handle completion notifications via toast, state, or any other UI mechanism. Also added unit tests covering the callback invocation and existing behavior.

Changes Made:
- frontend/src/hooks/useCallbackDetector.ts: added onComplete: () => void optional prop, removed alert()
- frontend/src/hooks/__tests__/useCallbackDetector.test.ts: new test file with 6 test cases

Impact it Made:
- Removes alert() anti-pattern from production React code
- Adds test coverage for the hook
- All 6 tests pass locally via vitest

Note: Please assign this PR to the `tmdeveloper007` account.