### PR TITLE
Fix command palette navigation and selection for keyboard users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved error handling and validation
 
 ### Fixed
+- Fixed command palette arrow-key navigation not highlighting or selecting a result on Enter
 - Fixed delete user dangling references
 - Fixed story translation bug
 - Fixed search query parameter validation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved error handling and validation
 
 ### Fixed
-- Fixed command palette arrow-key navigation not highlighting or selecting a result on Enter
 - Fixed delete user dangling references
 - Fixed story translation bug
 - Fixed search query parameter validation
@@ -51,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced `require()` with ES module import for `expo-server-sdk`
 - Cached ML model and tokenizer at module level to avoid repeated disk I/O
 - Fixed reservation flow issues
+- Fixed command palette arrow-key navigation not highlighting or selecting a result on Enter
 - Fixed data loss issues
 - Fixed story coherence scoring
 

--- a/frontend/src/components/search/CommandPalette.tsx
+++ b/frontend/src/components/search/CommandPalette.tsx
@@ -74,11 +74,37 @@ export const CommandPalette: React.FC<Props> = ({ open, onClose }) => {
     setQuery("");
   };
 
+  const allStories = results?.stories?.data ?? [];
+  const allUsers = results?.users?.data ?? [];
+  const navigableStories = allStories.slice(0, 4);
+
+  const handleSelectStory = (storyId: string) => {
+    saveRecent(query);
+    onClose();
+    navigate(`/post/${storyId}`);
+  };
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Escape") { onClose(); return; }
-    if (e.key === "Enter") { handleSubmit(query); return; }
-    if (e.key === "ArrowDown") setActiveIdx((i) => i + 1);
-    if (e.key === "ArrowUp") setActiveIdx((i) => Math.max(0, i - 1));
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveIdx((i) => (navigableStories.length ? Math.min(i + 1, navigableStories.length - 1) : 0));
+      return;
+    }
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIdx((i) => Math.max(0, i - 1));
+      return;
+    }
+    if (e.key === "Enter") {
+      const activeStory = navigableStories[activeIdx];
+      if (activeStory) {
+        handleSelectStory(activeStory._id);
+        return;
+      }
+      handleSubmit(query);
+      return;
+    }
   };
 
   const handleDeleteRecent = (term: string) => {
@@ -87,9 +113,6 @@ export const CommandPalette: React.FC<Props> = ({ open, onClose }) => {
   };
 
   if (!open) return null;
-
-  const allStories = results?.stories?.data ?? [];
-  const allUsers = results?.users?.data ?? [];
 
   return (
     <div
@@ -133,12 +156,15 @@ export const CommandPalette: React.FC<Props> = ({ open, onClose }) => {
               {allStories.length > 0 && (
                 <section className="p-2">
                   <p className="mb-1 px-3 text-[11px] font-bold uppercase tracking-widest text-slate-400">Stories</p>
-                  {allStories.slice(0, 4).map((story) => (
+                  {navigableStories.map((story, index) => (
                     <Link
                       key={story._id}
                       to={`/post/${story._id}`}
+                      onMouseEnter={() => setActiveIdx(index)}
                       onClick={() => { saveRecent(query); onClose(); }}
-                      className="flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm text-slate-700 transition-colors hover:bg-slate-50 dark:text-slate-200 dark:hover:bg-white/5"
+                      className={`flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm text-slate-700 transition-colors hover:bg-slate-50 dark:text-slate-200 dark:hover:bg-white/5 ${
+                        index === activeIdx ? "bg-slate-100 dark:bg-white/10" : ""
+                      }`}
                     >
                       <span className="text-base">📖</span>
                       <span className="truncate font-medium">{story.title}</span>


### PR DESCRIPTION
## Screenshot

N/A — The keyboard interaction can be verified directly by using ArrowUp/ArrowDown and Enter in the search results.

## What this PR does

This PR fixes keyboard navigation in the story search results.

Previously, `activeIdx` was updated when pressing **ArrowUp/ArrowDown**, but it was never used to visually identify the active result. Additionally, **ArrowDown** could move the index beyond the available results, and pressing **Enter** always performed a raw text search instead of opening the highlighted story.

This caused issues for keyboard-only users because there was no visual feedback and no way to select and open a highlighted result.

This change:

* Clamps `activeIdx` to the currently visible story results.
* Prevents ArrowDown from moving beyond the result count.
* Visually highlights the currently active story row.
* Makes **Enter** navigate to the highlighted story when one is selected.
* Falls back to the existing text-search submission when no result is selected.
* Improves keyboard-only accessibility and makes search result navigation more intuitive.

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

## Related issue

Closes #6780

## More screenshots (optional)

N/A — This is primarily a keyboard interaction/accessibility fix. The behavior can be tested by navigating search results with the keyboard.

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.

## Labels

**GSSoC**

