### PR TITLE
Add requested feature

### DIFF
--- a/backend/llm_service.py
+++ b/backend/llm_service.py
@@ -1,0 +1,164 @@
+"""
+llm_service.py
+--------------
+LLM integration and dynamic context injection service.
+Scans user prompt for lorebook keywords and injects strict lore directive blocks
+into system prompts for OpenAI, Anthropic, or Gemini story generation.
+"""
+
+import os
+from typing import Dict, List, Optional, Tuple, Any
+from lorebook import find_matching_lore, get_lore_entries
+
+
+LORE_DIRECTIVE_HEADER = "[WORLD LORE & RULES - STRICT ADHERENCE REQUIRED]"
+
+
+def inject_lore_into_system_prompt(
+    prompt: str,
+    base_system_prompt: str = "",
+    user_id: Optional[str] = None,
+    universe_id: Optional[str] = None,
+    entries: Optional[List[Dict[str, Any]]] = None,
+    db_path: Optional[str] = None
+) -> Tuple[str, List[Dict[str, Any]]]:
+    """
+    Scans `prompt` for lore keywords and injects matched lore rules into `base_system_prompt`.
+
+    Returns:
+        Tuple of (augmented_system_prompt, list_of_matched_entries)
+    """
+    matched_entries = find_matching_lore(
+        text=prompt,
+        user_id=user_id,
+        universe_id=universe_id,
+        custom_entries=entries,
+        db_path=db_path
+    )
+
+    if not matched_entries:
+        return base_system_prompt, []
+
+    # Build structured lore instruction block
+    lore_lines = [LORE_DIRECTIVE_HEADER]
+    lore_lines.append(
+        "The story prompt references specific world elements below. You MUST strictly adhere to all of the following rules, locations, and lore constraints without contradiction:"
+    )
+
+    for entry in matched_entries:
+        key = entry.get("key", "").strip()
+        category = entry.get("category", "general").strip()
+        content = entry.get("content", "").strip()
+        lore_lines.append(f"• [{key} ({category.upper()})]: {content}")
+
+    lore_block = "\n".join(lore_lines)
+
+    if base_system_prompt and base_system_prompt.strip():
+        augmented = f"{base_system_prompt.strip()}\n\n{lore_block}"
+    else:
+        augmented = lore_block
+
+    return augmented, matched_entries
+
+
+class LLMService:
+    """Service to handle LLM story generation with automatic lore injection."""
+
+    def __init__(self, default_provider: str = "openai"):
+        self.default_provider = default_provider
+
+    def generate_story_with_lore(
+        self,
+        prompt: str,
+        base_system_prompt: str = "You are an expert creative story generator. Craft vivid, compelling narratives.",
+        user_id: Optional[str] = None,
+        universe_id: Optional[str] = None,
+        entries: Optional[List[Dict[str, Any]]] = None,
+        provider: Optional[str] = None,
+        db_path: Optional[str] = None,
+        max_tokens: int = 1000,
+        temperature: float = 0.7
+    ) -> Dict[str, Any]:
+        """
+        Executes story generation after dynamically injecting matching lore into the system prompt.
+        """
+        selected_provider = provider or self.default_provider
+
+        # 1. Inject matching lore into system prompt
+        augmented_system_prompt, matched = inject_lore_into_system_prompt(
+            prompt=prompt,
+            base_system_prompt=base_system_prompt,
+            user_id=user_id,
+            universe_id=universe_id,
+            entries=entries,
+            db_path=db_path
+        )
+
+        # 2. Attempt call to LLM APIs or fallback to rich mock generator
+        openai_key = os.getenv("OPENAI_API_KEY")
+        anthropic_key = os.getenv("ANTHROPIC_API_KEY")
+
+        content = None
+        used_provider = "mock"
+
+        if selected_provider == "openai" and openai_key:
+            try:
+                from openai import OpenAI
+                client = OpenAI(api_key=openai_key)
+                response = client.chat.completions.create(
+                    model="gpt-4o-mini",
+                    messages=[
+                        {"role": "system", "content": augmented_system_prompt},
+                        {"role": "user", "content": prompt}
+                    ],
+                    max_tokens=max_tokens,
+                    temperature=temperature
+                )
+                content = response.choices[0].message.content
+                used_provider = "openai"
+            except Exception as e:
+                content = None
+
+        elif selected_provider == "anthropic" and anthropic_key:
+            try:
+                import anthropic
+                client = anthropic.Anthropic(api_key=anthropic_key)
+                response = client.messages.create(
+                    model="claude-3-haiku-20240307",
+                    system=augmented_system_prompt,
+                    messages=[{"role": "user", "content": prompt}],
+                    max_tokens=max_tokens,
+                    temperature=temperature
+                )
+                content = response.content[0].text
+                used_provider = "anthropic"
+            except Exception as e:
+                content = None
+
+        # Fallback simulated response for offline/local testing
+        if content is None:
+            used_provider = "mock_simulator"
+            lore_mention_text = ""
+            if matched:
+                lore_summary = ", ".join([f"'{e['key']}' ({e['category']})" for e in matched])
+                lore_mention_text = f"\n\n[Lore Adherence Applied for: {lore_summary}]"
+            
+            content = (
+                f"Story Generation Output:\n"
+                f"The story unfolds seamlessly based on your prompt: '{prompt}'.\n"
+                f"{lore_mention_text}\n"
+                f"Every detail strictly reflects the established setting rules and lore specifications."
+            )
+
+        return {
+            "prompt": prompt,
+            "system_prompt": augmented_system_prompt,
+            "matched_lore_count": len(matched),
+            "matched_entries": matched,
+            "provider": used_provider,
+            "generated_story": content
+        }
+
+
+# Global helper instance
+llm_service = LLMService()

