### PR TITLE
fix(utils): defer object URL revocation in downloadBlob

### DIFF
--- a/frontend/src/utils/story-export.utils.ts
+++ b/frontend/src/utils/story-export.utils.ts
@@ -25,7 +25,10 @@ export const downloadBlob = (blob: Blob, fileName: string): void => {
   link.click();
   link.remove();
 
+  setTimeout(() => {
   URL.revokeObjectURL(url);
+}, 0);
+
 };
 
 const escapeHtml = (value: string): string =>


### PR DESCRIPTION
### 📌 Description
Fixes #6733 by deferring `URL.revokeObjectURL` execution with `setTimeout` inside `downloadBlob`. This prevents premature revocation of the blob URL in browsers like Safari and Firefox, ensuring file downloads trigger reliably.

### 🧪 Changes Made
- Wrapped `URL.revokeObjectURL(url)` in `setTimeout(..., 0)` inside `story-export.utils.ts`.