### PR TITLE
fix: defer blob URL revocation and ensure anchor is in DOM for Firefox/Safari

### DIFF
--- a/frontend/src/components/cards/StoryTradingCard.tsx
+++ b/frontend/src/components/cards/StoryTradingCard.tsx
@@ -175,7 +175,9 @@ const StoryTradingCard = ({
 
       link.download = `${fileName}-trading-card.png`;
       link.href = canvas.toDataURL("image/png");
+      document.body.appendChild(link);
       link.click();
+      document.body.removeChild(link);
       toast.dismiss(toastId);
       toast.success("Trading card downloaded!");
     } catch (error) {

--- a/frontend/src/components/cover-generator/StoryCoverGenerator.tsx
+++ b/frontend/src/components/cover-generator/StoryCoverGenerator.tsx
@@ -39,7 +39,9 @@ const StoryCoverGenerator: React.FC<StoryCoverGeneratorProps> = ({
     const link = document.createElement("a");
     link.href = image;
     link.download = "story-cover.png";
+    document.body.appendChild(link);
     link.click();
+    document.body.removeChild(link);
   };
 
   return (

--- a/frontend/src/components/stories/stories.helpers.ts
+++ b/frontend/src/components/stories/stories.helpers.ts
@@ -118,6 +118,9 @@ export const downloadBlob = (blob: Blob, fileName: string) => {
   link.download = fileName;
   document.body.appendChild(link);
   link.click();
-  link.remove();
-  URL.revokeObjectURL(url); // Release blob reference immediately after download triggers
+
+  setTimeout(() => {
+    URL.revokeObjectURL(url);
+    document.body.removeChild(link);
+  }, 100);
 };

--- a/frontend/src/components/translate/StoryTranslator.tsx
+++ b/frontend/src/components/translate/StoryTranslator.tsx
@@ -161,8 +161,10 @@ export default function StoryTranslator({ story, isLogin, onClose }: Props) {
     a.download = `${translatedTitle || "translated-story"}.txt`;
     document.body.appendChild(a);
     a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
+    setTimeout(() => {
+      URL.revokeObjectURL(url);
+      document.body.removeChild(a);
+    }, 100);
     toast.success("Story downloaded!");
   };
 

--- a/frontend/src/utils/downloadStories.ts
+++ b/frontend/src/utils/downloadStories.ts
@@ -13,10 +13,13 @@ export const downloadTXT = (story: any) => {
 
   const link = document.createElement("a");
   link.href = url;
-
   link.download = `${story.title.replace(/[\\/:*?"<>|\s]+/g, "_")}.txt`;
 
+  document.body.appendChild(link);
   link.click();
 
-  URL.revokeObjectURL(url);
+  setTimeout(() => {
+    URL.revokeObjectURL(url);
+    document.body.removeChild(link);
+  }, 100);
 };

--- a/frontend/src/utils/story-export.utils.ts
+++ b/frontend/src/utils/story-export.utils.ts
@@ -23,9 +23,11 @@ export const downloadBlob = (blob: Blob, fileName: string): void => {
   link.download = fileName;
   document.body.appendChild(link);
   link.click();
-  link.remove();
 
-  URL.revokeObjectURL(url);
+  setTimeout(() => {
+    URL.revokeObjectURL(url);
+    document.body.removeChild(link);
+  }, 100);
 };
 
 const escapeHtml = (value: string): string =>


### PR DESCRIPTION
## Description
Fixed silent download failures in Firefox and Safari across multiple download functions.

### Root Cause
Several download functions created an `<a>` element, called `.click()`, and immediately revoked the blob URL. In Firefox and Safari, this races the async download initiation, causing downloads to silently fail or produce empty files.

### Changes
- **downloadTXT**: Append anchor to DOM, defer `revokeObjectURL` with `setTimeout`
- **downloadBlob (utils)**: Defer revocation and removal with `setTimeout`
- **downloadBlob (helpers)**: Defer revocation and removal with `setTimeout`
- **StoryTradingCard**: Append anchor to body before click
- **StoryCoverGenerator**: Append anchor to body before click
- **StoryTranslator**: Defer revocation and removal with `setTimeout`

## Related Issues
Closes #6776, #6775, #6777

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
