### PR TITLE
fix: guard Continue Reading button when onContinue is missing

### DIFF
--- a/frontend/src/components/stories/ReadingProgressBar.test.tsx
+++ b/frontend/src/components/stories/ReadingProgressBar.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import ReadingProgressBar from './ReadingProgressBar';
+
+describe('ReadingProgressBar', () => {
+  it('does not render Continue Reading when onContinue is not provided', () => {
+    render(<ReadingProgressBar progress={50} />);
+
+    expect(
+      screen.queryByRole('button', { name: 'Continue Reading' }),
+    ).toBeNull();
+  });
+
+  it('renders and calls onContinue when the handler is provided', () => {
+    const onContinue = vi.fn();
+
+    render(
+      <ReadingProgressBar
+        progress={50}
+        onContinue={onContinue}
+      />,
+    );
+
+    const button = screen.getByRole('button', {
+      name: 'Continue Reading',
+    });
+
+    expect(button).not.toBeNull();
+
+    fireEvent.click(button);
+
+    expect(onContinue).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the completed message when progress reaches 100', () => {
+    render(<ReadingProgressBar progress={100} />);
+
+    expect(screen.getByText(/Story completed!/i)).not.toBeNull();
+
+    expect(
+      screen.queryByRole('button', { name: 'Continue Reading' }),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/components/stories/ReadingProgressBar.tsx
+++ b/frontend/src/components/stories/ReadingProgressBar.tsx
@@ -30,7 +30,7 @@ const ReadingProgressBar: React.FC<ReadingProgressBarProps> = ({
       </div>
 
       {/* Continue Reading Button */}
-      {progress > 0 && progress < 100 && (
+      {progress > 0 && progress < 100 && onContinue && (
         <button
           type="button"
           onClick={onContinue}


### PR DESCRIPTION
## Summary

- Prevents the Continue Reading button from rendering when `onContinue` is not provided.
- Adds regression tests for the button visibility and callback behavior.
- Verifies the completed state does not show the Continue Reading button.

## Testing

- `npm test -- src/components/stories/ReadingProgressBar.test.tsx`
- 3 tests passed
- `git diff --check` passed

Closes #6638