### PR TITLE
Fix download anchor attachment for cross-browser compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved error handling and validation
 
 ### Fixed
+- Fixed story cover download silently failing in Firefox/Safari by appending the anchor to the DOM before triggering the click
 - Fixed delete user dangling references
 - Fixed story translation bug
 - Fixed search query parameter validation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved error handling and validation
 
 ### Fixed
-- Fixed story cover download silently failing in Firefox/Safari by appending the anchor to the DOM before triggering the click
 - Fixed delete user dangling references
+- Fixed story cover download silently failing in Firefox/Safari by appending the anchor to the DOM before triggering the click
 - Fixed story translation bug
 - Fixed search query parameter validation
 - Fixed payment signature length check

--- a/frontend/src/components/cover-generator/StoryCoverGenerator.tsx
+++ b/frontend/src/components/cover-generator/StoryCoverGenerator.tsx
@@ -39,7 +39,9 @@ const StoryCoverGenerator: React.FC<StoryCoverGeneratorProps> = ({
     const link = document.createElement("a");
     link.href = image;
     link.download = "story-cover.png";
+    document.body.appendChild(link);
     link.click();
+    document.body.removeChild(link);
   };
 
   return (


### PR DESCRIPTION
## Screenshot

N/A — This is a browser compatibility fix with no visual UI changes. The download behavior can be verified directly in Firefox and Safari.

## What this PR does

This PR fixes a cross-browser download issue in `StoryCoverGenerator.handleDownload`.

Previously, the download handler created a temporary `<a>` element and called `.click()` without attaching the anchor to `document.body`. While this may work in some browsers, Firefox and Safari require the anchor to be present in the DOM for the `download` attribute to reliably trigger.

As a result, downloading a generated story cover could silently fail in Firefox and Safari.

This change:

* Appends the temporary `<a>` element to `document.body` before triggering the download.
* Triggers the download using the existing `download` attribute.
* Removes the temporary anchor after triggering the download.
* Follows the established implementation pattern already used elsewhere in the codebase, including `story-export.utils.ts` and `stories.helpers.ts`.
* Preserves the existing story cover download behavior while improving browser compatibility.

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

## Related issue

Closes #6775

## More screenshots (optional)

N/A — No visual changes. This PR only fixes cross-browser download behavior.

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.

## Labels

**GSSoC**

