### PR TITLE
Fix podium display to reflect active filters and sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,11 +43,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved error handling and validation
 
 ### Fixed
-- Fixed leaderboard top-3 podium ignoring the active tab/search/sort filters
 - Fixed delete user dangling references
 - Fixed story translation bug
 - Fixed search query parameter validation
 - Fixed payment signature length check
+- Fixed leaderboard top-3 podium ignoring the active tab/search/sort filters
 - Replaced `require()` with ES module import for `expo-server-sdk`
 - Cached ML model and tokenizer at module level to avoid repeated disk I/O
 - Fixed reservation flow issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved error handling and validation
 
 ### Fixed
+- Fixed leaderboard top-3 podium ignoring the active tab/search/sort filters
 - Fixed delete user dangling references
 - Fixed story translation bug
 - Fixed search query parameter validation

--- a/frontend/src/components/leaderboard/LeaderboardComponent.tsx
+++ b/frontend/src/components/leaderboard/LeaderboardComponent.tsx
@@ -56,7 +56,7 @@ const LeaderboardComponent: React.FC = () => {
 
     return data;
   }, [contributors, activeTab, searchTerm, sortBy]);
-  const topThree = contributors.slice(0, 3);
+  const topThree = filteredContributors.slice(0, 3);
   return (
     <div className="w-full min-h-screen bg-[#070b12] text-slate-100 px-4 sm:px-6 lg:px-8 max-w-7xl mx-auto pt-8 pb-16 relative overflow-hidden box-border">
       {/* Background Radial Premium Ambient Glow Effects */}


### PR DESCRIPTION
## Screenshot

N/A — This is a data-rendering consistency fix. The behavior can be verified by switching tabs, changing the search term, and changing the sort option.

## What this PR does

This PR fixes an issue where the **Top 3 Podium** displayed contributors from the wrong dataset.

Previously, the podium always rendered `contributors.slice(0, 3)`, which used the raw, unfiltered and unsorted contributor array. Meanwhile, the contributor list below correctly used `filteredContributors`, which applies the selected tab, search term, and sort option.

As a result, changing the tab, searching, or sorting could update the contributor list while leaving the podium unchanged. This could cause a contributor to appear in 1st place on the podium while not appearing anywhere in the filtered results below.

This change:

* Uses `filteredContributors` as the source for the Top 3 Podium.
* Keeps the podium consistent with the selected tab.
* Keeps the podium consistent with the active search term.
* Keeps the podium consistent with the selected sorting option.
* Ensures the Top 3 contributors always match the results displayed below.

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

## Related issue

Closes #6778

## More screenshots (optional)

N/A — No new UI components were introduced. The existing podium can be verified by applying different filters, searches, and sorting options.

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.

## Labels

**GSSoC**

