### PR TITLE
Fix trading card download by appending anchor to DOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,10 +43,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved error handling and validation
 
 ### Fixed
-- Fixed story trading card download silently failing in Firefox/Safari by appending the anchor to the DOM before triggering the click
 - Fixed delete user dangling references
 - Fixed story translation bug
 - Fixed search query parameter validation
+- Fixed story trading card download silently failing in Firefox/Safari by appending the anchor to the DOM before triggering the click
 - Fixed payment signature length check
 - Replaced `require()` with ES module import for `expo-server-sdk`
 - Cached ML model and tokenizer at module level to avoid repeated disk I/O

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved error handling and validation
 
 ### Fixed
+- Fixed story trading card download silently failing in Firefox/Safari by appending the anchor to the DOM before triggering the click
 - Fixed delete user dangling references
 - Fixed story translation bug
 - Fixed search query parameter validation

--- a/frontend/src/components/cards/StoryTradingCard.tsx
+++ b/frontend/src/components/cards/StoryTradingCard.tsx
@@ -175,7 +175,9 @@ const StoryTradingCard = ({
 
       link.download = `${fileName}-trading-card.png`;
       link.href = canvas.toDataURL("image/png");
+      document.body.appendChild(link);
       link.click();
+      document.body.removeChild(link);
       toast.dismiss(toastId);
       toast.success("Trading card downloaded!");
     } catch (error) {


### PR DESCRIPTION
## Screenshot

N/A — This is a browser compatibility fix. The download behavior can be verified by testing the story download functionality in Firefox and Safari.

## What this PR does

This PR fixes a browser compatibility issue in `StoryTradingCard.handleDownload`.

Previously, the download handler created a temporary `<a>` element and called `.click()` without attaching the element to `document.body`. While this may work in some browsers, Firefox and Safari require the anchor to be attached to the DOM for the `download` attribute to reliably trigger.

As a result, story downloads could silently fail in Firefox and Safari.

This change:

* Appends the temporary `<a>` element to `document.body` before triggering the download.
* Preserves the existing download behavior.
* Ensures the download works reliably across supported browsers.
* Follows the same implementation pattern already used elsewhere in the codebase, including `story-export.utils.ts` and `stories.helpers.ts`.
* Removes the temporary element after triggering the download.

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

## Related issue

Closes #6777

## More screenshots (optional)

N/A — No visual UI changes. This PR only fixes cross-browser download behavior.

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.

## Labels

**GSSoC**

