### PR TITLE
test(#5947): add unit tests for useStoryAnalysis hook

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,6 +43,7 @@
     "jspdf": "^4.2.1",
     "jszip": "^3.10.1",
     "jwt-decode": "^4.0.0",
+    "lodash.debounce": "^4.0.8",
     "lucide-react": "^1.16.0",
     "quill": "^2.0.0",
     "quill-cursors": "^4.0.2",

--- a/frontend/src/hooks/__tests__/useStoryAnalysis.test.ts
+++ b/frontend/src/hooks/__tests__/useStoryAnalysis.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+// Mock analyzeStory so the hook's behavior can be observed in isolation.
+vi.mock("../../utils/storyAssistant", () => ({
+  analyzeStory: vi.fn(() => []),
+}));
+
+// Mock lodash.debounce with a controllable, cancel-aware implementation so the
+// 500ms debounce and the cleanup cancel() can be exercised with fake timers.
+// The hook uses a default import (`import debounce from "lodash.debounce"`),
+// so the factory must expose the function under the `default` key.
+vi.mock("lodash.debounce", () => {
+  const implementation = (fn: (...args: any[]) => void, wait: number) => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const debounced = ((...args: any[]) => {
+      timer = setTimeout(() => fn(...args), wait);
+    }) as any;
+    debounced.cancel = () => {
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    };
+    return debounced;
+  };
+  return { default: vi.fn(implementation) };
+});
+
+import { analyzeStory } from "../../utils/storyAssistant";
+import debounce from "lodash.debounce";
+import { useStoryAnalysis } from "../useStoryAnalysis";
+
+describe("useStoryAnalysis", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.clearAllTimers();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should return an empty suggestions array initially", () => {
+    (analyzeStory as any).mockReturnValue([]);
+    const { result } = renderHook(() => useStoryAnalysis("anything"));
+    expect(result.current).toEqual([]);
+  });
+
+  it("should call analyzeStory via the debounce after the 500ms delay", () => {
+    (analyzeStory as any).mockReturnValue([{ id: 1 } as any]);
+    renderHook(() => useStoryAnalysis("very very suddenly"));
+
+    // debounce wrapper is invoked synchronously, scheduling the real call
+    expect(debounce).toHaveBeenCalledTimes(1);
+    expect(debounce).toHaveBeenCalledWith(expect.any(Function), 500);
+    // but analyzeStory must NOT have run yet
+    expect(analyzeStory).not.toHaveBeenCalled();
+
+    // advancing near the debounce window must not fire it yet
+    vi.advanceTimersByTime(499);
+    expect(analyzeStory).not.toHaveBeenCalled();
+
+    // crossing the 500ms threshold fires the debounced function
+    vi.advanceTimersByTime(1);
+    expect(analyzeStory).toHaveBeenCalledTimes(1);
+    expect(analyzeStory).toHaveBeenCalledWith("very very suddenly");
+  });
+
+  it("should cancel pending debounced calls on cleanup", () => {
+    const { unmount } = renderHook(() => useStoryAnalysis("a story"));
+    // while pending, analyzeStory has not run
+    expect(analyzeStory).not.toHaveBeenCalled();
+
+    // unmount triggers the useEffect cleanup -> debounced.cancel()
+    unmount();
+
+    // after waiting well past the debounce window, the deferred call must NOT
+    // fire because cleanup cancelled the pending timer.
+    vi.advanceTimersByTime(1000);
+    expect(analyzeStory).not.toHaveBeenCalled();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,6 +274,9 @@ importers:
       jwt-decode:
         specifier: ^4.0.0
         version: 4.0.0
+      lodash.debounce:
+        specifier: ^4.0.8
+        version: 4.0.8
       lucide-react:
         specifier: ^1.16.0
         version: 1.16.0(react@19.2.6)


### PR DESCRIPTION
## What

Closes #5947 — add unit tests for the `useStoryAnalysis` hook (`frontend/src/hooks/useStoryAnalysis.ts`), which currently has **zero test coverage**.

The hook wraps `analyzeStory`, debounces the call (500ms via `lodash.debounce`), manages `suggestions` state, and cancels the pending debounced call on cleanup.

## Changes

- **New:** `frontend/src/hooks/__tests__/useStoryAnalysis.test.ts` — covers:
  - returns an empty suggestions array initially
  - calls `analyzeStory` via the debounce after the 500ms delay (and **not** before it), asserting `debounce(fn, 500)` is used
  - cancels pending debounced calls on cleanup (a deferred `analyzeStory` never fires after unmount)
- `frontend/package.json` / `pnpm-lock.yaml` — `lodash.debounce` was imported by the hook but missing from `frontend/package.json`. Added it (minimal lockfile entry; the package was already a transitive dep) so the dependency is explicit and resolvable at test time.

## How it is tested

`analyzeStory` and `lodash.debounce` are mocked with `vi.mock`, and `vi.useFakeTimers()` drives the 500ms debounce window and the cleanup `cancel()` path. The `lodash.debounce` mock exposes a `cancel()`-capable debounced function under the `default` key to match the hook default import.

```
frontend $ pnpm exec vitest run src/hooks/__tests__/useStoryAnalysis.test.ts
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Per-file `tsc` (matching the repo CI typecheck job) and `eslint` both pass on the new file.

## Note on CI

The repo `Frontend – TypeScript + Vite Build` and `docker-validation` checks fail on pre-existing TypeScript errors in unrelated files (`DialogueStyleAnalyzer.tsx`, `EditingAssistantSidebar.tsx`, `NarrativeFlowAnalyzer.tsx`, `ReaderFeedbackSimulator.tsx`, `RepetitionDetector.tsx`, `RevisionPlanner.tsx`) that are broken on `main` for every PR. These are out of scope for this issue. The `typecheck`, `lint`, and test checks pass for this change.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._