### PR TITLE
fix : made useRepetitionAnalysis accept and analyze story text

### DIFF
--- a/frontend/src/hooks/useRepetitionAnalysis.ts
+++ b/frontend/src/hooks/useRepetitionAnalysis.ts
@@ -1,3 +1,53 @@
-export function useRepetitionAnalysis(story: any) {
-  return [];
+export interface RepetitionItem {
+  phrase: string;
+  count: number;
+  positions: number[];
+}
+
+/**
+ * Detects repeated words or short phrases within a story.
+ * Ignores common stop words to reduce false positives.
+ */
+function detectRepetitions(story: string): RepetitionItem[] {
+  if (!story || typeof story !== "string" || story.trim().length === 0) {
+    return [];
+  }
+
+  const words = story.toLowerCase().split(/\s+/);
+  const stopWords = new Set([
+    "the", "a", "an", "and", "or", "but", "in", "on", "at", "to", "for",
+    "of", "with", "by", "from", "as", "is", "was", "are", "were", "been",
+    "be", "have", "has", "had", "do", "does", "did", "will", "would",
+    "could", "should", "may", "might", "must", "shall", "can", "need",
+    "it", "its", "this", "that", "these", "those", "he", "she", "they",
+    "we", "you", "i", "me", "him", "her", "us", "them", "my", "your",
+    "his", "her", "their", "our", "who", "which", "what", "when", "where",
+    "why", "how", "all", "each", "every", "both", "few", "more", "most",
+    "other", "some", "such", "no", "nor", "not", "only", "own", "same",
+    "so", "than", "too", "very", "just", "also", "now", "here", "there",
+  ]);
+
+  const wordCounts: Record<string, number[]> = {};
+  words.forEach((word, index) => {
+    const cleaned = word.replace(/[^a-z0-9]/g, "");
+    if (cleaned.length < 4 || stopWords.has(cleaned)) return;
+
+    if (!wordCounts[cleaned]) {
+      wordCounts[cleaned] = [];
+    }
+    wordCounts[cleaned].push(index);
+  });
+
+  return Object.entries(wordCounts)
+    .filter(([, positions]) => positions.length >= 3)
+    .map(([phrase, positions]) => ({
+      phrase,
+      count: positions.length,
+      positions,
+    }))
+    .sort((a, b) => b.count - a.count);
+}
+
+export function useRepetitionAnalysis(story: string): RepetitionItem[] {
+  return detectRepetitions(story);
 }


### PR DESCRIPTION
Closes #6758.

Summary of What Has Been Done:
Fixed the useRepetitionAnalysis hook at frontend/src/hooks/useRepetitionAnalysis.ts. The hook previously returned an empty array always, ignoring its input. Now it analyzes the story text and returns repeated words (appearing 3+ times, excluding stop words and short words).

Changes Made:
- Added RepetitionItem interface with phrase, count, and positions
- Implemented detectRepetitions function with stop-word filtering
- Changed parameter type from 'any' to 'string' for better type safety

Impact it Made:
- Fixes a non-functional hook that silently ignored its input
- Enables the story analysis UI to display actual repetition data
- Verified via eslint and per-file tsc --noEmit

Note: Please assign this PR to the `tmdeveloper007` account.