### PR TITLE
fix: use e.key '?' for help shortcut to support non-US keyboards

### DIFF
--- a/frontend/src/hooks/__tests__/useKeyboardShortcuts.test.tsx
+++ b/frontend/src/hooks/__tests__/useKeyboardShortcuts.test.tsx
@@ -105,7 +105,7 @@ describe("useKeyboardShortcuts", () => {
     expect(removeEventListenerSpy).toHaveBeenCalledWith("keydown", handler);
   });
 
-  describe("shift+/ shortcut", () => {
+  describe("? shortcut", () => {
     it("calls onOpenHelp and prevents default", async () => {
       const { unmount } = await renderShortcuts();
       const handler = getKeydownHandler();
@@ -120,6 +120,44 @@ describe("useKeyboardShortcuts", () => {
       handler!(event);
       expect(onOpenHelp).toHaveBeenCalledTimes(1);
       expect(event.preventDefault).toHaveBeenCalled();
+      unmount();
+      currentHook = null;
+    });
+
+    it("works on non-US layouts where ? is on a different physical key", async () => {
+      // On German QWERTZ, "?" is Shift+"/" which is the "Slash" key, but on
+      // other layouts (e.g. some AZERTY) the "?" character maps to a different
+      // e.code. The shortcut must fire on e.key === "?", not on e.code.
+      const { unmount } = await renderShortcuts();
+      const handler = getKeydownHandler();
+      expect(handler).toBeDefined();
+
+      const event = makeKeyboardEvent({
+        shiftKey: true,
+        code: "IntlBackslash", // not "Slash"
+        key: "?",
+      });
+
+      handler!(event);
+      expect(onOpenHelp).toHaveBeenCalledTimes(1);
+      expect(event.preventDefault).toHaveBeenCalled();
+      unmount();
+      currentHook = null;
+    });
+
+    it("does not trigger on plain / without shift producing ?", async () => {
+      const { unmount } = await renderShortcuts();
+      const handler = getKeydownHandler();
+      expect(handler).toBeDefined();
+
+      const event = makeKeyboardEvent({
+        shiftKey: false,
+        code: "Slash",
+        key: "/",
+      });
+
+      handler!(event);
+      expect(onOpenHelp).not.toHaveBeenCalled();
       unmount();
       currentHook = null;
     });

--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -44,7 +44,9 @@ const useKeyboardShortcuts = ({
         active !== null &&
         ["INPUT", "TEXTAREA", "SELECT"].includes(active.tagName);
 
-      if (e.shiftKey && e.code === "Slash") {
+      // Use e.key ("?") instead of e.code ("Slash") so the shortcut works on
+      // non-US layouts (QWERTZ, AZERTY, ...) where ? is on a different key.
+      if (e.key === "?") {
         e.preventDefault();
         handlersRef.current.onOpenHelp();
         return;


### PR DESCRIPTION
## Summary
- Fixes #6598
- The help modal shortcut checked \`e.shiftKey && e.code === "Slash"\`. \`e.code\` refers to the physical key position on a US QWERTY layout, so on QWERTZ / AZERTY / UK and other layouts the \`?\` character is on a different physical key with a different \`e.code\`, breaking the shortcut.

## Changes
- In \`frontend/src/hooks/useKeyboardShortcuts.ts\`, replaced \`e.shiftKey && e.code === "Slash"\` with \`e.key === "?"\`. \`e.key\` reflects the actual produced character regardless of physical layout, so a single character comparison covers both the shift state and the layout.
- Updated the existing \`shift+/ shortcut\` test describe block to \`? shortcut\` and added two tests:
  - fires on \`key: "?"\` even when \`code\` is **not** \`"Slash"\` (non-US layout case)
  - does **not** fire on plain \`/\` (no \`?\` produced)

## Verification
\`\`\`
frontend $ npm test -- useKeyboardShortcuts
 ✓ src/hooks/__tests__/useKeyboardShortcuts.test.tsx (11 tests)
 Test Files  1 passed (1)
      Tests  11 passed (11)
\`\`\`

---
_This pull request was created by an AI agent (OpenHands) on behalf of saidai-bhuvanesh._