### PR TITLE
Add file input for screenshot upload in bug report form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved error handling and validation
 
 ### Fixed
+- Fixed missing screenshot upload input on the Report a Bug form
 - Fixed delete user dangling references
 - Fixed story translation bug
 - Fixed search query parameter validation

--- a/frontend/src/components/report-bug/ReportBug.tsx
+++ b/frontend/src/components/report-bug/ReportBug.tsx
@@ -3,19 +3,21 @@ import { useForm } from "react-hook-form";
 import { toast } from "react-hot-toast";
 import { useSubmitBugReportMutation } from "../../redux/apis/bugReport.api";
 
-import { 
-  Bug, 
-  Send, 
-  AlertCircle, 
-  CheckCircle2, 
-  Info, 
-  Mail, 
-  Layers, 
-  Activity, 
+import {
+  Bug,
+  Send,
+  AlertCircle,
+  CheckCircle2,
+  Info,
+  Mail,
+  Layers,
+  Activity,
   MessageSquare,
   ClipboardList,
   Target,
   FileWarning,
+  Paperclip,
+  X,
 } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 
@@ -47,17 +49,48 @@ const SEVERITIES = [
   "Critical"
 ];
 
+const MAX_SCREENSHOT_SIZE = 5 * 1024 * 1024; // 5MB, matches backend multer limit
+
 const ReportBug = () => {
   const [submitBugReport, { isLoading: isSubmitting }] = useSubmitBugReportMutation();
   const [isSuccess, setIsSuccess] = useState(false);
+  const [screenshotName, setScreenshotName] = useState<string | null>(null);
+  const [screenshotError, setScreenshotError] = useState<string | null>(null);
 
   const {
     register,
     handleSubmit,
     reset,
+    setValue,
     formState: { errors }
   } = useForm<ReportBugFormData>();
   const { ref: screenshotRef, ...screenshotRegister } = register("screenshot");
+
+  const handleScreenshotChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) {
+      setScreenshotName(null);
+      setScreenshotError(null);
+      return;
+    }
+    if (file.size > MAX_SCREENSHOT_SIZE) {
+      setScreenshotError("Screenshot must be under 5MB");
+      setScreenshotName(null);
+      e.target.value = "";
+      setValue("screenshot", undefined);
+      return;
+    }
+    setScreenshotError(null);
+    setScreenshotName(file.name);
+  };
+
+  const clearScreenshot = () => {
+    setValue("screenshot", undefined);
+    setScreenshotName(null);
+    setScreenshotError(null);
+    const input = document.getElementById("screenshot") as HTMLInputElement | null;
+    if (input) input.value = "";
+  };
   useEffect(() => {
   const errorReport = sessionStorage.getItem("error-report");
 
@@ -95,6 +128,8 @@ const ReportBug = () => {
       setIsSuccess(true);
       toast.success("Bug report submitted successfully!");
       reset();
+      setScreenshotName(null);
+      setScreenshotError(null);
       
       // Scroll to top of form or success message
       window.scrollTo({ top: 0, behavior: 'smooth' });
@@ -412,6 +447,55 @@ const ReportBug = () => {
                     )}
                     <p className="mt-3 text-xs text-slate-500 dark:text-slate-400 ml-1">
                       Provide your email if you'd like us to reach out for more details or updates on the fix.
+                    </p>
+                  </div>
+
+                  {/* Section 4: Screenshot Upload */}
+                  <div className="pt-4 border-t border-slate-200 dark:border-slate-800">
+                    <label htmlFor="screenshot" className="block text-sm font-bold text-slate-700 dark:text-slate-300 mb-2 ml-1">
+                      Screenshot (Optional)
+                    </label>
+                    <input
+                      id="screenshot"
+                      type="file"
+                      accept="image/*"
+                      className="hidden"
+                      ref={screenshotRef}
+                      {...screenshotRegister}
+                      onChange={(e) => {
+                        screenshotRegister.onChange(e);
+                        handleScreenshotChange(e);
+                      }}
+                    />
+                    <div className="flex flex-wrap items-center gap-3">
+                      <label
+                        htmlFor="screenshot"
+                        className="inline-flex items-center gap-2 px-5 py-3 rounded-2xl bg-slate-100/50 dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700 hover:border-blue-500 text-slate-700 dark:text-slate-300 font-medium cursor-pointer transition-all duration-300"
+                      >
+                        <Paperclip className="w-4 h-4" />
+                        <span>Choose Image</span>
+                      </label>
+                      {screenshotName && (
+                        <span className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-blue-500/10 border border-blue-500/20 text-blue-600 dark:text-blue-400 text-sm font-medium">
+                          {screenshotName}
+                          <button
+                            type="button"
+                            onClick={clearScreenshot}
+                            aria-label="Remove screenshot"
+                            className="hover:text-red-500 transition-colors"
+                          >
+                            <X className="w-4 h-4" />
+                          </button>
+                        </span>
+                      )}
+                    </div>
+                    {screenshotError && (
+                      <p className="mt-2 text-sm text-red-500 flex items-center gap-1 ml-1" role="alert">
+                        <AlertCircle className="w-4 h-4" /> {screenshotError}
+                      </p>
+                    )}
+                    <p className="mt-3 text-xs text-slate-500 dark:text-slate-400 ml-1">
+                      Attach a screenshot to help us understand the issue (max 5MB).
                     </p>
                   </div>
 


### PR DESCRIPTION
## Screenshot

<!-- Add a screenshot or short recording showing the new screenshot upload field, selected file, and remove control. -->

N/A — UI screenshots can be added if required by the maintainers.

## What this PR does

This PR fixes the bug report form where the `screenshot` field was already registered with `react-hook-form` and submitted through `FormData`, and the backend already supported receiving the file through `multer` using `upload.single("screenshot")`.

However, the frontend did not render a `<input type="file">`, so users had no way to attach a screenshot while reporting a bug.

This change:

* Adds a screenshot file input to the bug report form.
* Accepts **image files only**.
* Limits uploads to **5 MB**, matching the backend's existing multer configuration.
* Adds a styled upload trigger consistent with the existing form UI.
* Displays the selected filename as a preview.
* Provides a remove control to clear the selected screenshot.
* Keeps the existing `react-hook-form` and `FormData` submission flow unchanged.

This makes the existing backend screenshot-upload functionality accessible to users through the frontend.

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

## Related issue

Closes #6768

## More screenshots (optional)

N/A — The change is a small UI fix; the main functionality can be verified by selecting an image, checking the filename preview, removing it, and submitting the bug report.

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.

## Labels

**GSSoC**