### PR TITLE
fix: use correct tag type for cache invalidation in writer application API

### DIFF
--- a/frontend/src/redux/apis/writer_application.api.ts
+++ b/frontend/src/redux/apis/writer_application.api.ts
@@ -1,4 +1,5 @@
 import baseApi from "../base_api/base.api";
+import { tagTypes } from "../tag-types";
 
 export const writerApplicationApi = baseApi.injectEndpoints({
   endpoints: (build) => ({
@@ -8,7 +9,7 @@ export const writerApplicationApi = baseApi.injectEndpoints({
         method: "POST",
         data,
       }),
-      invalidatesTags: ["User"],
+      invalidatesTags: [tagTypes.user],
     }),
     getAllWriterApplications: build.query({
       query: () => ({
@@ -23,7 +24,7 @@ export const writerApplicationApi = baseApi.injectEndpoints({
         method: "PATCH",
         data: { status },
       }),
-      invalidatesTags: ["WriterApplication", "User"],
+      invalidatesTags: [tagTypes.WriterApplication, tagTypes.user],
     }),
   }),
 });


### PR DESCRIPTION
The writer application mutation used `"User"` (uppercase) for `invalidatesTags` but the registered tag type is `"user"` (lowercase). This caused RTK Query to not invalidate the user profile cache after a successful writer application submission.

Fixes #5749