### PR TITLE
Fix Ctrl+Enter shortcut for generating stories in hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved error handling and validation
 
 ### Fixed
+- Fixed documented "Ctrl + Enter" shortcut not generating a story (handler never checked for it)
 - Fixed delete user dangling references
 - Fixed story translation bug
 - Fixed search query parameter validation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,13 +43,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved error handling and validation
 
 ### Fixed
-- Fixed documented "Ctrl + Enter" shortcut not generating a story (handler never checked for it)
 - Fixed delete user dangling references
 - Fixed story translation bug
 - Fixed search query parameter validation
 - Fixed payment signature length check
 - Replaced `require()` with ES module import for `expo-server-sdk`
 - Cached ML model and tokenizer at module level to avoid repeated disk I/O
+- Fixed documented "Ctrl + Enter" shortcut not generating a story (handler never checked for it)
 - Fixed reservation flow issues
 - Fixed data loss issues
 - Fixed story coherence scoring

--- a/frontend/src/hooks/__tests__/useKeyboardShortcuts.test.tsx
+++ b/frontend/src/hooks/__tests__/useKeyboardShortcuts.test.tsx
@@ -253,6 +253,67 @@ describe("useKeyboardShortcuts", () => {
     });
   });
 
+  describe("ctrl+Enter shortcut", () => {
+    it("calls onGenerate and prevents default when not typing", async () => {
+      const { unmount } = await renderShortcuts();
+      const handler = getKeydownHandler();
+      expect(handler).toBeDefined();
+
+      const event = makeKeyboardEvent({
+        ctrlKey: true,
+        key: "Enter",
+        code: "Enter",
+      });
+
+      handler!(event);
+      expect(onGenerate).toHaveBeenCalledTimes(1);
+      expect(event.preventDefault).toHaveBeenCalled();
+      unmount();
+      currentHook = null;
+    });
+
+    it("does not call onGenerate when focus is on TEXTAREA", async () => {
+      const { unmount } = await renderShortcuts();
+      const handler = getKeydownHandler();
+      expect(handler).toBeDefined();
+
+      const textarea = document.createElement("textarea");
+      Object.defineProperty(document, "activeElement", {
+        value: textarea,
+        writable: true,
+        configurable: true,
+      });
+
+      const event = makeKeyboardEvent({
+        ctrlKey: true,
+        key: "Enter",
+        code: "Enter",
+      });
+
+      handler!(event);
+      expect(onGenerate).not.toHaveBeenCalled();
+      unmount();
+      currentHook = null;
+    });
+
+    it("does not call onGenerate on plain Enter without ctrl", async () => {
+      const { unmount } = await renderShortcuts();
+      const handler = getKeydownHandler();
+      expect(handler).toBeDefined();
+
+      const event = makeKeyboardEvent({
+        ctrlKey: false,
+        key: "Enter",
+        code: "Enter",
+      });
+
+      handler!(event);
+      expect(onGenerate).not.toHaveBeenCalled();
+      unmount();
+      currentHook = null;
+    });
+  });
+
   describe("ctrl+s shortcut", () => {
     it("calls onPublish and prevents default when hasStory is true", async () => {
       const { unmount } = await renderShortcuts(true);

--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -67,6 +67,12 @@ const useKeyboardShortcuts = ({
         return;
       }
 
+      if (e.ctrlKey && e.key === "Enter") {
+        e.preventDefault();
+        handlersRef.current.onGenerate();
+        return;
+      }
+
       if (e.ctrlKey && e.key.toLowerCase() === "s") {
         e.preventDefault();
         if (handlersRef.current.hasStory) {


### PR DESCRIPTION
## Screenshot

N/A — This is a keyboard shortcut and test coverage fix with no visual UI changes.

## What this PR does

This PR fixes a missing keyboard shortcut in `useKeyboardShortcuts`.

The hook already accepted an `onGenerate` callback, and both the help modal and hint bar advertised **Ctrl + Enter** as the shortcut for generating a story. However, the keydown handler did not contain a branch to handle `Ctrl + Enter`, making `onGenerate` effectively unused outside the prompt textarea's local handler.

This change:

* Adds the missing **Ctrl + Enter** keyboard shortcut.
* Gates the shortcut consistently with the other non-typing shortcuts.
* Calls `onGenerate` when Ctrl + Enter is pressed.
* Preserves the existing behavior for typing-related shortcuts.
* Adds automated tests covering the new shortcut behavior.

This brings the actual keyboard behavior in line with the shortcuts already advertised in the UI.

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

## Related issue

Closes #6779

## More screenshots (optional)

N/A — No visual changes. The fix is covered by keyboard shortcut tests.

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.

## Labels

**GSSoC**

