### PR TITLE
fix: append anchor to DOM and defer revokeObjectURL for Firefox/Safari downloadTXT

### DIFF
--- a/frontend/src/utils/__tests__/downloadStories.test.ts
+++ b/frontend/src/utils/__tests__/downloadStories.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { downloadTXT } from "../downloadStories";
 
 describe("downloadStories", () => {

--- a/frontend/src/utils/__tests__/downloadStories.test.ts
+++ b/frontend/src/utils/__tests__/downloadStories.test.ts
@@ -3,21 +3,34 @@ import { downloadTXT } from "../downloadStories";
 
 describe("downloadStories", () => {
   let clickMock: ReturnType<typeof vi.fn>;
+  let appendChildMock: ReturnType<typeof vi.fn>;
+  let removeChildMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     vi.clearAllMocks();
     clickMock = vi.fn();
+    appendChildMock = vi.fn();
+    removeChildMock = vi.fn();
     vi.stubGlobal("document", {
       createElement: vi.fn().mockReturnValue({
         click: clickMock,
         download: "",
         href: "",
       }),
+      body: {
+        appendChild: appendChildMock,
+        removeChild: removeChildMock,
+      },
     });
     vi.stubGlobal("URL", {
       createObjectURL: vi.fn().mockReturnValue("blob:http://localhost/mock-url"),
       revokeObjectURL: vi.fn(),
     });
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("should return early when window is undefined (SSR safety)", () => {
@@ -32,7 +45,23 @@ describe("downloadStories", () => {
     expect(document.createElement).toHaveBeenCalledWith("a");
     expect(URL.createObjectURL).toHaveBeenCalled();
     expect(clickMock).toHaveBeenCalled();
-    expect(URL.revokeObjectURL).toHaveBeenCalled();
+  });
+
+  it("should append the anchor to document.body before clicking (Firefox/Safari)", () => {
+    downloadTXT({ title: "Test", content: "Content", prompt: "Prompt" });
+    expect(appendChildMock).toHaveBeenCalledTimes(1);
+    expect(appendChildMock).toHaveBeenCalled();
+    // click must happen while the node is attached
+    expect(clickMock).toHaveBeenCalled();
+    expect(removeChildMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("should defer URL.revokeObjectURL until after the current task", () => {
+    downloadTXT({ title: "Test", content: "Content", prompt: "Prompt" });
+    // revoke must not run synchronously right after click
+    expect(URL.revokeObjectURL).not.toHaveBeenCalled();
+    vi.runAllTimers();
+    expect(URL.revokeObjectURL).toHaveBeenCalledTimes(1);
   });
 
   it("should replace invalid filename characters with underscore", () => {

--- a/frontend/src/utils/downloadStories.ts
+++ b/frontend/src/utils/downloadStories.ts
@@ -16,7 +16,12 @@ export const downloadTXT = (story: any) => {
 
   link.download = `${story.title.replace(/[\\/:*?"<>|\s]+/g, "_")}.txt`;
 
+  // Firefox and Safari require the anchor to be attached to the DOM before click()
+  document.body.appendChild(link);
   link.click();
+  document.body.removeChild(link);
 
-  URL.revokeObjectURL(url);
+  // Defer revocation so the browser finishes reading the blob; a 0ms timeout
+  // pushes it off the current task, after the download has started.
+  setTimeout(() => URL.revokeObjectURL(url), 0);
 };


### PR DESCRIPTION
## What changed

Fixes `downloadTXT` in `frontend/src/utils/downloadStories.ts` so story TXT export works reliably in Firefox and Safari.

### Problem
- The temporary `<a>` element was never appended to `document.body` before `.click()`. Firefox and Safari require the anchor to be attached to the DOM, otherwise the download may never trigger.
- `URL.revokeObjectURL(url)` was called synchronously right after `.click()`. The browser can still be reading the blob at that point, so the object URL gets revoked too early, producing a silent failure or an empty/corrupted file.

### Fix
1. Append the anchor to `document.body` before `click()`, then remove it afterwards (Firefox/Safari requirement).
2. Defer `URL.revokeObjectURL(url)` with a `setTimeout(..., 0)` so it runs after the current task, once the download has started reading the blob.

## Tests
Added/updated Vitest cases in `frontend/src/utils/__tests__/downloadStories.test.ts`:
- Verifies the anchor is appended to `document.body` and removed (Firefox/Safari behavior).
- Verifies `URL.revokeObjectURL` is not called synchronously and only runs after timers flush (deferred revoke).

All 6 tests pass.

Closes #6776

---

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._