### PR TITLE
feat : added onComplete callback to useEndingSatisfaction hook

### DIFF
--- a/frontend/src/hooks/__tests__/useEndingSatisfaction.test.ts
+++ b/frontend/src/hooks/__tests__/useEndingSatisfaction.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import useEndingSatisfaction from "../useEndingSatisfaction";
+
+describe("useEndingSatisfaction", () => {
+  it("returns a metrics array", () => {
+    const { result } = renderHook(() => useEndingSatisfaction());
+    expect(Array.isArray(result.current.metrics)).toBe(true);
+  });
+
+  it("returns an overallScore number", () => {
+    const { result } = renderHook(() => useEndingSatisfaction());
+    expect(typeof result.current.overallScore).toBe("number");
+  });
+
+  it("returns a rerunAnalysis function", () => {
+    const { result } = renderHook(() => useEndingSatisfaction());
+    expect(typeof result.current.rerunAnalysis).toBe("function");
+  });
+
+  it("computes overallScore as average of metric scores", () => {
+    const { result } = renderHook(() => useEndingSatisfaction());
+    const { metrics, overallScore } = result.current;
+    const expected = Math.round(
+      metrics.reduce((sum, item) => sum + item.score, 0) / metrics.length
+    );
+    expect(overallScore).toBe(expected);
+  });
+
+  it("calls onComplete when rerunAnalysis is invoked", () => {
+    const onComplete = vi.fn();
+    const { result } = renderHook(() => useEndingSatisfaction({ onComplete }));
+    result.current.rerunAnalysis();
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not throw when onComplete is not provided", () => {
+    const { result } = renderHook(() => useEndingSatisfaction());
+    expect(() => result.current.rerunAnalysis()).not.toThrow();
+  });
+});

--- a/frontend/src/hooks/useEndingSatisfaction.ts
+++ b/frontend/src/hooks/useEndingSatisfaction.ts
@@ -1,7 +1,13 @@
 import { useMemo } from "react";
 import { getEndingMetrics } from "../utils/endingSatisfaction";
 
-export default function useEndingSatisfaction() {
+interface UseEndingSatisfactionOptions {
+  onComplete?: () => void;
+}
+
+export default function useEndingSatisfaction(options: UseEndingSatisfactionOptions = {}) {
+  const { onComplete } = options;
+
   const metrics = useMemo(() => getEndingMetrics(), []);
 
   const overallScore = Math.round(
@@ -10,7 +16,9 @@ export default function useEndingSatisfaction() {
   );
 
   const rerunAnalysis = () => {
-    alert("Ending analysis completed.");
+    if (onComplete) {
+      onComplete();
+    }
   };
 
   return {


### PR DESCRIPTION
Closes #6746.

Summary of What Has Been Done:
Added an optional onComplete callback prop to the useEndingSatisfaction hook, replacing the window.alert() call in rerunAnalysis with a callback mechanism. This allows parent components to handle completion notifications in a UI-appropriate way. Also added unit tests covering the new callback behavior and existing functionality.

Changes Made:
- frontend/src/hooks/useEndingSatisfaction.ts: added onComplete: () => void optional prop, removed alert()
- frontend/src/hooks/__tests__/useEndingSatisfaction.test.ts: new test file with 6 test cases

Impact it Made:
- Removes alert() anti-pattern from production React code
- Improves API ergonomics with a callback pattern
- All 6 tests pass locally via vitest

Note: Please assign this PR to the `tmdeveloper007` account.