### PR TITLE
Fix downloadTXT anchor attachment and URL revocation timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,9 +43,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved error handling and validation
 
 ### Fixed
-- Fixed TXT story download silently failing in Firefox/Safari by appending the anchor to the DOM and deferring object URL revocation
 - Fixed delete user dangling references
 - Fixed story translation bug
+- Fixed TXT story download silently failing in Firefox/Safari by appending the anchor to the DOM and deferring object URL revocation
 - Fixed search query parameter validation
 - Fixed payment signature length check
 - Replaced `require()` with ES module import for `expo-server-sdk`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved error handling and validation
 
 ### Fixed
+- Fixed TXT story download silently failing in Firefox/Safari by appending the anchor to the DOM and deferring object URL revocation
 - Fixed delete user dangling references
 - Fixed story translation bug
 - Fixed search query parameter validation

--- a/frontend/src/utils/__tests__/downloadStories.test.ts
+++ b/frontend/src/utils/__tests__/downloadStories.test.ts
@@ -1,23 +1,36 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { downloadTXT } from "../downloadStories";
 
 describe("downloadStories", () => {
   let clickMock: ReturnType<typeof vi.fn>;
+  let appendChildMock: ReturnType<typeof vi.fn>;
+  let removeChildMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers();
     clickMock = vi.fn();
+    appendChildMock = vi.fn();
+    removeChildMock = vi.fn();
     vi.stubGlobal("document", {
       createElement: vi.fn().mockReturnValue({
         click: clickMock,
         download: "",
         href: "",
       }),
+      body: {
+        appendChild: appendChildMock,
+        removeChild: removeChildMock,
+      },
     });
     vi.stubGlobal("URL", {
       createObjectURL: vi.fn().mockReturnValue("blob:http://localhost/mock-url"),
       revokeObjectURL: vi.fn(),
     });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("should return early when window is undefined (SSR safety)", () => {
@@ -31,7 +44,13 @@ describe("downloadStories", () => {
     expect(() => downloadTXT(story)).not.toThrow();
     expect(document.createElement).toHaveBeenCalledWith("a");
     expect(URL.createObjectURL).toHaveBeenCalled();
+    expect(appendChildMock).toHaveBeenCalled();
     expect(clickMock).toHaveBeenCalled();
+    expect(removeChildMock).toHaveBeenCalled();
+
+    // Revocation is deferred so the browser has time to start the download.
+    expect(URL.revokeObjectURL).not.toHaveBeenCalled();
+    vi.runAllTimers();
     expect(URL.revokeObjectURL).toHaveBeenCalled();
   });
 

--- a/frontend/src/utils/downloadStories.ts
+++ b/frontend/src/utils/downloadStories.ts
@@ -16,7 +16,11 @@ export const downloadTXT = (story: any) => {
 
   link.download = `${story.title.replace(/[\\/:*?"<>|\s]+/g, "_")}.txt`;
 
+  document.body.appendChild(link);
   link.click();
+  document.body.removeChild(link);
 
-  URL.revokeObjectURL(url);
+  // Defer revocation so Firefox/Safari have time to start reading the blob
+  // before the object URL is invalidated.
+  setTimeout(() => URL.revokeObjectURL(url), 0);
 };


### PR DESCRIPTION
## Screenshot

N/A — This is a browser compatibility and download reliability fix with no visual UI changes.

## What this PR does

This PR fixes cross-browser issues in `downloadTXT` related to temporary anchor handling and object URL revocation.

Previously, `downloadTXT` created a temporary `<a>` element and called `.click()` without attaching it to `document.body`. In Firefox and Safari, this can cause downloads to silently fail because the anchor needs to be present in the DOM for the `download` attribute to work reliably.

Additionally, the object URL was revoked immediately after `.click()`. This could invalidate the Blob URL before the browser had a chance to process the download.

This change:

* Appends the temporary `<a>` element to `document.body` before triggering the download.
* Removes the anchor after the download is triggered.
* Defers `URL.revokeObjectURL()` using `setTimeout(..., 0)` so the browser has time to consume the Blob URL.
* Follows the established download pattern used elsewhere in the codebase, including `story-export.utils.ts` and `stories.helpers.ts`.
* Updates the existing unit tests to mock `document.body.appendChild` and `removeChild`.
* Adds assertions covering the deferred object URL revocation behavior.

This improves TXT download reliability across browsers while keeping the existing download functionality unchanged.

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

## Related issue

Closes #6776

## More screenshots

N/A — No UI changes. The fix is covered by unit tests and can be verified through browser download behavior.

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.

## Labels

**GSSoC**

