### PR TITLE
fix(hooks): replace alert with onComplete callback in useCallbackDete…

### DIFF
--- a/frontend/src/hooks/useCallbackDetector.ts
+++ b/frontend/src/hooks/useCallbackDetector.ts
@@ -1,11 +1,15 @@
 import { useMemo } from "react";
 import { getCallbacks } from "../utils/callbackDetector";
 
-export default function useCallbackDetector() {
+interface UseCallbackDetectorOptions {
+  onComplete?: () => void;
+}
+
+export default function useCallbackDetector(options?: UseCallbackDetectorOptions) {
   const callbacks = useMemo(() => getCallbacks(), []);
 
   const rerunAnalysis = () => {
-    alert("Callback analysis completed.");
+    options?.onComplete?.();
   };
 
   return {


### PR DESCRIPTION
### 📌 Description
Fixes #6745 by removing the blocking `alert()` dialog from `useCallbackDetector` and replacing it with an optional `onComplete` callback handler.

### 🧪 Changes Made
- Added `UseCallbackDetectorOptions` interface with an optional `onComplete` callback.
- Replaced `alert("Callback analysis completed.")` inside `rerunAnalysis` with `options?.onComplete?.()`.