### PR TITLE
test: add useCallbackDetector testsis:issue assignee:@me

### DIFF
--- a/frontend/src/hooks/__tests__/useCallbackDetector.test.ts
+++ b/frontend/src/hooks/__tests__/useCallbackDetector.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import useCallbackDetector from "../useCallbackDetector";
+
+describe("useCallbackDetector", () => {
+  it("returns the detected callbacks", () => {
+    const { result } = renderHook(() => useCallbackDetector());
+
+    expect(result.current.callbacks).toHaveLength(3);
+
+    expect(result.current.callbacks[0]).toMatchObject({
+      id: 1,
+      element: "Silver Necklace",
+      firstAppearance: "Chapter 1",
+      callback: "Chapter 8",
+    });
+
+    expect(result.current.callbacks[1]).toMatchObject({
+      id: 2,
+      element: "Old Letter",
+      firstAppearance: "Chapter 2",
+      callback: "Chapter 10",
+    });
+
+    expect(result.current.callbacks[2]).toMatchObject({
+      id: 3,
+      element: "Broken Watch",
+      firstAppearance: "Chapter 3",
+      callback: "Chapter 9",
+    });
+  });
+
+  it("returns the same callbacks reference when rerendered", () => {
+    const { result, rerender } = renderHook(() => useCallbackDetector());
+
+    const firstCallbacks = result.current.callbacks;
+
+    rerender();
+
+    expect(result.current.callbacks).toBe(firstCallbacks);
+  });
+
+  it("calls alert when rerunAnalysis is invoked", () => {
+    const alertSpy = vi
+      .spyOn(window, "alert")
+      .mockImplementation(() => {});
+
+    const { result } = renderHook(() => useCallbackDetector());
+
+    act(() => {
+      result.current.rerunAnalysis();
+    });
+
+    expect(alertSpy).toHaveBeenCalledTimes(1);
+    expect(alertSpy).toHaveBeenCalledWith(
+      "Callback analysis completed.",
+    );
+
+    alertSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for useCallbackDetector
- verify detected callbacks are returned
- verify callback results are memoized
- verify rerunAnalysis triggers the expected alert

## Testing
- npm test -- src/hooks/__tests__/useCallbackDetector.test.ts
The targeted useCallbackDetector tests pass locally.

I also ran `npm run build` locally and reproduced the existing frontend build failure: 51 TypeScript errors across unrelated components, hooks, and utility/type modules. The same errors appear in the CI frontend build.

These failures are unrelated to this PR, which only adds tests for useCallbackDetector.
Update: I also ran the frontend build on the current main branch and reproduced the same 51 TypeScript errors.

Therefore, the failing Frontend TypeScript + Vite Build is present on main and is not introduced by this PR. The targeted useCallbackDetector test suite passes (3/3).

I have kept the PR scoped to issue #6743 and have not modified unrelated files.

Closes #6743