--- a/backend/lorebook.py
+++ b/backend/lorebook.py
@@ -1,0 +1,345 @@
+"""
+lorebook.py
+-----------
+Backend database model, keyword matcher, and REST API blueprint for the Lorebook feature.
+Stores lorebook entries (rules, locations, magic systems, characters, etc.) and offers
+dynamic keyword matching for context injection into LLM system prompts.
+"""
+
+import os
+import re
+import sqlite3
+import time
+from typing import Dict, List, Optional, Any
+from flask import Blueprint, jsonify, request
+
+DEFAULT_DB_PATH = os.getenv("LOREBOOK_DB_PATH", os.path.join(os.path.dirname(__file__), "lorebook.db"))
+
+lorebook_bp = Blueprint("lorebook", __name__, url_prefix="/api/lorebook")
+
+
+def get_db_connection(db_path: Optional[str] = None) -> sqlite3.Connection:
+    """Creates and returns a sqlite3 database connection with Row factory enabled."""
+    path = db_path or DEFAULT_DB_PATH
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_db(db_path: Optional[str] = None) -> None:
+    """Initializes the lorebook_entries database schema if it doesn't already exist."""
+    conn = get_db_connection(db_path)
+    cursor = conn.cursor()
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS lorebook_entries (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT,
+            universe_id TEXT,
+            key TEXT NOT NULL,
+            category TEXT NOT NULL DEFAULT 'general',
+            content TEXT NOT NULL,
+            is_active INTEGER NOT NULL DEFAULT 1,
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL
+        )
+    """)
+    cursor.execute("CREATE INDEX IF NOT EXISTS idx_lorebook_user ON lorebook_entries(user_id)")
+    cursor.execute("CREATE INDEX IF NOT EXISTS idx_lorebook_universe ON lorebook_entries(universe_id)")
+    cursor.execute("CREATE INDEX IF NOT EXISTS idx_lorebook_key ON lorebook_entries(key)")
+    conn.commit()
+    conn.close()
+
+
+def _row_to_dict(row: sqlite3.Row) -> Dict[str, Any]:
+    """Converts SQLite Row to dictionary with boolean for is_active."""
+    d = dict(row)
+    d["is_active"] = bool(d["is_active"])
+    return d
+
+
+def add_lore_entry(
+    key: str,
+    content: str,
+    category: str = "general",
+    user_id: Optional[str] = None,
+    universe_id: Optional[str] = None,
+    is_active: bool = True,
+    db_path: Optional[str] = None
+) -> Dict[str, Any]:
+    """Inserts a new lorebook entry into the database."""
+    init_db(db_path)
+    now = time.time()
+    conn = get_db_connection(db_path)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        INSERT INTO lorebook_entries (user_id, universe_id, key, category, content, is_active, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (user_id, universe_id, key.strip(), category.strip().lower(), content.strip(), 1 if is_active else 0, now, now)
+    )
+    entry_id = cursor.lastrowid
+    conn.commit()
+    
+    cursor.execute("SELECT * FROM lorebook_entries WHERE id = ?", (entry_id,))
+    row = cursor.fetchone()
+    conn.close()
+    return _row_to_dict(row)
+
+
+def get_lore_entries(
+    user_id: Optional[str] = None,
+    universe_id: Optional[str] = None,
+    category: Optional[str] = None,
+    active_only: bool = False,
+    db_path: Optional[str] = None
+) -> List[Dict[str, Any]]:
+    """Retrieves lore entries matching optional filters."""
+    init_db(db_path)
+    conn = get_db_connection(db_path)
+    cursor = conn.cursor()
+
+    query = "SELECT * FROM lorebook_entries WHERE 1=1"
+    params: List[Any] = []
+
+    if user_id is not None:
+        query += " AND (user_id = ? OR user_id IS NULL)"
+        params.append(user_id)
+    if universe_id is not None:
+        query += " AND (universe_id = ? OR universe_id IS NULL)"
+        params.append(universe_id)
+    if category is not None and category.strip():
+        query += " AND category = ?"
+        params.append(category.strip().lower())
+    if active_only:
+        query += " AND is_active = 1"
+
+    query += " ORDER BY created_at DESC"
+
+    cursor.execute(query, params)
+    rows = cursor.fetchall()
+    conn.close()
+    return [_row_to_dict(row) for row in rows]
+
+
+def get_lore_entry_by_id(entry_id: int, db_path: Optional[str] = None) -> Optional[Dict[str, Any]]:
+    """Retrieves a single lore entry by ID."""
+    init_db(db_path)
+    conn = get_db_connection(db_path)
+    cursor = conn.cursor()
+    cursor.execute("SELECT * FROM lorebook_entries WHERE id = ?", (entry_id,))
+    row = cursor.fetchone()
+    conn.close()
+    return _row_to_dict(row) if row else None
+
+
+def update_lore_entry(
+    entry_id: int,
+    key: Optional[str] = None,
+    content: Optional[str] = None,
+    category: Optional[str] = None,
+    is_active: Optional[bool] = None,
+    user_id: Optional[str] = None,
+    universe_id: Optional[str] = None,
+    db_path: Optional[str] = None
+) -> Optional[Dict[str, Any]]:
+    """Updates an existing lore entry fields."""
+    init_db(db_path)
+    entry = get_lore_entry_by_id(entry_id, db_path)
+    if not entry:
+        return None
+
+    now = time.time()
+    updates = []
+    params: List[Any] = []
+
+    if key is not None:
+        updates.append("key = ?")
+        params.append(key.strip())
+    if content is not None:
+        updates.append("content = ?")
+        params.append(content.strip())
+    if category is not None:
+        updates.append("category = ?")
+        params.append(category.strip().lower())
+    if is_active is not None:
+        updates.append("is_active = ?")
+        params.append(1 if is_active else 0)
+    if user_id is not None:
+        updates.append("user_id = ?")
+        params.append(user_id)
+    if universe_id is not None:
+        updates.append("universe_id = ?")
+        params.append(universe_id)
+
+    if not updates:
+        return entry
+
+    updates.append("updated_at = ?")
+    params.append(now)
+    params.append(entry_id)
+
+    conn = get_db_connection(db_path)
+    cursor = conn.cursor()
+    cursor.execute(f"UPDATE lorebook_entries SET {', '.join(updates)} WHERE id = ?", params)
+    conn.commit()
+    conn.close()
+
+    return get_lore_entry_by_id(entry_id, db_path)
+
+
+def delete_lore_entry(entry_id: int, db_path: Optional[str] = None) -> bool:
+    """Deletes a lore entry by ID."""
+    init_db(db_path)
+    conn = get_db_connection(db_path)
+    cursor = conn.cursor()
+    cursor.execute("DELETE FROM lorebook_entries WHERE id = ?", (entry_id,))
+    affected = cursor.rowcount
+    conn.commit()
+    conn.close()
+    return affected > 0
+
+
+def find_matching_lore(
+    text: str,
+    user_id: Optional[str] = None,
+    universe_id: Optional[str] = None,
+    db_path: Optional[str] = None,
+    custom_entries: Optional[List[Dict[str, Any]]] = None
+) -> List[Dict[str, Any]]:
+    """
+    Scans `text` for active lorebook entry keywords.
+    Uses case-insensitive word-boundary matching so that keywords like 'Hogwarts'
+    match 'hogwarts' or 'Hogwarts,' but not partial words unless key contains non-word chars.
+    Returns list of matched entry dicts.
+    """
+    if not text or not text.strip():
+        return []
+
+    entries = custom_entries
+    if entries is None:
+        entries = get_lore_entries(user_id=user_id, universe_id=universe_id, active_only=True, db_path=db_path)
+
+    matched = []
+    text_lower = text.lower()
+
+    for entry in entries:
+        if not entry.get("is_active", True):
+            continue
+        
+        key = entry.get("key", "").strip()
+        if not key:
+            continue
+
+        # Prepare regex pattern with word boundaries for alphanumeric keys
+        key_pattern = re.escape(key.lower())
+        pattern = rf"\b{key_pattern}\b"
+        
+        if re.search(pattern, text_lower):
+            matched.append(entry)
+
+    return matched
+
+
+# ── Flask REST API Endpoints ───────────────────────────────────────────────────
+
+@lorebook_bp.route("", methods=["GET"])
+def api_get_entries():
+    """Fetch lore entries."""
+    user_id = request.args.get("user_id")
+    universe_id = request.args.get("universe_id")
+    category = request.args.get("category")
+    active_only = request.args.get("active_only", "false").lower() in ("true", "1")
+
+    entries = get_lore_entries(
+        user_id=user_id,
+        universe_id=universe_id,
+        category=category,
+        active_only=active_only
+    )
+    return jsonify({"entries": entries, "total": len(entries)})
+
+
+@lorebook_bp.route("", methods=["POST"])
+def api_create_entry():
+    """Create a new lore entry."""
+    data = request.get_json(force=True) or {}
+    key = data.get("key")
+    content = data.get("content")
+    category = data.get("category", "general")
+    user_id = data.get("user_id")
+    universe_id = data.get("universe_id")
+    is_active = data.get("is_active", True)
+
+    if not key or not isinstance(key, str) or not key.strip():
+        return jsonify({"error": "Field 'key' is required and must be a non-empty string"}), 400
+    if not content or not isinstance(content, str) or not content.strip():
+        return jsonify({"error": "Field 'content' is required and must be a non-empty string"}), 400
+
+    entry = add_lore_entry(
+        key=key,
+        content=content,
+        category=category,
+        user_id=user_id,
+        universe_id=universe_id,
+        is_active=is_active
+    )
+    return jsonify({"message": "Lore entry created successfully", "entry": entry}), 201
+
+
+@lorebook_bp.route("/<int:entry_id>", methods=["GET"])
+def api_get_entry(entry_id: int):
+    """Fetch single entry by ID."""
+    entry = get_lore_entry_by_id(entry_id)
+    if not entry:
+        return jsonify({"error": f"Lore entry with ID {entry_id} not found"}), 404
+    return jsonify({"entry": entry})
+
+
+@lorebook_bp.route("/<int:entry_id>", methods=["PUT"])
+def api_update_entry(entry_id: int):
+    """Update an existing entry."""
+    data = request.get_json(force=True) or {}
+    entry = update_lore_entry(
+        entry_id=entry_id,
+        key=data.get("key"),
+        content=data.get("content"),
+        category=data.get("category"),
+        is_active=data.get("is_active"),
+        user_id=data.get("user_id"),
+        universe_id=data.get("universe_id")
+    )
+    if not entry:
+        return jsonify({"error": f"Lore entry with ID {entry_id} not found"}), 404
+    return jsonify({"message": "Lore entry updated successfully", "entry": entry})
+
+
+@lorebook_bp.route("/<int:entry_id>", methods=["DELETE"])
+def api_delete_entry(entry_id: int):
+    """Delete an entry."""
+    success = delete_lore_entry(entry_id)
+    if not success:
+        return jsonify({"error": f"Lore entry with ID {entry_id} not found"}), 404
+    return jsonify({"message": f"Lore entry {entry_id} deleted successfully"})
+
+
+@lorebook_bp.route("/match", methods=["POST"])
+def api_match_prompt():
+    """Scans prompt for lore matching entries."""
+    data = request.get_json(force=True) or {}
+    prompt = data.get("prompt", "")
+    user_id = data.get("user_id")
+    universe_id = data.get("universe_id")
+    custom_entries = data.get("custom_entries")
+
+    matched = find_matching_lore(
+        text=prompt,
+        user_id=user_id,
+        universe_id=universe_id,
+        custom_entries=custom_entries
+    )
+    return jsonify({
+        "prompt": prompt,
+        "matched_count": len(matched),
+        "matched_entries": matched
+    })

--- a/backend/tests/test_llm_service.py
+++ b/backend/tests/test_llm_service.py
@@ -1,0 +1,92 @@
+"""
+tests/test_llm_service.py
+--------------------------
+Unit tests for backend/llm_service.py context injection logic.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from lorebook import init_db, add_lore_entry
+from llm_service import inject_lore_into_system_prompt, LLMService, LORE_DIRECTIVE_HEADER
+
+
+class TestLLMService(unittest.TestCase):
+
+    def setUp(self):
+        self.db_fd, self.db_path = tempfile.mkstemp(suffix=".db")
+        init_db(self.db_path)
+        
+        add_lore_entry(
+            key="Hogwarts",
+            content="A magical school in Scotland hidden from muggles.",
+            category="location",
+            db_path=self.db_path
+        )
+        add_lore_entry(
+            key="Ancient Runes",
+            content="Protection spells cast using stone symbols.",
+            category="magic_system",
+            db_path=self.db_path
+        )
+
+    def tearDown(self):
+        os.close(self.db_fd)
+        os.unlink(self.db_path)
+
+    def test_inject_lore_into_system_prompt_single_match(self):
+        prompt = "Write a scene about a student arriving at Hogwarts."
+        base_prompt = "You are a fantasy writer."
+
+        augmented, matched = inject_lore_into_system_prompt(
+            prompt=prompt,
+            base_system_prompt=base_prompt,
+            db_path=self.db_path
+        )
+
+        self.assertEqual(len(matched), 1)
+        self.assertEqual(matched[0]["key"], "Hogwarts")
+        self.assertIn("You are a fantasy writer.", augmented)
+        self.assertIn(LORE_DIRECTIVE_HEADER, augmented)
+        self.assertIn("[Hogwarts (LOCATION)]: A magical school in Scotland hidden from muggles.", augmented)
+
+    def test_inject_lore_into_system_prompt_multiple_matches(self):
+        prompt = "The student entered Hogwarts to study Ancient Runes."
+        augmented, matched = inject_lore_into_system_prompt(
+            prompt=prompt,
+            db_path=self.db_path
+        )
+
+        self.assertEqual(len(matched), 2)
+        self.assertIn("Hogwarts", augmented)
+        self.assertIn("Ancient Runes", augmented)
+
+    def test_inject_lore_no_matches(self):
+        prompt = "A simple story in a normal city."
+        augmented, matched = inject_lore_into_system_prompt(
+            prompt=prompt,
+            base_system_prompt="Base prompt.",
+            db_path=self.db_path
+        )
+
+        self.assertEqual(len(matched), 0)
+        self.assertEqual(augmented, "Base prompt.")
+
+    def test_llm_service_generate_story(self):
+        service = LLMService()
+        result = service.generate_story_with_lore(
+            prompt="Tell a story about Hogwarts.",
+            db_path=self.db_path
+        )
+
+        self.assertEqual(result["matched_lore_count"], 1)
+        self.assertIn(LORE_DIRECTIVE_HEADER, result["system_prompt"])
+        self.assertIn("generated_story", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_lorebook.py
+++ b/backend/tests/test_lorebook.py
@@ -1,0 +1,110 @@
+"""
+tests/test_lorebook.py
+-----------------------
+Unit tests for backend/lorebook.py database functions, keyword matcher, and Flask API.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from flask import Flask
+
+# Add parent dir to sys.path so lorebook and llm_service can be imported directly
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from lorebook import (
+    init_db,
+    add_lore_entry,
+    get_lore_entries,
+    get_lore_entry_by_id,
+    update_lore_entry,
+    delete_lore_entry,
+    find_matching_lore,
+    lorebook_bp,
+)
+
+
+class TestLorebookDB(unittest.TestCase):
+
+    def setUp(self):
+        self.db_fd, self.db_path = tempfile.mkstemp(suffix=".db")
+        init_db(self.db_path)
+
+        self.app = Flask(__name__)
+        self.app.register_blueprint(lorebook_bp)
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        os.close(self.db_fd)
+        os.unlink(self.db_path)
+
+    def test_add_and_get_lore_entry(self):
+        entry = add_lore_entry(
+            key="Hogwarts",
+            content="A magical school in Scotland hidden from muggles.",
+            category="location",
+            user_id="user1",
+            db_path=self.db_path
+        )
+        self.assertEqual(entry["key"], "Hogwarts")
+        self.assertEqual(entry["category"], "location")
+        self.assertTrue(entry["is_active"])
+
+        entries = get_lore_entries(user_id="user1", db_path=self.db_path)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["key"], "Hogwarts")
+
+    def test_update_lore_entry(self):
+        entry = add_lore_entry(key="Elder Wand", content="Ancient wand.", category="item", db_path=self.db_path)
+        updated = update_lore_entry(
+            entry_id=entry["id"],
+            content="Most powerful wand made of elder wood.",
+            is_active=False,
+            db_path=self.db_path
+        )
+        self.assertEqual(updated["content"], "Most powerful wand made of elder wood.")
+        self.assertFalse(updated["is_active"])
+
+    def test_delete_lore_entry(self):
+        entry = add_lore_entry(key="DeleteMe", content="To be deleted", db_path=self.db_path)
+        success = delete_lore_entry(entry["id"], db_path=self.db_path)
+        self.assertTrue(success)
+        self.assertIsNone(get_lore_entry_by_id(entry["id"], db_path=self.db_path))
+
+    def test_find_matching_lore(self):
+        add_lore_entry(key="Hogwarts", content="A magical school.", category="location", db_path=self.db_path)
+        add_lore_entry(key="Forbidden Forest", content="Dangerous woods.", category="location", db_path=self.db_path)
+        add_lore_entry(key="Inactive Realm", content="Secret.", is_active=False, db_path=self.db_path)
+
+        prompt = "Harry arrived at Hogwarts on a cold autumn morning."
+        matches = find_matching_lore(prompt, db_path=self.db_path)
+
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0]["key"], "Hogwarts")
+
+    def test_find_matching_lore_case_insensitive_and_punctuation(self):
+        add_lore_entry(key="Shadow Magic", content="Forbidden art.", category="magic_system", db_path=self.db_path)
+        
+        prompt = "Using shadow magic, the sorcerer vanished!"
+        matches = find_matching_lore(prompt, db_path=self.db_path)
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0]["key"], "Shadow Magic")
+
+    def test_api_create_and_fetch_lore(self):
+        res = self.client.post("/api/lorebook", json={
+            "key": "Gryffindor",
+            "content": "House of bravery and chivalry.",
+            "category": "faction"
+        })
+        self.assertEqual(res.status_code, 201)
+        data = res.get_json()
+        self.assertEqual(data["entry"]["key"], "Gryffindor")
+
+        res_get = self.client.get("/api/lorebook")
+        self.assertEqual(res_get.status_code, 200)
+        self.assertGreaterEqual(len(res_get.get_json()["entries"]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/components/LoreManager/LoreManager.css
+++ b/frontend/components/LoreManager/LoreManager.css
@@ -1,0 +1,380 @@
+/* LoreManager.css - Premium Glassmorphism Design System for Lorebook Management */
+
+.lore-manager-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+  color: #e2e8f0;
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+}
+
+.lore-header {
+  margin-bottom: 2rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  padding-bottom: 1.5rem;
+}
+
+.lore-header-title {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a855f7 0%, #6366f1 50%, #3b82f6 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin: 0 0 0.5rem 0;
+}
+
+.lore-header-icon {
+  font-size: 2.2rem;
+}
+
+.lore-header-description {
+  color: #94a3b8;
+  font-size: 1rem;
+  margin: 0;
+  line-height: 1.5;
+}
+
+/* Controls Bar */
+.lore-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.5rem;
+  background: rgba(15, 23, 42, 0.65);
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 1rem 1.25rem;
+  border-radius: 12px;
+}
+
+.lore-search-group {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex: 1;
+  min-width: 280px;
+}
+
+.lore-search-input {
+  width: 100%;
+  padding: 0.6rem 1rem;
+  background: rgba(30, 41, 59, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  color: #f8fafc;
+  font-size: 0.95rem;
+  transition: all 0.2s ease;
+}
+
+.lore-search-input:focus {
+  outline: none;
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.25);
+}
+
+.lore-filter-select {
+  padding: 0.6rem 1rem;
+  background: rgba(30, 41, 59, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  color: #f8fafc;
+  font-size: 0.95rem;
+  cursor: pointer;
+}
+
+.lore-action-buttons {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, #6366f1 0%, #4f46e5 100%);
+  color: white;
+  border: none;
+  padding: 0.65rem 1.25rem;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.btn-primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 14px rgba(99, 102, 241, 0.4);
+}
+
+.btn-secondary {
+  background: rgba(51, 65, 85, 0.7);
+  color: #cbd5e1;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 0.65rem 1rem;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.btn-secondary:hover {
+  background: rgba(71, 85, 105, 0.9);
+  color: #f8fafc;
+}
+
+/* Category Badges */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.65rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.badge-location { background: rgba(59, 130, 246, 0.2); color: #60a5fa; border: 1px solid rgba(59, 130, 246, 0.4); }
+.badge-rule { background: rgba(245, 158, 11, 0.2); color: #fbbf24; border: 1px solid rgba(245, 158, 11, 0.4); }
+.badge-magic_system { background: rgba(168, 85, 247, 0.2); color: #c084fc; border: 1px solid rgba(168, 85, 247, 0.4); }
+.badge-character { background: rgba(16, 185, 129, 0.2); color: #34d399; border: 1px solid rgba(16, 185, 129, 0.4); }
+.badge-faction { background: rgba(244, 63, 94, 0.2); color: #fb7185; border: 1px solid rgba(244, 63, 94, 0.4); }
+.badge-general { background: rgba(148, 163, 184, 0.2); color: #cbd5e1; border: 1px solid rgba(148, 163, 184, 0.4); }
+
+.badge-active { background: rgba(16, 185, 129, 0.25); color: #34d399; }
+.badge-inactive { background: rgba(100, 116, 139, 0.25); color: #94a3b8; }
+
+/* Grid Layout */
+.lore-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 1.25rem;
+  margin-bottom: 2.5rem;
+}
+
+.lore-card {
+  background: rgba(15, 23, 42, 0.7);
+  backdrop-filter: blur(16px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  transition: all 0.25s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.lore-card:hover {
+  transform: translateY(-3px);
+  border-color: rgba(99, 102, 241, 0.35);
+  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.5);
+}
+
+.lore-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.lore-card-key {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: #f1f5f9;
+  margin: 0;
+}
+
+.lore-card-meta {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.lore-card-content {
+  color: #94a3b8;
+  font-size: 0.92rem;
+  line-height: 1.55;
+  margin-bottom: 1.25rem;
+  flex-grow: 1;
+  white-space: pre-wrap;
+}
+
+.lore-card-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  padding-top: 0.75rem;
+}
+
+.btn-icon {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: #cbd5e1;
+  padding: 0.4rem 0.75rem;
+  border-radius: 6px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.btn-icon:hover {
+  background: rgba(99, 102, 241, 0.2);
+  color: #a5b4fc;
+}
+
+.btn-icon-danger:hover {
+  background: rgba(239, 68, 68, 0.2);
+  color: #fca5a5;
+}
+
+/* Modal Form */
+.lore-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.75);
+  backdrop-filter: blur(8px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: 1rem;
+}
+
+.lore-modal {
+  background: #0f172a;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 16px;
+  width: 100%;
+  max-width: 540px;
+  padding: 1.75rem;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.6);
+
+  animation: modalPop 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes modalPop {
+  0% { opacity: 0; transform: scale(0.95); }
+  100% { opacity: 1; transform: scale(1); }
+}
+
+.form-group {
+  margin-bottom: 1.25rem;
+}
+
+.form-label {
+  display: block;
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: #cbd5e1;
+  margin-bottom: 0.4rem;
+}
+
+.form-input, .form-textarea, .form-select {
+  width: 100%;
+  padding: 0.65rem 0.9rem;
+  background: rgba(30, 41, 59, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  color: #f8fafc;
+  font-size: 0.95rem;
+  box-sizing: border-box;
+}
+
+.form-textarea {
+  min-height: 110px;
+  resize: vertical;
+}
+
+.form-input:focus, .form-textarea:focus, .form-select:focus {
+  outline: none;
+  border-color: #818cf8;
+}
+
+.form-checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+/* Simulator Section */
+.simulator-section {
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.8) 0%, rgba(30, 41, 59, 0.5) 100%);
+  border: 1px solid rgba(168, 85, 247, 0.3);
+  border-radius: 16px;
+  padding: 1.75rem;
+  margin-top: 2rem;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+}
+
+.simulator-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.simulator-title {
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: #f1f5f9;
+  margin: 0;
+}
+
+.prompt-input {
+  width: 100%;
+  min-height: 90px;
+  padding: 0.8rem 1rem;
+  background: rgba(15, 23, 42, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 10px;
+  color: #f8fafc;
+  font-size: 1rem;
+  margin-bottom: 1rem;
+  box-sizing: border-box;
+}
+
+.matched-box {
+  background: rgba(15, 23, 42, 0.9);
+  border: 1px solid rgba(99, 102, 241, 0.25);
+  border-radius: 10px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+.matched-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.prompt-preview-block {
+  background: #090d16;
+  border: 1px solid rgba(168, 85, 247, 0.3);
+  border-radius: 10px;
+  padding: 1.2rem;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.85rem;
+  color: #c084fc;
+  white-space: pre-wrap;
+  line-height: 1.6;
+  max-height: 250px;
+  overflow-y: auto;
+}

--- a/frontend/components/LoreManager/LoreManager.test.tsx
+++ b/frontend/components/LoreManager/LoreManager.test.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { describe, it, expect, vi } from "vitest";
+import { LoreManager } from "./LoreManager";
+
+describe("LoreManager Component", () => {
+  it("renders Lorebook Manager title and initial lore cards", () => {
+    render(<LoreManager />);
+
+    expect(screen.getByText(/Lorebook Manager/i)).toBeInTheDocument();
+    expect(screen.getByTestId("lore-search-input")).toBeInTheDocument();
+
+    // Check pre-populated entries
+    expect(screen.getByText("Hogwarts")).toBeInTheDocument();
+    expect(screen.getByText("Shadow Magic")).toBeInTheDocument();
+  });
+
+  it("opens add entry modal and creates a new lore entry", async () => {
+    render(<LoreManager />);
+
+    const addBtn = screen.getByTestId("add-entry-btn");
+    fireEvent.click(addBtn);
+
+    expect(screen.getByTestId("lore-modal")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId("entry-key-input"), {
+      target: { value: "Azkaban" },
+    });
+    fireEvent.change(screen.getByTestId("entry-content-input"), {
+      target: { value: "A fortress prison guarded by Dementors." },
+    });
+
+    const saveBtn = screen.getByTestId("save-entry-btn");
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText("Azkaban")).toBeInTheDocument();
+      expect(screen.getByText("A fortress prison guarded by Dementors.")).toBeInTheDocument();
+    });
+  });
+
+  it("filters entries by search query", () => {
+    render(<LoreManager />);
+
+    const searchInput = screen.getByTestId("lore-search-input");
+    fireEvent.change(searchInput, { target: { value: "Hogwarts" } });
+
+    expect(screen.getByText("Hogwarts")).toBeInTheDocument();
+    expect(screen.queryByText("Law of Equivalence")).not.toBeInTheDocument();
+  });
+
+  it("detects keywords and injects context into live prompt simulator preview", () => {
+    render(<LoreManager />);
+
+    const promptInput = screen.getByTestId("simulator-prompt-input");
+    fireEvent.change(promptInput, {
+      target: { value: "A dark wizard attacked Hogwarts using Shadow Magic." },
+    });
+
+    const preview = screen.getByTestId("system-prompt-preview");
+    expect(preview.textContent).toContain("Hogwarts");
+    expect(preview.textContent).toContain("Shadow Magic");
+    expect(preview.textContent).toContain("[WORLD LORE & RULES - STRICT ADHERENCE REQUIRED]");
+  });
+
+  it("runs simulator test generation", () => {
+    render(<LoreManager />);
+
+    const runBtn = screen.getByTestId("run-simulator-btn");
+    fireEvent.click(runBtn);
+
+    expect(screen.getByText(/Dynamic Context Injector Activated/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/components/LoreManager/LoreManager.tsx
+++ b/frontend/components/LoreManager/LoreManager.tsx
@@ -1,0 +1,467 @@
+import React, { useState, useMemo, useEffect } from "react";
+import "./LoreManager.css";
+
+export type LoreCategory = "location" | "rule" | "magic_system" | "character" | "faction" | "general";
+
+export interface LoreEntry {
+  id: number;
+  key: string;
+  category: LoreCategory;
+  content: string;
+  is_active: boolean;
+  user_id?: string;
+  universe_id?: string;
+  created_at?: number;
+}
+
+const PRESET_SAMPLE_ENTRIES: Omit<LoreEntry, "id">[] = [
+  {
+    key: "Hogwarts",
+    category: "location",
+    content: "A magical school in Scotland hidden from muggles by ancient charm protections.",
+    is_active: true,
+  },
+  {
+    key: "Shadow Magic",
+    category: "magic_system",
+    content: "Requires shadow essence harvested under a dark moon. Cannot be cast in direct sunlight.",
+    is_active: true,
+  },
+  {
+    key: "Law of Equivalence",
+    category: "rule",
+    content: "To create something through alchemy, an object of equal value must be sacrificed.",
+    is_active: true,
+  },
+  {
+    key: "Eldoria",
+    category: "location",
+    content: "Floating capital city of the Cloud Realm, powered by Aether Crystals.",
+    is_active: true,
+  },
+];
+
+export const LoreManager: React.FC = () => {
+  const [entries, setEntries] = useState<LoreEntry[]>([
+    {
+      id: 1,
+      key: "Hogwarts",
+      category: "location",
+      content: "A magical school in Scotland hidden from muggles by ancient charm protections.",
+      is_active: true,
+    },
+    {
+      id: 2,
+      key: "Shadow Magic",
+      category: "magic_system",
+      content: "Requires shadow essence harvested under a dark moon. Cannot be cast in direct sunlight.",
+      is_active: true,
+    },
+    {
+      id: 3,
+      key: "Law of Equivalence",
+      category: "rule",
+      content: "To create something through alchemy, an object of equal value must be sacrificed.",
+      is_active: true,
+    },
+  ]);
+
+  const [searchQuery, setSearchQuery] = useState<string>("");
+  const [selectedCategory, setSelectedCategory] = useState<string>("all");
+  const [showActiveOnly, setShowActiveOnly] = useState<boolean>(false);
+
+  // Form Modal State
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [editingEntryId, setEditingEntryId] = useState<number | null>(null);
+  const [formData, setFormData] = useState<{
+    key: string;
+    category: LoreCategory;
+    content: string;
+    is_active: boolean;
+  }>({
+    key: "",
+    category: "general",
+    content: "",
+    is_active: true,
+  });
+
+  // Simulator State
+  const [testPrompt, setTestPrompt] = useState<string>(
+    "Write a short scene about a new student arriving at Hogwarts to learn Shadow Magic."
+  );
+  const [testGenerationResult, setTestGenerationResult] = useState<string | null>(null);
+
+  // Matcher Logic for Live Simulator
+  const matchedEntries = useMemo(() => {
+    if (!testPrompt.trim()) return [];
+    const lowerPrompt = testPrompt.toLowerCase();
+
+    return entries.filter((entry) => {
+      if (!entry.is_active || !entry.key.trim()) return false;
+      const keyLower = entry.key.toLowerCase();
+
+      // Escape special regex chars
+      const escapedKey = keyLower.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const pattern = new RegExp(`\\b${escapedKey}\\b`, "i");
+      return pattern.test(lowerPrompt);
+    });
+  }, [testPrompt, entries]);
+
+  // Form Handlers
+  const handleOpenAddModal = () => {
+    setEditingEntryId(null);
+    setFormData({
+      key: "",
+      category: "general",
+      content: "",
+      is_active: true,
+    });
+    setIsModalOpen(true);
+  };
+
+  const handleOpenEditModal = (entry: LoreEntry) => {
+    setEditingEntryId(entry.id);
+    setFormData({
+      key: entry.key,
+      category: entry.category,
+      content: entry.content,
+      is_active: entry.is_active,
+    });
+    setIsModalOpen(true);
+  };
+
+  const handleSaveEntry = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!formData.key.trim() || !formData.content.trim()) return;
+
+    if (editingEntryId !== null) {
+      setEntries((prev) =>
+        prev.map((item) =>
+          item.id === editingEntryId
+            ? { ...item, ...formData, key: formData.key.trim(), content: formData.content.trim() }
+            : item
+        )
+      );
+    } else {
+      const newEntry: LoreEntry = {
+        id: Date.now(),
+        key: formData.key.trim(),
+        category: formData.category,
+        content: formData.content.trim(),
+        is_active: formData.is_active,
+      };
+      setEntries((prev) => [newEntry, ...prev]);
+    }
+    setIsModalOpen(false);
+  };
+
+  const handleDeleteEntry = (id: number) => {
+    if (window.confirm("Are you sure you want to delete this lore entry?")) {
+      setEntries((prev) => prev.filter((item) => item.id !== id));
+    }
+  };
+
+  const handleToggleActive = (id: number) => {
+    setEntries((prev) =>
+      prev.map((item) => (item.id === id ? { ...item, is_active: !item.is_active } : item))
+    );
+  };
+
+  const handleAddPresets = () => {
+    const existingKeys = new Set(entries.map((e) => e.key.toLowerCase()));
+    const newItems: LoreEntry[] = PRESET_SAMPLE_ENTRIES.filter(
+      (p) => !existingKeys.has(p.key.toLowerCase())
+    ).map((p, idx) => ({ ...p, id: Date.now() + idx }));
+
+    if (newItems.length > 0) {
+      setEntries((prev) => [...newItems, ...prev]);
+    }
+  };
+
+  // Filtered entries for grid display
+  const filteredEntries = useMemo(() => {
+    return entries.filter((entry) => {
+      const matchesSearch =
+        entry.key.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        entry.content.toLowerCase().includes(searchQuery.toLowerCase());
+      const matchesCategory =
+        selectedCategory === "all" || entry.category === selectedCategory;
+      const matchesActive = !showActiveOnly || entry.is_active;
+
+      return matchesSearch && matchesCategory && matchesActive;
+    });
+  }, [entries, searchQuery, selectedCategory, showActiveOnly]);
+
+  // Construct Injected Prompt Block for Live Simulator Preview
+  const injectedSystemPromptPreview = useMemo(() => {
+    if (matchedEntries.length === 0) {
+      return "No active lore keywords detected in prompt.";
+    }
+
+    const loreLines = [
+      "[WORLD LORE & RULES - STRICT ADHERENCE REQUIRED]",
+      "The story prompt references specific world elements below. You MUST strictly adhere to all of the following rules, locations, and lore constraints without contradiction:",
+    ];
+
+    matchedEntries.forEach((entry) => {
+      loreLines.push(`• [${entry.key} (${entry.category.toUpperCase()})]: ${entry.content}`);
+    });
+
+    return loreLines.join("\n");
+  }, [matchedEntries]);
+
+  const handleRunSimulator = () => {
+    if (matchedEntries.length === 0) {
+      setTestGenerationResult(
+        "No matching lore entries were detected. Standard prompt sent to AI generator."
+      );
+      return;
+    }
+
+    const matchedKeys = matchedEntries.map((e) => `'${e.key}' (${e.category})`).join(", ");
+    setTestGenerationResult(
+      `✓ Dynamic Context Injector Activated!\n` +
+        `Injected ${matchedEntries.length} lore rule(s): ${matchedKeys}.\n\n` +
+        `Generated Response Preview:\n` +
+        `"The narrative unfolds adhering to the rules of ${matchedEntries.map((e) => e.key).join(" and ")} accurately."`
+    );
+  };
+
+  return (
+    <div className="lore-manager-container" data-testid="lore-manager">
+      {/* Header */}
+      <div className="lore-header">
+        <h1 className="lore-header-title">
+          <span className="lore-header-icon">📖</span> Lorebook Manager
+        </h1>
+        <p className="lore-header-description">
+          Define custom locations, rules, magic systems, and factions. The dynamic context injector automatically
+          detects keywords in your prompt and injects strict directives into the LLM system prompt.
+        </p>
+      </div>
+
+      {/* Controls Bar */}
+      <div className="lore-controls">
+        <div className="lore-search-group">
+          <input
+            type="text"
+            className="lore-search-input"
+            placeholder="Search lore by keyword or content..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            data-testid="lore-search-input"
+          />
+          <select
+            className="lore-filter-select"
+            value={selectedCategory}
+            onChange={(e) => setSelectedCategory(e.target.value)}
+            data-testid="lore-category-select"
+          >
+            <option value="all">All Categories</option>
+            <option value="location">Locations</option>
+            <option value="rule">Rules</option>
+            <option value="magic_system">Magic Systems</option>
+            <option value="character">Characters</option>
+            <option value="faction">Factions</option>
+            <option value="general">General</option>
+          </select>
+        </div>
+
+        <div className="lore-action-buttons">
+          <button className="btn-secondary" onClick={handleAddPresets}>
+            + Add Presets
+          </button>
+          <button className="btn-primary" onClick={handleOpenAddModal} data-testid="add-entry-btn">
+            + New Lore Entry
+          </button>
+        </div>
+      </div>
+
+      {/* Lore Entries Grid */}
+      <div className="lore-grid" data-testid="lore-entries-grid">
+        {filteredEntries.length === 0 ? (
+          <div style={{ gridColumn: "1 / -1", textAlign: "center", padding: "3rem 1rem", color: "#64748b" }}>
+            <p style={{ fontSize: "1.2rem", fontWeight: 600 }}>No Lorebook entries found.</p>
+            <p style={{ fontSize: "0.9rem" }}>Add a new entry or click "+ Add Presets" to get started.</p>
+          </div>
+        ) : (
+          filteredEntries.map((entry) => (
+            <div key={entry.id} className="lore-card" data-testid={`lore-card-${entry.id}`}>
+              <div>
+                <div className="lore-card-header">
+                  <h3 className="lore-card-key">{entry.key}</h3>
+                  <div className="lore-card-meta">
+                    <span className={`badge badge-${entry.category}`}>{entry.category.replace("_", " ")}</span>
+                    <span className={`badge ${entry.is_active ? "badge-active" : "badge-inactive"}`}>
+                      {entry.is_active ? "Active" : "Disabled"}
+                    </span>
+                  </div>
+                </div>
+                <p className="lore-card-content">{entry.content}</p>
+              </div>
+
+              <div className="lore-card-actions">
+                <button className="btn-icon" onClick={() => handleToggleActive(entry.id)}>
+                  {entry.is_active ? "Disable" : "Enable"}
+                </button>
+                <button className="btn-icon" onClick={() => handleOpenEditModal(entry)}>
+                  Edit
+                </button>
+                <button
+                  className="btn-icon btn-icon-danger"
+                  onClick={() => handleDeleteEntry(entry.id)}
+                  data-testid={`delete-btn-${entry.id}`}
+                >
+                  Delete
+                </button>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+
+      {/* Dynamic Context Injector Playground / Simulator */}
+      <div className="simulator-section" data-testid="simulator-section">
+        <div className="simulator-header">
+          <span style={{ fontSize: "1.6rem" }}>⚡</span>
+          <h2 className="simulator-title">Dynamic Context Injector Simulator</h2>
+        </div>
+        <p style={{ color: "#94a3b8", fontSize: "0.92rem", marginBottom: "1rem" }}>
+          Type a story prompt below to test keyword detection and view the live LLM System Prompt injection.
+        </p>
+
+        <textarea
+          className="prompt-input"
+          value={testPrompt}
+          onChange={(e) => setTestPrompt(e.target.value)}
+          placeholder="Enter a story prompt to test lore matching (e.g. Hogwarts)..."
+          data-testid="simulator-prompt-input"
+        />
+
+        <div className="matched-box">
+          <div style={{ fontSize: "0.88rem", fontWeight: 700, color: "#cbd5e1" }}>
+            Detected Keywords Matched ({matchedEntries.length}):
+          </div>
+          <div className="matched-tags">
+            {matchedEntries.length === 0 ? (
+              <span style={{ fontSize: "0.85rem", color: "#64748b" }}>No keywords matched in current prompt.</span>
+            ) : (
+              matchedEntries.map((e) => (
+                <span key={e.id} className={`badge badge-${e.category}`}>
+                  ✓ {e.key}
+                </span>
+              ))
+            )}
+          </div>
+        </div>
+
+        <div style={{ marginBottom: "1rem" }}>
+          <div style={{ fontSize: "0.88rem", fontWeight: 700, color: "#cbd5e1", marginBottom: "0.4rem" }}>
+            Injected System Prompt Preview:
+          </div>
+          <div className="prompt-preview-block" data-testid="system-prompt-preview">
+            {injectedSystemPromptPreview}
+          </div>
+        </div>
+
+        <button className="btn-primary" onClick={handleRunSimulator} data-testid="run-simulator-btn">
+          Test Generation Injector
+        </button>
+
+        {testGenerationResult && (
+          <div
+            style={{
+              marginTop: "1rem",
+              padding: "1rem",
+              background: "rgba(16, 185, 129, 0.1)",
+              border: "1px solid rgba(16, 185, 129, 0.3)",
+              borderRadius: "8px",
+              color: "#34d399",
+              whiteSpace: "pre-wrap",
+              fontSize: "0.9rem",
+            }}
+          >
+            {testGenerationResult}
+          </div>
+        )}
+      </div>
+
+      {/* Modal for Add/Edit Lore Entry */}
+      {isModalOpen && (
+        <div className="lore-modal-overlay" data-testid="lore-modal">
+          <div className="lore-modal">
+            <h2 style={{ margin: "0 0 1.25rem 0", color: "#f8fafc", fontSize: "1.4rem" }}>
+              {editingEntryId ? "Edit Lore Entry" : "Create New Lore Entry"}
+            </h2>
+
+            <form onSubmit={handleSaveEntry}>
+              <div className="form-group">
+                <label className="form-label">Keyword / Entity Name (Key)</label>
+                <input
+                  type="text"
+                  className="form-input"
+                  placeholder="e.g. Hogwarts, Shadow Magic, Law of Equivalence"
+                  value={formData.key}
+                  onChange={(e) => setFormData({ ...formData, key: e.target.value })}
+                  required
+                  data-testid="entry-key-input"
+                />
+              </div>
+
+              <div className="form-group">
+                <label className="form-label">Category</label>
+                <select
+                  className="form-select"
+                  value={formData.category}
+                  onChange={(e) => setFormData({ ...formData, category: e.target.value as LoreCategory })}
+                  data-testid="entry-category-input"
+                >
+                  <option value="location">Location</option>
+                  <option value="rule">Rule</option>
+                  <option value="magic_system">Magic System</option>
+                  <option value="character">Character</option>
+                  <option value="faction">Faction</option>
+                  <option value="general">General</option>
+                </select>
+              </div>
+
+              <div className="form-group">
+                <label className="form-label">Lore Content / Rule Description</label>
+                <textarea
+                  className="form-textarea"
+                  placeholder="Define specific rules, locations, or properties that the AI must strictly adhere to..."
+                  value={formData.content}
+                  onChange={(e) => setFormData({ ...formData, content: e.target.value })}
+                  required
+                  data-testid="entry-content-input"
+                />
+              </div>
+
+              <div className="form-group">
+                <label className="form-checkbox-label">
+                  <input
+                    type="checkbox"
+                    checked={formData.is_active}
+                    onChange={(e) => setFormData({ ...formData, is_active: e.target.checked })}
+                  />
+                  <span>Active (Inject into prompts when keyword is mentioned)</span>
+                </label>
+              </div>
+
+              <div style={{ display: "flex", justifyContent: "flex-end", gap: "0.75rem", marginTop: "1.5rem" }}>
+                <button type="button" className="btn-secondary" onClick={() => setIsModalOpen(false)}>
+                  Cancel
+                </button>
+                <button type="submit" className="btn-primary" data-testid="save-entry-btn">
+                  Save Lore Entry
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default LoreManager;

--- a/frontend/components/LoreManager/index.ts
+++ b/frontend/components/LoreManager/index.ts
@@ -1,0 +1,3 @@
+import { LoreManager } from "./LoreManager";
+export default LoreManager;
+export * from "./LoreManager";

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -75,6 +75,7 @@ const PaymentComponent = lazy(() => import("./components/home/pricing/payment.co
 const SearchPageComponent = lazy(() => import("./pages/analytics/SearchPage"));
 const ChatPage = lazy(() => import("./components/chat/ChatPage"));
 const StoryConsistencyGuardian = lazy(() => import("./components/story-consistency/StoryConsistencyGuardian"));
+const LoreManager = lazy(() => import("./components/LoreManager"));
 
 // --- Suspense helper ---
 
@@ -108,6 +109,14 @@ const router = createBrowserRouter([
       {
         path: "templates",
         element: lazyPage(<TemplatesComponent />),
+      },
+      {
+        path: "lorebook",
+        element: (
+          <ProtectedRoute allowedRoles={ALL_ROLES}>
+            {lazyPage(<LoreManager />)}
+          </ProtectedRoute>
+        ),
       },
       {
         path: "create",

--- a/frontend/src/components/LoreManager/LoreManager.tsx
+++ b/frontend/src/components/LoreManager/LoreManager.tsx
@@ -1,0 +1,2 @@
+export { LoreManager as default, LoreManager } from "../../../components/LoreManager/LoreManager";
+export type { LoreCategory, LoreEntry } from "../../../components/LoreManager/LoreManager";

--- a/frontend/src/components/LoreManager/index.ts
+++ b/frontend/src/components/LoreManager/index.ts
@@ -1,0 +1,2 @@
+export { default, LoreManager } from "../../../components/LoreManager";
+export type { LoreCategory, LoreEntry } from "../../../components/LoreManager";

--- a/frontend/src/components/story-comparison/DiffViewer.tsx
+++ b/frontend/src/components/story-comparison/DiffViewer.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useRef, useCallback, useState } from "react";
-import { diffChars, diffWords, Change } from "jsdiff";
+import { diffChars, diffWords, Change } from "diff";
 
 import DiffHighlight from "./DiffHighlight";
 

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,6 +1,5 @@
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
-import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],

--- a/package-lock.json
+++ b/package-lock.json
@@ -344,7 +344,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -2251,7 +2250,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -2300,7 +2298,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2939,7 +2936,6 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
       "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.7.2"
       },
@@ -3621,7 +3617,6 @@
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -4515,7 +4510,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -5075,7 +5069,6 @@
       "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -5274,7 +5267,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
       "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -5345,7 +5337,6 @@
       "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5356,7 +5347,6 @@
       "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5562,7 +5552,6 @@
       "integrity": "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.66.0",
         "@typescript-eslint/types": "8.66.0",
@@ -6045,7 +6034,6 @@
       "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6106,7 +6094,6 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -6553,7 +6540,6 @@
       "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -6850,7 +6836,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.44",
         "caniuse-lite": "^1.0.30001806",
@@ -7128,7 +7113,6 @@
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -7666,8 +7650,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/d3": {
       "version": "7.9.0",
@@ -7986,7 +7969,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9061,7 +9043,6 @@
       "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9376,7 +9357,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
       "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -10371,8 +10351,7 @@
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.15.0.tgz",
       "integrity": "sha512-dMW4CWBTUK1AEEDeZc1g4xpPGIrSf9fJF960qbTZmN/QwZIWY5wgliS6JWl9/25fpTGJrMRtSjGtOmPnfjZB+A==",
-      "license": "Standard 'no charge' license: https://gsap.com/standard-license.",
-      "peer": true
+      "license": "Standard 'no charge' license: https://gsap.com/standard-license."
     },
     "node_modules/handlebars": {
       "version": "4.7.9",
@@ -10714,7 +10693,6 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.15.tgz",
       "integrity": "sha512-VrNANlmnWQnh5COXIIOQXM9oOJw7naGKlBT74ZOOR6lpVXc3gFEu9FJLDFcpCJ2j+NWr8TIwtWD//T6ZX6TKiQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -11537,7 +11515,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -14776,7 +14753,6 @@
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -15090,7 +15066,6 @@
       "resolved": "https://registry.npmjs.org/quill/-/quill-2.0.3.tgz",
       "integrity": "sha512-xEYQBqfYx/sfb33VJiKnSJp8ehloavImQ2A6564GAbqG55PGw1dAWUn1MUbQB62t0azawUS2CZZhWCjO8gRvTw==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "eventemitter3": "^5.0.1",
         "lodash-es": "^4.17.21",
@@ -15105,8 +15080,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/quill-cursors/-/quill-cursors-4.3.0.tgz",
       "integrity": "sha512-fHG6Ryon9KwD05L3gO14d8gqdapdVr2G/Rszl4g7T0X7ZQfG1j+/wAPx8JjhzZz+uWAekA9U0RjstfIt9M35IA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/quill-delta": {
       "version": "5.1.0",
@@ -15182,7 +15156,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
       "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15211,7 +15184,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
       "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15285,15 +15257,13 @@
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
       "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-redux": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
       "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -15457,8 +15427,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -15726,7 +15695,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
       "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.9"
       },
@@ -16792,8 +16760,7 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
       "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.3",
@@ -17213,7 +17180,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -17344,7 +17310,6 @@
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.5.tgz",
       "integrity": "sha512-rw55FUaqOoI7RvlQwLbhO4nSDApnQ4/CykPuiQ/EPvtrX3WA9Ig55jIt9VvbBJbzJuj12ueRu4PMZ2SxPVbihg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -17954,7 +17919,6 @@
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18290,7 +18254,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -19368,7 +19331,6 @@
       "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.32.tgz",
       "integrity": "sha512-lfiJIIC4Xayt5ItynE407ehlE03pCjeOc4hkR4yxxvvNJ4kuiN25B0g+Qp8XagYz361LLL7DCzR5bvFJ81QKtQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lib0": "^0.2.99"
       },
@@ -19409,7 +19371,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION

## What this PR does

* Implemented a complete **Lorebook feature** for managing story-world lore and rules.
* Added persistent lorebook storage with SQLite, including CRUD operations for lore entries.
* Added support for lore entry fields such as key, category, content, active status, and timestamps.
* Implemented **case-insensitive keyword matching with word-boundary detection** so relevant lore is identified from user prompts without matching partial words.
* Added a Flask REST API for creating, reading, updating, deleting, and matching lorebook entries.
* Added dynamic **lore context injection** into the LLM system prompt whenever relevant lore is detected.
* Integrated the lore injection flow with the existing LLM service and supported LLM providers.
* Added the **LoreManager React UI** for viewing, searching, filtering, creating, editing, deleting, and activating/deactivating lore entries.
* Added a live prompt simulator to preview which lore entries are detected and how the system prompt is augmented.
* Registered the Lorebook blueprint and database initialization with the Flask application.
* Added backend tests covering database initialization, CRUD functionality, keyword matching, active/inactive entries, and dynamic system-prompt injection.
* Verified the backend test suite using:
  `python -m unittest discover -s backend/tests`

## Screenshot 

N/A — This PR primarily introduces backend lorebook functionality, LLM prompt injection, and the LoreManager UI. The implementation can be verified through the application and automated tests.


## Type of change

* [ ] Bug fix
* [x] New feature
* [ ] Code refactor
* [ ] Documentation update

## Related issue

None

## More screenshots (optional)

N/A — No additional screenshots are required beyond the application UI itself.

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.

